### PR TITLE
fix(types,codegen): correct string equality, float %, and len() typing

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -412,6 +412,11 @@ func (g *cgen) binary(ex *Binary) (string, error) {
 	if ex.Op == "+" && g.c.NodeKind(ex) == KString {
 		return fmt.Sprintf("mfl_cat(%s, %s)", l, r), nil
 	}
+	// Compare strings by value, not by pointer. C's == on char* compares
+	// addresses, so equal-but-distinct strings would wrongly differ.
+	if (ex.Op == "==" || ex.Op == "!=") && g.c.NodeKind(ex.L) == KString {
+		return fmt.Sprintf("(strcmp(%s, %s) %s 0)", l, r, ex.Op), nil
+	}
 	return fmt.Sprintf("(%s %s %s)", l, ex.Op, r), nil
 }
 

--- a/operators_net_test.go
+++ b/operators_net_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"encoding/base64"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// parseFuncs parses readable function sources through the real base64 path,
+// mirroring runNative but without compiling — used by tests that only need the
+// type checker's verdict.
+func parseFuncs(t *testing.T, funcs ...string) []*FuncDecl {
+	t.Helper()
+	var fns []*FuncDecl
+	for _, f := range funcs {
+		enc := base64.StdEncoding.EncodeToString([]byte(normalize(f)))
+		raw, err := base64.StdEncoding.DecodeString(enc)
+		if err != nil {
+			t.Fatalf("b64: %v", err)
+		}
+		fn, err := ParseFunc(string(raw))
+		if err != nil {
+			t.Fatalf("parse %q: %v", f, err)
+		}
+		fns = append(fns, fn)
+	}
+	return fns
+}
+
+// checkErr asserts that type-checking the given program fails with a message
+// containing want — i.e. the error is a clean MFL diagnostic, not leaked cc
+// output from a downstream compile failure.
+func checkErr(t *testing.T, want string, funcs ...string) {
+	t.Helper()
+	_, err := Check(parseFuncs(t, funcs...))
+	if err == nil {
+		t.Fatalf("expected type error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %q", want, err.Error())
+	}
+}
+
+// --- Issue #1: string ==/!= compare by value, not by pointer. ---
+
+func TestStringEqualityByValue(t *testing.T) {
+	// b is built at runtime via concatenation, so it is a distinct pointer from
+	// the literal a. A pointer compare would wrongly report "notequal".
+	got := runNative(t, `func main() { a := "ab" b := "a" + "b" if a == b { println("equal") } else { println("notequal") } }`)
+	if got != "equal\n" {
+		t.Fatalf("string == by value: got %q, want \"equal\\n\"", got)
+	}
+}
+
+func TestStringInequalityByValue(t *testing.T) {
+	got := runNative(t, `func main() { a := "abc" b := "abd" if a != b { println("differ") } else { println("same") } }`)
+	if got != "differ\n" {
+		t.Fatalf("string != by value: got %q, want \"differ\\n\"", got)
+	}
+}
+
+// --- Issue #2: % on floats is a clean MFL type error, not leaked cc output. ---
+
+func TestModuloFloatRejected(t *testing.T) {
+	checkErr(t, "mismatch", `func main() { x := 5.0 y := 2.0 println(x % y) }`)
+}
+
+func TestModuloIntStillWorks(t *testing.T) {
+	if got := runNative(t, `func main() { println(7 % 3) }`); got != "1\n" {
+		t.Fatalf("int %% regressed: got %q", got)
+	}
+}
+
+// --- Issue #3: len() on a non-string/non-slice is a type error, never strlen() on a scalar. ---
+
+func TestLenOnIntRejected(t *testing.T) {
+	checkErr(t, "string or slice", `func main() { println(len(5)) }`)
+}
+
+func TestLenOnStringAndSliceStillWorks(t *testing.T) {
+	if got := runNative(t, `func main() { s := "hello" println(len(s)) }`); got != "5\n" {
+		t.Fatalf("len(string) regressed: got %q", got)
+	}
+}
+
+// --- Issue #4: networking builtins + concurrent server compile and run. ---
+
+// TestNetworkingExampleCompiles builds the documented concurrent HTTP server
+// (listen/accept/read/write/close + a `go` goroutine) end-to-end through cc,
+// proving the flagship networking example actually codegens and links.
+func TestNetworkingExampleCompiles(t *testing.T) {
+	fns := parseFuncs(t,
+		`func page() { return "<h1>hi</h1>" }`,
+		`func response() { body := page() return "HTTP/1.1 200 OK\r\nContent-Length: " + str(len(body)) + "\r\n\r\n" + body }`,
+		`func handle(conn) { read(conn) write(conn, response()) close(conn) }`,
+		`func main() { server := listen(0) for { conn := accept(server) go handle(conn) } }`)
+	bin, err := os.CreateTemp("", "mfl-net-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(fns, bin.Name()); err != nil {
+		t.Fatalf("networking example failed to compile: %v", err)
+	}
+}
+
+// TestNetworkingRoundTrip exercises the socket builtins live: an MFL server
+// accepts one connection, reads the request, writes a reply and exits. A Go
+// client drives it and verifies the bytes make the full round trip.
+func TestNetworkingRoundTrip(t *testing.T) {
+	const port = 47654
+	fns := parseFuncs(t,
+		`func main() { s := listen(`+itoa(port)+`) conn := accept(s) read(conn) write(conn, "pong") close(conn) }`)
+	bin, err := os.CreateTemp("", "mfl-srv-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(fns, bin.Name()); err != nil {
+		t.Fatalf("server failed to compile: %v", err)
+	}
+
+	cmd := exec.Command(bin.Name())
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// The server needs a moment to bind; retry-dial until it is listening.
+	var conn net.Conn
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", "127.0.0.1:"+itoa(port), 200*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("could not connect to MFL server: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write to server: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 64)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read from server: %v", err)
+	}
+	if got := string(buf[:n]); got != "pong" {
+		t.Fatalf("round trip: got %q, want \"pong\"", got)
+	}
+}
+
+// itoa is a tiny dependency-free int->string for embedding ports in MFL source.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/types.go
+++ b/types.go
@@ -80,6 +80,8 @@ type Checker struct {
 
 	pairs []int      // flattened pairs: pairs[2i], pairs[2i+1]
 	plus  []plusCons // overloaded '+' constraints, resolved by fixpoint
+
+	lenArgs []int // slots passed to len(); must resolve to string or slice
 }
 
 type plusCons struct{ l, r, res int }
@@ -229,6 +231,12 @@ func Check(funcs []*FuncDecl) (*Checker, error) {
 		r := c.find(i)
 		if c.kind[r] == KVar || c.kind[r] == KNum {
 			c.kind[r] = KInt
+		}
+	}
+	// 5. validate len() arguments now that kinds are fully resolved.
+	for _, slot := range c.lenArgs {
+		if k := c.kindOf(slot); k != KString && k != KSlice {
+			return nil, fmt.Errorf("len: argument must be a string or slice, got %s", k)
 		}
 	}
 	return c, nil
@@ -456,9 +464,15 @@ func (c *Checker) genBinary(fn *FuncDecl, ex *Binary) (int, error) {
 		res := newSlot(c, KVar)
 		c.plus = append(c.plus, plusCons{l: ls, r: rs, res: res})
 		return res, nil
-	case "-", "*", "/", "%":
+	case "-", "*", "/":
 		c.addPair(ls, rs)
 		c.addPair(ls, newSlot(c, KNum))
+		return ls, nil
+	case "%":
+		// C's % is integer-only; reject float operands at type-check time
+		// so the user gets a clean MFL error instead of leaked cc output.
+		c.addPair(ls, rs)
+		c.addPair(ls, c.cInt)
 		return ls, nil
 	case "==", "!=", "<", "<=", ">", ">=":
 		c.addPair(ls, rs)
@@ -488,6 +502,9 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("len: 1 arg")
 		}
 		// len works on strings or slices; codegen reads the resolved kind.
+		// Record the arg so we can reject non-string/non-slice values (e.g.
+		// an int) after solving, instead of emitting strlen() on a scalar.
+		c.lenArgs = append(c.lenArgs, argSlots[0])
 		return c.cInt, nil
 	case "append":
 		if len(argSlots) != 2 {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** expand language capabilities, benchmarks/reports, more examples, refine docs

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #29 (am/am-7b5889-tgx468): feat(examples): add factorial, nth-prime, and modular exponentiation examples
    touches: codegen.go, examples/complex/factorial.mfl, examples/complex/nth_prime.mfl, examples/complex/power_mod.mfl, issue_fixes_test.go, types.go
- PR #28 (am/am-7b5889-tgx3cd): feat(examples): add prime factorization example
    touches: codegen.go, examples/complex/classify_divisors.mfl, examples/complex/prime_factors.mfl, examples/complex/reverse_digits.mfl, types.go
- PR #27 (am/am-7b5889-tgx2km): feat(examples): add numeric palindrome example
    touches: codegen.go, examples/complex/mccarthy91.mfl, examples/complex/palindrome.mfl, examples/complex/pythagorean.mfl, types.go
- PR #26 (am/am-7b5889-tgx1f2): feat(examples): add Euler's totient function example
    touches: codegen.go, examples/complex/fizzbuzz.mfl, examples/complex/totient.mfl, examples/complex/tribonacci.mfl, types.go
- PR #25 (am/am-7b5889-tgx0il): feat(examples): add bubble sort, digit sum, and harmonic series examples
    touches: codegen.go, examples/complex/bubble_sort.mfl, examples/complex/digit_sum.mfl, examples/complex/harmonic.mfl, examples/complex/pascal.mfl, examples/complex/sqrt.mfl, examples/complex/stats.mfl, types.go
- PR #24 (am/am-7b5889-tgwzmz): feat(bench): add reproducible fib(40) benchmark harness
    touches: Makefile, README.md, examples/bench/BENCHMARKS.md, examples/bench/README.md, examples/bench/fib.c, examples/bench/fib.rs, examples/bench/run_bench.sh
- PR #23 (am/am-7b5889-tgwysy): feat(examples): add digital root example
    touches: examples/complex/digital_root.mfl, examples/complex/hanoi.mfl, examples/complex/trailing_zeros.mfl
- PR #22 (am/am-7b5889-tgwy0q): feat(examples): add Lucas numbers sequence example
    touches: codegen.go, correctness_test.go, examples/complex/catalan.mfl, examples/complex/happy_numbers.mfl, examples/complex/lucas.mfl, types.go


**Branch:** `am/am-7b5889-tgx4yt`

## Summary

Fixes the four open correctness issues in the MFL compiler. #1: string ==/!= now compile to strcmp() value comparison instead of a C pointer compare, so equal-but-distinct strings compare equal. #2: the % operator is constrained to int operands, turning float modulo into a clean MFL type error instead of leaked cc output. #3: len() arguments are validated to be a string or slice after inference, so len(int) is rejected rather than emitting strlen() on a scalar. #4: a new operators_net_test.go adds regression tests for all three operator fixes plus the previously-untested networking builtins (concurrent HTTP server compile-smoke + a live listen/accept/read/write/close round-trip). All edits localized to binary()/genBinary/genCall and a post-solve check, avoiding the in-flight example PRs.

**Diff:**
```
codegen.go            |   5 ++
 operators_net_test.go | 178 ++++++++++++++++++++++++++++++++++++++++++++++++++
 types.go              |  19 +++++-
 3 files changed, 201 insertions(+), 1 deletion(-)
```
