### PR TITLE
docs: machine-first landing page + monthly changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+From a language to a platform you can build on.
+
+- **machweb — a web framework written in MFL.** `Request`/`Response` types,
+  response builders (`ok_text`/`ok_html`/`ok_json`/`created`/`bad_request`/
+  `not_found`), `parse_request`, a `param(path, prefix)` path helper, and
+  `serve(port, handler)` which dispatches each request — in its own goroutine —
+  to a handler closure `func(Request) Response`. A backend compiles to a single
+  native binary with no runtime dependencies. See [`framework/`](framework/).
+- **Map-based router.** `new_router()` → `route(r, method, path, handler)` →
+  `serve_router(port, r)`. Handlers live in a `map[string]func` keyed by
+  `"METHOD PATH"`; routing is method-aware and unmatched requests return `404`.
+- **The `func` type.** A function-value type whose signature is inferred by
+  unification — it lets closures be stored in slices, maps
+  (`make(map[string]func)`), and struct fields. This is what makes a router's
+  handler table possible.
+- **Multi-file `machin encode`.** `encode` now accepts several source files and
+  concatenates them, so a framework and an app compose into one program:
+  `machin encode framework/machweb.src myapp.src > app.mfl`.
+
 ## v0.3.0
 
 Ergonomics, toward feeling like Go to write:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 > A statically-typed language whose on-disk form is base64 — one function per line, blank line between functions. It compiles to native machine code through C.
 
-📖 Full reference: [`SPEC.md`](SPEC.md) · language tour: [`docs/LANGUAGE.md`](docs/LANGUAGE.md) · web framework: [`framework/`](framework/) · self-hosted server: [`selfhost/`](selfhost/)
+📖 [Landing page](https://javimosch.github.io/machin/) · full reference: [`SPEC.md`](SPEC.md) · language tour: [`docs/LANGUAGE.md`](docs/LANGUAGE.md) · web framework: [`framework/`](framework/) · self-hosted server: [`selfhost/`](selfhost/)
 
 ```bash
 # A program IS base64 — one function per line:

--- a/docs/changelog-2026-06-product.md
+++ b/docs/changelog-2026-06-product.md
@@ -1,0 +1,84 @@
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-blue-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🧬</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">A new machine-first language</h3>
+              <p class="text-slate-400 leading-relaxed">MFL was born: a backend language whose source is base64 — one function per line — designed to be written and read by machines, not humans. The whole toolchain (lexer, parser, type inference, code generator) ships in Go.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-emerald-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">⚡</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Compiles to native code</h3>
+              <p class="text-slate-400 leading-relaxed">Programs are translated to C and compiled with cc -O2 — values are unboxed and there is no runtime VM. fib(40) runs in ~0.20s, neck-and-neck with hand-written C. Static typing is fully inferred: no annotations, type clashes caught at build time.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🧱</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">The full Go-flavored core</h3>
+              <p class="text-slate-400 leading-relaxed">Slices, structs, and maps; closures and higher-order functions; implicit generics by monomorphization; multiple and named returns; variadic parameters; and range loops — the language reads and writes much like Go, all compiled with no boxing.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-amber-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🧵</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Concurrency that doesn't leak</h3>
+              <p class="text-slate-400 leading-relaxed">Goroutines (pthread-backed), channels for communication, and a per-goroutine arena that reclaims memory when a request finishes — so a long-running server stays memory-bounded (RSS flat across 12,000 requests).</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-blue-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🌐</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Bidirectional JSON over HTTP</h3>
+              <p class="text-slate-400 leading-relaxed">BSD sockets, concurrent HTTP serving, JSON serialization and parsing (json(x) / parse(s, T{})), plus a string-operations library — enough to build a routed JSON API on a native binary with no runtime dependencies.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-emerald-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🚀</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">machweb — a backend framework</h3>
+              <p class="text-slate-400 leading-relaxed">A tiny web framework written in MFL itself: Request/Response types, response builders, request parsing, and a map-based router that dispatches each request — in its own goroutine — to a handler. Compose it with your app and compile to a single executable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">📦</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Released v0.1.0 → v0.3.0</h3>
+              <p class="text-slate-400 leading-relaxed">Three tagged releases this month, a formal language specification (SPEC.md), 35+ runnable examples, and a self-hosted server that serves the project's own catalog — the language is now capable enough to host part of its own tooling.</p>
+            </div>
+          </div>
+        </div>

--- a/docs/changelog-2026-06.html
+++ b/docs/changelog-2026-06.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Changelog June 2026 - machin</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    <style>
+      body { font-family: 'Inter', system-ui, sans-serif; background-color: #0a0a0b; color: #e2e8f0; }
+      h1, h2, h3 { font-family: 'Geist', system-ui, sans-serif; }
+      .tab-btn { transition: all 0.2s ease; }
+      .tab-btn.active { background-color: #1a1a1d; border-color: #3b82f6; color: #fff; }
+      .tab-content { display: none; animation: fadeIn 0.3s ease; }
+      .tab-content.active { display: block; }
+      @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+      .feature-card { background: linear-gradient(135deg, #1a1a1d 0%, #151517 100%); border: 1px solid #262629; transition: all 0.3s ease; }
+      .feature-card:hover { border-color: #3b82f6; transform: translateY(-2px); }
+    </style>
+  </head>
+  <body class="bg-[#0a0a0b] min-h-screen">
+    <div class="max-w-5xl mx-auto px-6 py-16">
+      <header class="mb-16">
+        <a href="changelog.html" class="text-blue-400 hover:text-blue-300 text-sm mb-6 inline-block transition-colors">&larr; Back to Changelog</a>
+        <h1 class="text-5xl font-bold text-white mt-4 tracking-tight">Changelog</h1>
+        <p class="text-slate-400 mt-3 text-lg">June 2026</p>
+        
+        <!-- Tabs -->
+        <div class="flex gap-2 mt-8">
+          <button onclick="switchTab('product')" id="tab-product" class="tab-btn active px-5 py-2.5 rounded-lg border border-slate-700 text-slate-300 font-medium text-sm hover:border-slate-600">
+            Product
+          </button>
+          <button onclick="switchTab('technical')" id="tab-technical" class="tab-btn px-5 py-2.5 rounded-lg border border-slate-700 text-slate-300 font-medium text-sm hover:border-slate-600">
+            Technical
+          </button>
+        </div>
+      </header>
+
+      <!-- Product Changelog -->
+      <div id="content-product" class="tab-content active">
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-blue-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🧬</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">A new machine-first language</h3>
+              <p class="text-slate-400 leading-relaxed">MFL was born: a backend language whose source is base64 — one function per line — designed to be written and read by machines, not humans. The whole toolchain (lexer, parser, type inference, code generator) ships in Go.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-emerald-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">⚡</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Compiles to native code</h3>
+              <p class="text-slate-400 leading-relaxed">Programs are translated to C and compiled with cc -O2 — values are unboxed and there is no runtime VM. fib(40) runs in ~0.20s, neck-and-neck with hand-written C. Static typing is fully inferred: no annotations, type clashes caught at build time.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🧱</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">The full Go-flavored core</h3>
+              <p class="text-slate-400 leading-relaxed">Slices, structs, and maps; closures and higher-order functions; implicit generics by monomorphization; multiple and named returns; variadic parameters; and range loops — the language reads and writes much like Go, all compiled with no boxing.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-amber-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🧵</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Concurrency that doesn't leak</h3>
+              <p class="text-slate-400 leading-relaxed">Goroutines (pthread-backed), channels for communication, and a per-goroutine arena that reclaims memory when a request finishes — so a long-running server stays memory-bounded (RSS flat across 12,000 requests).</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-blue-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🌐</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Bidirectional JSON over HTTP</h3>
+              <p class="text-slate-400 leading-relaxed">BSD sockets, concurrent HTTP serving, JSON serialization and parsing (json(x) / parse(s, T{})), plus a string-operations library — enough to build a routed JSON API on a native binary with no runtime dependencies.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-emerald-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🚀</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">machweb — a backend framework</h3>
+              <p class="text-slate-400 leading-relaxed">A tiny web framework written in MFL itself: Request/Response types, response builders, request parsing, and a map-based router that dispatches each request — in its own goroutine — to a handler. Compose it with your app and compile to a single executable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">📦</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">Released v0.1.0 → v0.3.0</h3>
+              <p class="text-slate-400 leading-relaxed">Three tagged releases this month, a formal language specification (SPEC.md), 35+ runnable examples, and a self-hosted server that serves the project's own catalog — the language is now capable enough to host part of its own tooling.</p>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Technical Changelog -->
+      <div id="content-technical" class="tab-content">
+        <div class="space-y-8">
+
+        <section>
+          <h2 class="text-2xl font-semibold text-red-400 mb-4 flex items-center gap-2">
+            <span>🐛</span> Bug Fixes
+          </h2>
+          <ul class="space-y-2 text-slate-300">
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>fix(types,codegen): correct string equality, float %, and len() typing (#30)</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 class="text-2xl font-semibold text-purple-400 mb-4 flex items-center gap-2">
+            <span>💼</span> Other
+          </h2>
+          <ul class="space-y-2 text-slate-300">
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add docs/ landing page and update CHANGELOG</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add a map-based router to machweb (+ the func type) (#62)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add machweb: a backend web framework written in MFL (#61)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Release v0.3.0: named returns and variadic parameters</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add variadic parameters (v0.3) (#60)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add named return values (v0.3 feature) (#59)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Release v0.2.1: arena memory management</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add arena memory management (per-goroutine reclamation) (#58)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add a self-hosted server written in MFL (#57)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Consolidate v0.2.0: add SPEC.md and CHANGELOG, bump version</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add generics via monomorphization (implicit, no annotations) (#56)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add closures and first-class functions (lambda-lifting) (#55)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add multiple return values + parallel/comma-ok assignment (#54)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add for-range loops over slices, maps, and strings (#53)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add string operations + an HTTP router example (#52)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add JSON parsing: parse(s, T{}) + http_body, POST echo API (#51)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add JSON serialization and a JSON-over-HTTP API (#50)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add maps: make(map[K]V), indexing, has/delete/keys (#49)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add channels: goroutine communication (#48)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add structs: the keystone composite type (#47)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add language reference and Sieve example</li>
+            <li><span class="text-slate-500 text-sm mr-3">[20/06]</span>Add Makefile, LICENSE, and tau-style README</li>
+            <li><span class="text-slate-500 text-sm mr-3">[20/06]</span>Add slices and goroutines; concurrent HTTP server</li>
+            <li><span class="text-slate-500 text-sm mr-3">[20/06]</span>Add Go-style for loops and sockets; HTTP server example</li>
+            <li><span class="text-slate-500 text-sm mr-3">[20/06]</span>Compile MFL to native code; remove interpreter and decode</li>
+            <li><span class="text-slate-500 text-sm mr-3">[20/06]</span>Make .mfl the source of truth; drop human-readable .mfs crutch</li>
+            <li><span class="text-slate-500 text-sm mr-3">[20/06]</span>Add basic + complex MFL examples (compiled to .mfl)</li>
+          </ul>
+        </section>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      function switchTab(tab) {
+        document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
+        document.querySelectorAll('.tab-btn').forEach(el => el.classList.remove('active'));
+        document.getElementById('content-' + tab).classList.add('active');
+        document.getElementById('tab-' + tab).classList.add('active');
+      }
+    </script>
+  </body>
+</html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Changelog - machin</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    <style>
+      body { font-family: 'Inter', system-ui, sans-serif; background-color: #0a0a0b; color: #e2e8f0; }
+      h1 { font-family: 'Geist', system-ui, sans-serif; }
+    </style>
+  </head>
+  <body class="bg-[#0a0a0b] min-h-screen">
+    <div class="max-w-5xl mx-auto px-6 py-16">
+      <header class="mb-16">
+        <a href="index.html" class="text-blue-400 hover:text-blue-300 text-sm mb-6 inline-block transition-colors">&larr; Back to Docs</a>
+        <h1 class="text-5xl font-bold text-white mt-4 tracking-tight">Changelog</h1>
+        <p class="text-slate-400 mt-3 text-lg">Monthly changelogs</p>
+      </header>
+      <div class="space-y-4">
+        <a href="changelog-2026-06.html" class="block p-6 bg-slate-900 rounded-xl border border-slate-700 hover:border-brand-500 transition-colors">
+          <span class="text-brand-400">June 2026</span>
+          <span class="text-slate-400 ml-4">→ View</span>
+        </a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MFL — the Machine-First Language</title>
+<meta name="description" content="A backend language based on Go, but the source is base64. Statically typed by inference, compiled to native code through C.">
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --border:#272d36; --fg:#e6edf3;
+    --muted:#9aa6b2; --accent:#58e1a5; --accent2:#7aa2ff; --code:#0b0f14;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--fg);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+  a{color:var(--accent2);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
+  header{padding:72px 0 40px;text-align:center}
+  .badge{display:inline-block;font-size:12px;color:var(--accent);
+    border:1px solid var(--border);border-radius:999px;padding:3px 12px;margin-bottom:20px}
+  h1{font-size:clamp(38px,7vw,64px);margin:0;letter-spacing:-1.5px}
+  .tag{color:var(--muted);font-size:20px;margin:14px 0 26px}
+  .cta a{display:inline-block;margin:0 6px;padding:10px 18px;border-radius:8px;
+    border:1px solid var(--border);font-weight:600}
+  .cta a.primary{background:var(--accent);color:#04150e;border-color:var(--accent)}
+  section{padding:34px 0;border-top:1px solid var(--border)}
+  h2{font-size:24px;letter-spacing:-.4px;margin:0 0 16px}
+  p.lead{color:var(--muted)}
+  pre{background:var(--code);border:1px solid var(--border);border-radius:10px;
+    padding:16px 18px;overflow:auto;font-size:13.5px;color:#cdd9e5}
+  .split{display:grid;gap:14px;grid-template-columns:1fr 1fr}
+  @media(max-width:680px){.split{grid-template-columns:1fr}}
+  .label{font-size:12px;color:var(--muted);margin:0 0 6px;text-transform:uppercase;letter-spacing:.5px}
+  .grid{display:grid;gap:14px;grid-template-columns:repeat(2,1fr)}
+  @media(max-width:680px){.grid{grid-template-columns:1fr}}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:16px}
+  .card h3{margin:0 0 6px;font-size:16px}
+  .card p{margin:0;color:var(--muted);font-size:14px}
+  .kw{color:var(--accent2)} .str{color:var(--accent)} .cm{color:#6b7785}
+  table{border-collapse:collapse;width:100%;font-size:14px}
+  td,th{border:1px solid var(--border);padding:8px 12px;text-align:left}
+  th{color:var(--muted);font-weight:600}
+  footer{padding:40px 0 70px;color:var(--muted);font-size:14px;text-align:center;border-top:1px solid var(--border)}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <div class="badge">v0.3.0 · compiles to native code</div>
+  <h1>machin ⎯ MFL</h1>
+  <p class="tag">A backend language based on Go — but the source is base64.<br>Written for machines, not humans.</p>
+  <div class="cta">
+    <a class="primary" href="https://github.com/javimosch/machin">GitHub</a>
+    <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Spec</a>
+    <a href="#framework">Build a backend</a>
+  </div>
+</div></header>
+
+<div class="wrap">
+
+<section>
+  <h2>The source <em>is</em> base64</h2>
+  <p class="lead">A program is base64 — one function per line, a blank line between functions. The dense form is the source of truth; the readable text is a projection the machine produces on demand.</p>
+  <div class="split">
+    <div><p class="label">on disk (.mfl)</p>
+<pre>ZnVuYyBmaWIobikgeyBpZiBuIDwgMiB7
+IHJldHVybiBuIH0gcmV0dXJuIGZpYihu
+IC0gMSkgKyBmaWIobiAtIDIpIH0=
+
+ZnVuYyBtYWluKCkgeyBwcmludGxuKGZp
+YigxMCkpIH0=</pre></div>
+    <div><p class="label">decoded</p>
+<pre><span class="kw">func</span> fib(n) {
+    <span class="kw">if</span> n &lt; 2 { <span class="kw">return</span> n }
+    <span class="kw">return</span> fib(n - 1) + fib(n - 2)
+}
+
+<span class="kw">func</span> main() { println(fib(10)) }</pre></div>
+  </div>
+</section>
+
+<section>
+  <h2>Statically typed, zero annotations, native speed</h2>
+  <p class="lead">Types are inferred by unification. The compiler emits C and hands it to <code>cc -O2</code>, so values are unboxed and there is no runtime VM.</p>
+  <table>
+    <tr><th>fib(40), ~331M calls</th><th>time</th></tr>
+    <tr><td><b>MFL</b> (native via cc -O2)</td><td><b>0.20s</b></td></tr>
+    <tr><td>hand-written C</td><td>0.19s</td></tr>
+    <tr><td>Rust (rustc -O)</td><td>0.29s</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>The whole Go-flavored core</h2>
+  <div class="grid">
+    <div class="card"><h3>Composite types</h3><p>slices <code>[]T</code>, structs, maps <code>map[K]V</code> — all unboxed.</p></div>
+    <div class="card"><h3>Concurrency</h3><p><code>go</code> goroutines, channels, a per-goroutine arena that bounds servers.</p></div>
+    <div class="card"><h3>Closures &amp; generics</h3><p>capturing lambdas, higher-order functions, implicit generics by monomorphization.</p></div>
+    <div class="card"><h3>Multiple &amp; named returns</h3><p><code>q, r := divmod(a, b)</code>, comma-ok, and <code>func f() (q, r)</code>.</p></div>
+    <div class="card"><h3>Variadics</h3><p><code>func sum(nums...)</code>, called <code>sum(1,2,3)</code> or spread <code>sum(xs...)</code>.</p></div>
+    <div class="card"><h3>JSON over HTTP</h3><p>sockets, <code>json(x)</code> / <code>parse(s, T{})</code>, string ops &amp; routing.</p></div>
+  </div>
+</section>
+
+<section id="framework">
+  <h2>Build a backend with machweb</h2>
+  <p class="lead">A web framework written in MFL itself. Compose it with your app and compile to one native binary — no runtime dependencies.</p>
+<pre><span class="kw">func</span> main() {
+    r := new_router()
+    route(r, <span class="str">"GET"</span>,  <span class="str">"/"</span>,          <span class="kw">func</span>(req) { <span class="kw">return</span> ok_text(<span class="str">"home"</span>) })
+    route(r, <span class="str">"GET"</span>,  <span class="str">"/api/todos"</span>, <span class="kw">func</span>(req) { <span class="kw">return</span> ok_json(json(todos())) })
+    route(r, <span class="str">"POST"</span>, <span class="str">"/api/echo"</span>,  <span class="kw">func</span>(req) { <span class="kw">return</span> ok_json(req.body) })
+    serve_router(48080, r)
+}</pre>
+<pre class="cm"><span class="cm"># compose framework + app, compile, run</span>
+machin encode framework/machweb.src app.src &gt; app.mfl
+machin run app.mfl</pre>
+</section>
+
+<section>
+  <h2>Quick start</h2>
+<pre>git clone https://github.com/javimosch/machin &amp;&amp; cd machin
+make build                              <span class="cm"># → bin/machin (needs Go + a C compiler)</span>
+bin/machin run examples/demo.mfl
+bin/machin build examples/complex/primes.mfl -o primes &amp;&amp; ./primes</pre>
+</section>
+
+</div>
+
+<footer><div class="wrap">
+  <a href="https://github.com/javimosch/machin">Repository</a> ·
+  <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Specification</a> ·
+  <a href="https://github.com/javimosch/machin/tree/main/examples">Examples</a> ·
+  <a href="https://github.com/javimosch/machin/tree/main/framework">Framework</a> ·
+  <a href="https://github.com/javimosch/machin/releases">Releases</a>
+  <p>MIT — <a href="https://www.linkedin.com/in/arancibiajav/">Javier Leandro Arancibia</a></p>
+</div></footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,42 +4,46 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MFL — the Machine-First Language</title>
-<meta name="description" content="A backend language based on Go, but the source is base64. Statically typed by inference, compiled to native code through C.">
+<meta name="description" content="A backend language whose source is base64. Written for machines, not humans. Statically typed by inference, compiled to native code.">
 <style>
   :root{
-    --bg:#0d1117; --panel:#161b22; --border:#272d36; --fg:#e6edf3;
-    --muted:#9aa6b2; --accent:#58e1a5; --accent2:#7aa2ff; --code:#0b0f14;
+    --bg:#0a0c10; --panel:#12161d; --border:#222932; --fg:#e6edf3;
+    --muted:#8b97a4; --accent:#58e1a5; --accent2:#7aa2ff; --code:#070a0e;
   }
   *{box-sizing:border-box}
   html{scroll-behavior:smooth}
   body{margin:0;background:var(--bg);color:var(--fg);
     font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
-  a{color:var(--accent2);text-decoration:none}
-  a:hover{text-decoration:underline}
-  code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
-  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
-  header{padding:72px 0 40px;text-align:center}
+  a{color:var(--accent2);text-decoration:none} a:hover{text-decoration:underline}
+  code,pre,.b64{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  .wrap{max-width:860px;margin:0 auto;padding:0 20px}
+  header{padding:76px 0 30px;text-align:center}
   .badge{display:inline-block;font-size:12px;color:var(--accent);
     border:1px solid var(--border);border-radius:999px;padding:3px 12px;margin-bottom:20px}
-  h1{font-size:clamp(38px,7vw,64px);margin:0;letter-spacing:-1.5px}
-  .tag{color:var(--muted);font-size:20px;margin:14px 0 26px}
-  .cta a{display:inline-block;margin:0 6px;padding:10px 18px;border-radius:8px;
+  h1{font-size:clamp(40px,7vw,66px);margin:0;letter-spacing:-1.5px}
+  .tag{color:var(--muted);font-size:20px;margin:14px 0 10px}
+  .tag b{color:var(--fg)}
+  .cta{margin-top:24px}
+  .cta a{display:inline-block;margin:0 5px 8px;padding:10px 18px;border-radius:8px;
     border:1px solid var(--border);font-weight:600}
   .cta a.primary{background:var(--accent);color:#04150e;border-color:var(--accent)}
   section{padding:34px 0;border-top:1px solid var(--border)}
-  h2{font-size:24px;letter-spacing:-.4px;margin:0 0 16px}
-  p.lead{color:var(--muted)}
+  h2{font-size:24px;letter-spacing:-.4px;margin:0 0 10px}
+  p.lead{color:var(--muted);margin-top:0}
+  .b64{display:block;background:var(--code);border:1px solid var(--border);border-radius:10px;
+    padding:16px 18px;font-size:13px;color:#7fdcb0;white-space:pre-wrap;word-break:break-all;line-height:1.7}
+  .b64 + .b64{margin-top:10px}
+  .cap{font-size:12px;color:var(--muted);margin:8px 2px 0}
   pre{background:var(--code);border:1px solid var(--border);border-radius:10px;
-    padding:16px 18px;overflow:auto;font-size:13.5px;color:#cdd9e5}
-  .split{display:grid;gap:14px;grid-template-columns:1fr 1fr}
-  @media(max-width:680px){.split{grid-template-columns:1fr}}
-  .label{font-size:12px;color:var(--muted);margin:0 0 6px;text-transform:uppercase;letter-spacing:.5px}
+    padding:14px 16px;overflow:auto;font-size:13.5px;color:#cdd9e5}
+  .cm{color:#6b7785}
+  .pipe{display:flex;gap:10px;flex-wrap:wrap;align-items:center;color:var(--muted);font-size:14px;margin-top:6px}
+  .pipe span{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:8px 12px}
+  .pipe .arrow{background:none;border:none;padding:0;color:var(--accent)}
   .grid{display:grid;gap:14px;grid-template-columns:repeat(2,1fr)}
   @media(max-width:680px){.grid{grid-template-columns:1fr}}
   .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:16px}
-  .card h3{margin:0 0 6px;font-size:16px}
-  .card p{margin:0;color:var(--muted);font-size:14px}
-  .kw{color:var(--accent2)} .str{color:var(--accent)} .cm{color:#6b7785}
+  .card h3{margin:0 0 6px;font-size:16px} .card p{margin:0;color:var(--muted);font-size:14px}
   table{border-collapse:collapse;width:100%;font-size:14px}
   td,th{border:1px solid var(--border);padding:8px 12px;text-align:left}
   th{color:var(--muted);font-weight:600}
@@ -48,42 +52,42 @@
 </head>
 <body>
 <header><div class="wrap">
-  <div class="badge">v0.3.0 · compiles to native code</div>
+  <div class="badge">v0.3.0 · compiled to native code</div>
   <h1>machin ⎯ MFL</h1>
-  <p class="tag">A backend language based on Go — but the source is base64.<br>Written for machines, not humans.</p>
+  <p class="tag">A backend language whose source is <b>base64</b>.<br>Written for machines. You don't read the code — the machine does.</p>
   <div class="cta">
     <a class="primary" href="https://github.com/javimosch/machin">GitHub</a>
     <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Spec</a>
-    <a href="#framework">Build a backend</a>
+    <a href="changelog.html">Changelog</a>
   </div>
 </div></header>
 
 <div class="wrap">
 
 <section>
-  <h2>The source <em>is</em> base64</h2>
-  <p class="lead">A program is base64 — one function per line, a blank line between functions. The dense form is the source of truth; the readable text is a projection the machine produces on demand.</p>
-  <div class="split">
-    <div><p class="label">on disk (.mfl)</p>
-<pre>ZnVuYyBmaWIobikgeyBpZiBuIDwgMiB7
-IHJldHVybiBuIH0gcmV0dXJuIGZpYihu
-IC0gMSkgKyBmaWIobiAtIDIpIH0=
+  <h2>This is a program</h2>
+  <p class="lead">Not a representation of one — the program itself. A `.mfl` file is base64, one function per line. The machine emits it and consumes it; there is no readable source to author or maintain. The recursive Fibonacci below is complete and runs:</p>
+  <code class="b64">ZnVuYyBmaWIobikgeyBpZiBuIDwgMiB7IHJldHVybiBuIH0gcmV0dXJuIGZpYihuIC0gMSkgKyBmaWIobiAtIDIpIH0=</code>
+  <code class="b64">ZnVuYyBtYWluKCkgeyBwcmludGxuKGZpYigxMCkpIH0=</code>
+  <p class="cap">A blank line separates functions. Each line is independently addressable — tooling ships, caches, or rewrites one function without touching the rest.</p>
+</section>
 
-ZnVuYyBtYWluKCkgeyBwcmludGxuKGZp
-YigxMCkpIH0=</pre></div>
-    <div><p class="label">decoded</p>
-<pre><span class="kw">func</span> fib(n) {
-    <span class="kw">if</span> n &lt; 2 { <span class="kw">return</span> n }
-    <span class="kw">return</span> fib(n - 1) + fib(n - 2)
-}
-
-<span class="kw">func</span> main() { println(fib(10)) }</pre></div>
+<section>
+  <h2>No human in the loop</h2>
+  <p class="lead">Readable syntax exists for people to scan; MFL drops it as overhead, because the entity writing and reading the code is a machine. You state intent — the machine produces the base64 and compiles it.</p>
+  <div class="pipe">
+    <span>intent</span><span class="arrow">→</span>
+    <span>.mfl (base64)</span><span class="arrow">→</span>
+    <span>infer + monomorphize</span><span class="arrow">→</span>
+    <span>C</span><span class="arrow">→</span>
+    <span>cc -O2</span><span class="arrow">→</span>
+    <span>native binary</span>
   </div>
 </section>
 
 <section>
-  <h2>Statically typed, zero annotations, native speed</h2>
-  <p class="lead">Types are inferred by unification. The compiler emits C and hands it to <code>cc -O2</code>, so values are unboxed and there is no runtime VM.</p>
+  <h2>Native speed, zero annotations</h2>
+  <p class="lead">Types are inferred by unification; values compile unboxed. There is no interpreter and no runtime VM.</p>
   <table>
     <tr><th>fib(40), ~331M calls</th><th>time</th></tr>
     <tr><td><b>MFL</b> (native via cc -O2)</td><td><b>0.20s</b></td></tr>
@@ -94,37 +98,34 @@ YigxMCkpIH0=</pre></div>
 
 <section>
   <h2>The whole Go-flavored core</h2>
+  <p class="lead">Everything below is expressed in the base64 form and compiled to native code.</p>
   <div class="grid">
-    <div class="card"><h3>Composite types</h3><p>slices <code>[]T</code>, structs, maps <code>map[K]V</code> — all unboxed.</p></div>
-    <div class="card"><h3>Concurrency</h3><p><code>go</code> goroutines, channels, a per-goroutine arena that bounds servers.</p></div>
-    <div class="card"><h3>Closures &amp; generics</h3><p>capturing lambdas, higher-order functions, implicit generics by monomorphization.</p></div>
-    <div class="card"><h3>Multiple &amp; named returns</h3><p><code>q, r := divmod(a, b)</code>, comma-ok, and <code>func f() (q, r)</code>.</p></div>
-    <div class="card"><h3>Variadics</h3><p><code>func sum(nums...)</code>, called <code>sum(1,2,3)</code> or spread <code>sum(xs...)</code>.</p></div>
-    <div class="card"><h3>JSON over HTTP</h3><p>sockets, <code>json(x)</code> / <code>parse(s, T{})</code>, string ops &amp; routing.</p></div>
+    <div class="card"><h3>Composite types</h3><p>slices, structs, maps — all unboxed.</p></div>
+    <div class="card"><h3>Concurrency</h3><p>goroutines, channels, and a per-goroutine arena that keeps servers memory-bounded.</p></div>
+    <div class="card"><h3>Closures &amp; generics</h3><p>capturing function values and implicit generics by monomorphization.</p></div>
+    <div class="card"><h3>Returns</h3><p>multiple, named, comma-ok, and variadic parameters.</p></div>
+    <div class="card"><h3>JSON over HTTP</h3><p>sockets, serialize and parse, string ops, routing.</p></div>
+    <div class="card"><h3>One binary</h3><p>a backend compiles to a single native executable, no runtime deps.</p></div>
   </div>
 </section>
 
-<section id="framework">
-  <h2>Build a backend with machweb</h2>
-  <p class="lead">A web framework written in MFL itself. Compose it with your app and compile to one native binary — no runtime dependencies.</p>
-<pre><span class="kw">func</span> main() {
-    r := new_router()
-    route(r, <span class="str">"GET"</span>,  <span class="str">"/"</span>,          <span class="kw">func</span>(req) { <span class="kw">return</span> ok_text(<span class="str">"home"</span>) })
-    route(r, <span class="str">"GET"</span>,  <span class="str">"/api/todos"</span>, <span class="kw">func</span>(req) { <span class="kw">return</span> ok_json(json(todos())) })
-    route(r, <span class="str">"POST"</span>, <span class="str">"/api/echo"</span>,  <span class="kw">func</span>(req) { <span class="kw">return</span> ok_json(req.body) })
-    serve_router(48080, r)
-}</pre>
-<pre class="cm"><span class="cm"># compose framework + app, compile, run</span>
+<section>
+  <h2>A concurrent HTTP server — one line</h2>
+  <p class="lead">This base64 line is the entry point of a goroutine-per-connection web server (listen, accept loop, dispatch):</p>
+  <code class="b64">ZnVuYyBtYWluKCkgeyBzZXJ2ZXIgOj0gbGlzdGVuKDQ4MDgwKSBmb3IgeyBjb25uIDo9IGFjY2VwdChzZXJ2ZXIpIGdvIGhhbmRsZShjb25uKSB9IH0=</code>
+  <p class="cap">The machweb framework — itself written in MFL — adds routing and JSON on top. You compose it with your app and compile:</p>
+<pre><span class="cm"># the machine composes the framework + your intent into one program</span>
 machin encode framework/machweb.src app.src &gt; app.mfl
 machin run app.mfl</pre>
 </section>
 
 <section>
-  <h2>Quick start</h2>
+  <h2>Run it</h2>
 <pre>git clone https://github.com/javimosch/machin &amp;&amp; cd machin
-make build                              <span class="cm"># → bin/machin (needs Go + a C compiler)</span>
+make build                                  <span class="cm"># → bin/machin (needs Go + a C compiler)</span>
 bin/machin run examples/demo.mfl
 bin/machin build examples/complex/primes.mfl -o primes &amp;&amp; ./primes</pre>
+  <p class="cap">Curious what a line says? <code>machin build &lt;file&gt; --emit-c</code> prints the C the machine generated — an inspection escape hatch, not a step you live in.</p>
 </section>
 
 </div>
@@ -132,7 +133,7 @@ bin/machin build examples/complex/primes.mfl -o primes &amp;&amp; ./primes</pre>
 <footer><div class="wrap">
   <a href="https://github.com/javimosch/machin">Repository</a> ·
   <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Specification</a> ·
-  <a href="https://github.com/javimosch/machin/tree/main/examples">Examples</a> ·
+  <a href="changelog.html">Changelog</a> ·
   <a href="https://github.com/javimosch/machin/tree/main/framework">Framework</a> ·
   <a href="https://github.com/javimosch/machin/releases">Releases</a>
   <p>MIT — <a href="https://www.linkedin.com/in/arancibiajav/">Javier Leandro Arancibia</a></p>


### PR DESCRIPTION
The docs task, with two review fixes applied.

## 1. Machine-first landing page (`docs/index.html`)

The first version showed human-readable code — which contradicts machin's whole identity. Rewritten to be genuinely machine-first:

- The **base64 IS the artifact**. Three real programs are shown as base64 (the fib program and a concurrent HTTP server's entry line) — each **verified to decode** to a valid program.
- Framed around the philosophy: *you don't read the code, the machine does; you state intent, the machine emits and consumes the base64.* Includes the intent → `.mfl` → C → native pipeline.
- **No readable MFL source anywhere** — only base64, toolchain/shell commands, tables, and prose. (`--emit-c` is mentioned as an inspection escape hatch, not a workflow step.)

## 2. Monthly changelog via the `changelog-updater` skill

Used the actual skill (`~/.config/opencode/skills/changelog-updater`) to generate:
- `docs/changelog-2026-06.html` — Product + Technical dual-view, from git history
- `docs/changelog.html` — the wrapper

The skill's default product summary was stale (left over from another project — BTC/WebSocket), so I **replaced it with a real, hand-improved summary** covering the month: a new machine-first language, native compilation, the Go-flavored core, leak-free concurrency, JSON over HTTP, machweb, and the v0.1.0 → v0.3.0 releases.

Plus a hand-written `Unreleased` section in `CHANGELOG.md` (machweb, router, `func` type, multi-file encode) and a README landing-page link.

Verified: featured base64 decodes to valid programs; HTML balances; tests still pass. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new landing page for the MFL project with language overview and example usage.
  * Created a dedicated changelog section with product and technical change documentation.
  * Updated README with a link to the new landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->