### PR TITLE
feat: map-based router for machweb (+ func type)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -110,9 +110,13 @@ type User struct {
 }
 ```
 
-A field type is `int`, `float`, `bool`, `string`, `[]T`, `map[K]V`, or another
-struct name. Structs have **value semantics**: assigning or passing one copies
-it.
+A field type is `int`, `float`, `bool`, `string`, `[]T`, `map[K]V`, `func` (a
+function value), or another struct name. Structs have **value semantics**:
+assigning or passing one copies it.
+
+The `func` type denotes a function value whose signature is inferred from use —
+it lets closures be stored in slices, maps (`make(map[string]func)`), and struct
+fields, which is how a router keeps a table of handlers.
 
 ### 5.2 Functions
 

--- a/codegen.go
+++ b/codegen.go
@@ -39,6 +39,8 @@ func cTypeName(t string) string {
 		return "int"
 	case "string":
 		return "char*"
+	case "func":
+		return "mfl_closure"
 	}
 	return "mfl_" + t
 }

--- a/framework/README.md
+++ b/framework/README.md
@@ -55,6 +55,25 @@ reclaimed when the response is sent).
   `param("/users/42", "/users/") == "42"`.
 - `json(x)` / `parse(s, T{})` — serialize / parse JSON (built into machin).
 
+## Map-based router
+
+For exact `METHOD PATH` matching, register handlers on a router (a
+`map[string]func`) and serve it:
+
+```go
+func main() {
+    r := new_router()
+    route(r, "GET",  "/",          func(req) { return ok_text("home") })
+    route(r, "GET",  "/api/todos", func(req) { return ok_json(json(todos())) })
+    route(r, "POST", "/api/echo",  func(req) { return ok_json(req.body) })
+    serve_router(48080, r)
+}
+```
+
+Unmatched method+path combinations return `404` automatically. See
+`framework/router_app.src`. (For dynamic segments like `/hello/<name>`, use the
+plain `serve(port, handler)` form with `param`.)
+
 ## Example
 
 `example.src` is a small JSON todo API. Run it:

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -77,3 +77,34 @@ func serve(port, handler) {
         go machweb_handle(conn, handler)
     }
 }
+
+// ---- map-based router ----
+//
+// A router maps "METHOD PATH" to a handler closure func(Request) Response.
+//
+//   r := new_router()
+//   route(r, "GET", "/", func(req) { return ok_text("home") })
+//   serve_router(48080, r)
+
+func new_router() (r) {
+    r = make(map[string]func)
+}
+
+func route(router, method, path, handler) {
+    router[method + " " + path] = handler
+}
+
+func dispatch(router, req) (res) {
+    key := req.method + " " + req.path
+    if has(router, key) {
+        h := router[key]
+        res = h(req)
+    } else {
+        res = not_found()
+    }
+}
+
+// serve_router runs a router-backed server.
+func serve_router(port, router) {
+    serve(port, func(req) { return dispatch(router, req) })
+}

--- a/framework/router_app.src
+++ b/framework/router_app.src
@@ -1,0 +1,33 @@
+// A JSON API using machweb's map-based router. Compose and run:
+//   machin encode framework/machweb.src framework/router_app.src > app.mfl
+//   machin run app.mfl
+//   ./framework/run.sh framework/router_app.src
+
+type Todo struct {
+    id    int
+    title string
+    done  bool
+}
+
+func todos() (list) {
+    list = []Todo{}
+    list = append(list, Todo{id: 1, title: "learn MFL", done: true})
+    list = append(list, Todo{id: 2, title: "route with machweb", done: false})
+}
+
+func main() {
+    r := new_router()
+    route(r, "GET", "/", func(req) {
+        return ok_html("<h1>machweb router</h1><p>GET <code>/api/todos</code>, GET <code>/health</code>, POST <code>/api/echo</code></p>")
+    })
+    route(r, "GET", "/health", func(req) {
+        return ok_json("{\"status\":\"ok\"}")
+    })
+    route(r, "GET", "/api/todos", func(req) {
+        return ok_json(json(todos()))
+    })
+    route(r, "POST", "/api/echo", func(req) {
+        return ok_json(json(parse(req.body, Todo{})))
+    })
+    serve_router(48080, r)
+}

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -336,6 +336,18 @@ func TestClosureIIFE(t *testing.T) {
 	}
 }
 
+func TestMapOfClosuresRouter(t *testing.T) {
+	// the map-based router pattern: handler closures stored in map[string]func,
+	// dispatched by key, with a miss fallback
+	got := runProg(t,
+		`func reg(m, k, h) { m[k] = h }`,
+		`func dispatch(m, k, x) (out) { if has(m, k) { h := m[k] out = h(x) } else { out = -1 } }`,
+		`func main() { r := make(map[string]func) reg(r, "double", func(x) { return x * 2 }) reg(r, "square", func(x) { return x * x }) println(dispatch(r, "double", 5), dispatch(r, "square", 5), dispatch(r, "nope", 5), len(r)) }`)
+	if got != "10 25 -1 2\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestFrameworkDispatchPattern(t *testing.T) {
 	// the machweb pattern: a handler closure returning a struct, dispatched
 	// through a function that calls it (as serve -> handle -> handler does)

--- a/parser.go
+++ b/parser.go
@@ -176,6 +176,10 @@ func (p *Parser) parseTypeName() (string, error) {
 		}
 		return "chan " + elem, nil
 	}
+	if p.peek().Val == "func" { // a function value; its signature is inferred
+		p.next()
+		return "func", nil
+	}
 	t := p.next()
 	if t.Kind != TIdent {
 		return "", fmt.Errorf("expected a type name, got %q", t.Val)

--- a/types.go
+++ b/types.go
@@ -274,6 +274,8 @@ func (c *Checker) typeSlot(t string) (int, error) {
 		return newSlot(c, KBool), nil
 	case "string":
 		return newSlot(c, KString), nil
+	case "func":
+		return newSlot(c, KFunc), nil // signature filled in by unification
 	}
 	if _, ok := c.structs[t]; ok {
 		return newStructSlot(c, t), nil
@@ -697,7 +699,7 @@ func (c *Checker) checkTypeName(t string) error {
 		return c.checkTypeName(vt)
 	}
 	switch t {
-	case "int", "float", "bool", "string":
+	case "int", "float", "bool", "string", "func":
 		return nil
 	}
 	if _, ok := c.structs[t]; ok {


### PR DESCRIPTION
Grows machweb with a **map-based router**, and adds the language piece it needs: a **`func` type** so closures can live in containers.

## Router

```go
func main() {
    r := new_router()
    route(r, "GET",  "/",          func(req) { return ok_text("home") })
    route(r, "GET",  "/api/todos", func(req) { return ok_json(json(todos())) })
    route(r, "POST", "/api/echo",  func(req) { return ok_json(req.body) })
    serve_router(48080, r)
}
```

Handlers are stored in a `map[string]func` keyed by `"METHOD PATH"`; `dispatch` looks up the request and calls the handler, or returns `404`. Routing is **method-aware** (a `POST` to a `GET` route is a 404).

## The `func` type

Storing closures in a map needs a value-type annotation, but there was no function-type syntax. Added `func` as a type for `make(map[K]func)`, slice elements, and struct fields. It's a `KFunc` whose **signature is inferred by unification** — the stored handlers' signature flows into the map's value type, and the call site (`h := router[key]; h(req)`) forces it. Composes with monomorphization.

`parseTypeName` / `typeSlot` / `checkTypeName` / `cTypeName` handle `func`; the C representation is `mfl_closure`.

## Verification

`framework/router_app.src`:
```
GET  /            -> <h1>machweb router</h1>...
GET  /health      -> {"status":"ok"}
GET  /api/todos   -> [ {...}, {...} ]
POST /api/echo    -> {"id":7,"title":"routed","done":true}
GET  /missing     -> 404      (no route)
POST /health      -> 404      (method-aware)
```

New test for the map-of-closures pattern (register, dispatch by key, miss fallback). Full suite + all examples pass; `go vet` clean. SPEC + framework README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)