### PR TITLE
feat: machweb — a backend framework written in MFL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /machin
 /bin/
+/framework/app.mfl

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 > A statically-typed language whose on-disk form is base64 — one function per line, blank line between functions. It compiles to native machine code through C.
 
-📖 Full reference: [`SPEC.md`](SPEC.md) · language tour: [`docs/LANGUAGE.md`](docs/LANGUAGE.md) · self-hosted server: [`selfhost/`](selfhost/)
+📖 Full reference: [`SPEC.md`](SPEC.md) · language tour: [`docs/LANGUAGE.md`](docs/LANGUAGE.md) · web framework: [`framework/`](framework/) · self-hosted server: [`selfhost/`](selfhost/)
 
 ```bash
 # A program IS base64 — one function per line:

--- a/framework/README.md
+++ b/framework/README.md
@@ -1,0 +1,71 @@
+# machweb — a tiny backend framework for MFL
+
+`machweb` is a minimal web framework **written in MFL**. You compose it ahead of
+your app and compile the result to a native binary — your backend is a single
+self-contained executable with no runtime dependencies.
+
+## Hello, server
+
+`app.src`:
+
+```go
+func main() {
+    serve(48080, func(req) {
+        if req.path == "/" {
+            return ok_text("hello from machweb")
+        }
+        return not_found()
+    })
+}
+```
+
+Compose with the framework, compile, run:
+
+```sh
+machin encode framework/machweb.src app.src > app.mfl
+machin run app.mfl
+# or: ./framework/run.sh app.src
+```
+
+`machin encode` accepts multiple source files and concatenates them, so the
+framework's functions and yours end up in one program.
+
+## API
+
+A handler is a closure `func(Request) Response`. `serve(port, handler)` runs the
+server, dispatching every request to it in its own goroutine (whose memory is
+reclaimed when the response is sent).
+
+**Request** — `req.method`, `req.path`, `req.body`.
+
+**Response builders:**
+
+| Builder | Status / type |
+|---------|---------------|
+| `ok_text(body)` | 200, `text/plain` |
+| `ok_html(body)` | 200, `text/html` |
+| `ok_json(body)` | 200, `application/json` |
+| `created(body)` | 201, `application/json` |
+| `bad_request(msg)` | 400, `text/plain` |
+| `not_found()` | 404, `text/plain` |
+
+**Helpers:**
+
+- `param(path, prefix)` — the path segment after a prefix, e.g.
+  `param("/users/42", "/users/") == "42"`.
+- `json(x)` / `parse(s, T{})` — serialize / parse JSON (built into machin).
+
+## Example
+
+`example.src` is a small JSON todo API. Run it:
+
+```sh
+./framework/run.sh framework/example.src
+curl localhost:48080/
+curl localhost:48080/api/todos
+curl localhost:48080/hello/machine
+curl -X POST -d '{"id":9,"title":"posted","done":true}' localhost:48080/api/echo
+```
+
+Because the whole thing compiles to native code, the request path is just C: no
+interpreter, no allocations beyond the per-request arena.

--- a/framework/example.src
+++ b/framework/example.src
@@ -1,0 +1,40 @@
+// A small JSON API built on machweb. Compose and run:
+//   machin encode framework/machweb.src framework/example.src > app.mfl
+//   machin run app.mfl
+//
+// Then:
+//   curl localhost:48080/
+//   curl localhost:48080/api/todos
+//   curl localhost:48080/hello/machine
+//   curl -X POST -d '{"id":9,"title":"posted"}' localhost:48080/api/echo
+
+type Todo struct {
+    id    int
+    title string
+    done  bool
+}
+
+func todos() (list) {
+    list = []Todo{}
+    list = append(list, Todo{id: 1, title: "learn MFL", done: true})
+    list = append(list, Todo{id: 2, title: "build a backend on machweb", done: false})
+}
+
+func route(req) (res) {
+    if req.path == "/" {
+        res = ok_html("<h1>machweb</h1><p>Endpoints: <code>/api/todos</code>, <code>/hello/&lt;name&gt;</code>, POST <code>/api/echo</code></p>")
+    } else if req.path == "/api/todos" {
+        res = ok_json(json(todos()))
+    } else if has_prefix(req.path, "/hello/") {
+        res = ok_text("hello, " + param(req.path, "/hello/"))
+    } else if req.method == "POST" && req.path == "/api/echo" {
+        t := parse(req.body, Todo{})
+        res = ok_json(json(t))
+    } else {
+        res = not_found()
+    }
+}
+
+func main() {
+    serve(48080, func(req) { return route(req) })
+}

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -1,0 +1,79 @@
+// machweb — a tiny web framework for MFL.
+//
+// Compose it ahead of your app and compile:
+//   machin encode framework/machweb.src yourapp.src > app.mfl
+//   machin run app.mfl
+//
+// Your app provides a `main` that calls serve(port, handler), where handler is
+// a closure  func(Request) Response.  Every request is dispatched to it in its
+// own goroutine; the goroutine's memory is reclaimed when the response is sent.
+
+type Request struct {
+    method string
+    path   string
+    body   string
+}
+
+type Response struct {
+    status string
+    ctype  string
+    body   string
+}
+
+// ---- response builders ----
+
+func response(status, ctype, body) (r) {
+    r = Response{status: status, ctype: ctype, body: body}
+}
+
+func ok_text(body) (r) { r = response("200 OK", "text/plain; charset=utf-8", body) }
+func ok_html(body) (r) { r = response("200 OK", "text/html; charset=utf-8", body) }
+func ok_json(body) (r) { r = response("200 OK", "application/json", body) }
+func created(body) (r) { r = response("201 Created", "application/json", body) }
+func bad_request(msg) (r) { r = response("400 Bad Request", "text/plain", msg) }
+func not_found() (r) { r = response("404 Not Found", "text/plain", "not found") }
+
+// ---- request helpers ----
+
+// parse_request extracts the method, path, and body from a raw HTTP request.
+func parse_request(raw) (req) {
+    nl := index(raw, "\r\n")
+    line := substr(raw, 0, nl)
+    parts := split(line, " ")
+    m := ""
+    p := "/"
+    if len(parts) >= 2 {
+        m = parts[0]
+        p = parts[1]
+    }
+    req = Request{method: m, path: p, body: http_body(raw)}
+}
+
+// param returns the path segment after a prefix:
+//   param("/users/42", "/users/") == "42"
+func param(path, prefix) (v) {
+    if has_prefix(path, prefix) {
+        v = substr(path, len(prefix), len(path))
+    }
+}
+
+// ---- server ----
+
+func machweb_handle(conn, handler) {
+    raw := read(conn)
+    req := parse_request(raw)
+    res := handler(req)
+    out := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.body)) + "\r\nConnection: close\r\n\r\n" + res.body
+    write(conn, out)
+    close(conn)
+}
+
+// serve runs the HTTP server. Each connection is handled in its own goroutine.
+func serve(port, handler) {
+    server := listen(port)
+    println("machweb on http://localhost:" + str(port))
+    for {
+        conn := accept(server)
+        go machweb_handle(conn, handler)
+    }
+}

--- a/framework/run.sh
+++ b/framework/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Compose the machweb framework with an app, compile, and run it.
+#   ./framework/run.sh framework/example.src
+set -euo pipefail
+cd "$(dirname "$0")/.."
+go build -o machin .
+app="${1:-framework/example.src}"
+./machin encode framework/machweb.src "$app" > framework/app.mfl
+exec ./machin run framework/app.mfl

--- a/main.go
+++ b/main.go
@@ -155,17 +155,23 @@ func cmdBuild(args []string) error {
 	return nil
 }
 
-// cmdEncode lifts loose Go-like text into canonical MFL. This is a machine
-// convenience for minting programs, not a human authoring path.
+// cmdEncode lifts loose Go-like text into canonical MFL. Multiple source files
+// are concatenated in order, so a framework can be composed with an app:
+//   machin encode framework/machweb.src myapp.src > app.mfl
 func cmdEncode(args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("encode: need exactly one source file")
+	if len(args) < 1 {
+		return fmt.Errorf("encode: need at least one source file")
 	}
-	data, err := os.ReadFile(args[0])
-	if err != nil {
-		return err
+	var combined strings.Builder
+	for _, path := range args {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		combined.Write(data)
+		combined.WriteByte('\n')
 	}
-	blocks, err := splitFunctions(string(data))
+	blocks, err := splitFunctions(combined.String())
 	if err != nil {
 		return err
 	}

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -336,6 +336,18 @@ func TestClosureIIFE(t *testing.T) {
 	}
 }
 
+func TestFrameworkDispatchPattern(t *testing.T) {
+	// the machweb pattern: a handler closure returning a struct, dispatched
+	// through a function that calls it (as serve -> handle -> handler does)
+	got := runProg(t,
+		`type Resp struct { code int  body string }`,
+		`func dispatch(h, n) (r) { r = h(n) }`,
+		`func main() { res := dispatch(func(x) { return Resp{code: 200, body: str(x * 2)} }, 21) println(res.code, res.body) }`)
+	if got != "200 42\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestVariadicCollect(t *testing.T) {
 	got := runProg(t,
 		`func sum(nums...) { t := 0 for _, n := range nums { t = t + n } return t }`,


### PR DESCRIPTION
A tiny web framework people can build real backends on — and it's **written in MFL itself**. You compose it ahead of your app and compile to a single native binary with no runtime dependencies.

## Hello, server

```go
func main() {
    serve(48080, func(req) {
        if req.path == "/" { return ok_text("hello from machweb") }
        return not_found()
    })
}
```

```sh
machin encode framework/machweb.src app.src > app.mfl && machin run app.mfl
# or: ./framework/run.sh app.src
```

## What's in it

- **Types** `Request` (`method`/`path`/`body`) and `Response`.
- **Response builders:** `ok_text`/`ok_html`/`ok_json`/`created`/`bad_request`/`not_found`.
- **`parse_request`** and a **`param(path, prefix)`** path helper.
- **`serve(port, handler)`** — runs the server, dispatching each request to a handler closure `func(Request) Response` in its own goroutine (memory reclaimed by the arena when the response is sent).

It dogfoods the whole language: closures (the handler), structs + slices + JSON, string ops (routing/path params), goroutines + sockets, and v0.3 named returns (the builders use `(r) { ... }`).

## Toolchain change

`machin encode` now accepts **multiple source files** and concatenates them, so a framework and an app compose into one program:

```
machin encode framework/machweb.src myapp.src > myapp.mfl
```

## Example app + verification

`framework/example.src` is a JSON todo API. Verified end-to-end with curl:

```
GET  /              -> <h1>machweb</h1>...
GET  /api/todos     -> [ {"id":1,"title":"learn MFL","done":true}, ... ]   (valid JSON)
GET  /hello/machine -> hello, machine                                       (path param)
POST /api/echo      -> {"id":9,"title":"posted","done":true}                (parse + reserialize)
GET  /nope          -> HTTP/1.1 404 Not Found
```

New test for the dispatch pattern (a handler closure returning a struct, called through a function). Full suite + all examples pass; `go vet` clean. README + run script included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)