### PR TITLE
ci: windows/amd64 release target + AGENTS.md release runbook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: release
 
 # Cut a release by pushing a version tag:
 #   git tag v0.5.0 && git push origin v0.5.0
-# This cross-compiles machin for linux/macOS x amd64/arm64 and attaches the
-# binaries (plus SHA256SUMS.txt) to the GitHub release for that tag.
+# This cross-compiles machin for linux/macOS x amd64/arm64 and windows/amd64,
+# and attaches the binaries (plus SHA256SUMS.txt) to the release for that tag.
 
 on:
   push:
@@ -30,12 +30,13 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           mkdir -p dist
-          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
             os="${target%/*}"; arch="${target#*/}"
-            echo "building machin-${TAG}-${os}-${arch}"
+            ext=""; [ "$os" = "windows" ] && ext=".exe" # Windows binaries need .exe
+            echo "building machin-${TAG}-${os}-${arch}${ext}"
             GOOS="$os" GOARCH="$arch" \
               go build -trimpath -ldflags="-s -w" \
-              -o "dist/machin-${TAG}-${os}-${arch}" .
+              -o "dist/machin-${TAG}-${os}-${arch}${ext}" .
           done
           ( cd dist && sha256sum machin-* > SHA256SUMS.txt )
           ls -l dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+Orientation for agents working on **machin** (the toolchain) / **MFL** (the
+language). Humans state intent; the machine reads and writes the code.
+
+## What this is
+
+machin compiles MFL to native code through C:
+
+```
+.mfl ──base64 decode──▶ parse ──▶ infer types ──▶ emit C ──▶ cc -O2 ──▶ native binary
+```
+
+| Stage | File |
+|-------|------|
+| Lex / parse | `lexer.go`, `parser.go` |
+| Lambda-lift / closure-convert | `transform.go` |
+| Type inference + monomorphization | `types.go` |
+| C codegen | `codegen.go` |
+| Build / run (invokes `cc`) | `build.go` |
+| CLI | `main.go` |
+
+The full language reference is [`SPEC.md`](SPEC.md).
+
+## Standing constraints (do not violate)
+
+- **The `.mfl` base64 IS the source of truth.** One function per line, a blank
+  line between functions. There is no human-readable source form and no `decode`
+  command. Never present readable MFL as the authoring/reading surface, and
+  never make the public landing page show readable MFL — it shows base64.
+  (`machin build --emit-c` exists for inspecting what runs; that is the only
+  "peek".)
+- **Machine-first / minimalism.** Prefer the smallest change that holds the
+  surface minimal. Target C/Rust/Zig-class performance — the default build has
+  no runtime overhead a C programmer wouldn't accept.
+- Keep the working tree clean. Commit/push only the intended change.
+
+## Dev workflow
+
+```bash
+go build ./...                 # build the compiler
+go vet ./... && go test ./...  # must be green before a PR
+make examples                  # run every example (also: examples/run.sh)
+```
+
+Author MFL by writing loose Go-like `.src` text and minting `.mfl` from it:
+
+```bash
+go run . encode my.src > my.mfl      # multiple files concatenate (framework + app)
+go run . run my.mfl                  # compile to native + execute
+go run . run my.mfl --safe           # + bounds / div-zero / overflow checks
+```
+
+When adding a language feature, thread it through **every** pass that switches on
+node type: `transform.go` (lifter, `collectDeclared`, `freeIdents`), `types.go`
+(`genStmt`, and arity/return walkers), and `codegen.go`. Add a test in
+`*_test.go` and, when it is user-facing, an example under `examples/complex/`
+and a note in `SPEC.md` + `README.md`.
+
+### Branch → PR → merge
+
+Feature work goes on a branch, then a PR, then squash-merge + delete the branch.
+- Commit messages end with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- PR bodies end with:
+  `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+- Do not merge without the user's go-ahead.
+- Stacked PRs: GitHub *closes* (does not retarget) a PR when its base branch is
+  deleted on merge. If you stack, expect to rebase the child onto `main`
+  (`git rebase origin/main` — already-merged commits drop out as duplicate
+  patches) and open a fresh PR against `main`.
+
+## Releasing
+
+Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml).
+Pushing a `v*` tag cross-compiles machin and attaches the binaries to that tag's
+GitHub release. **To cut a release:**
+
+1. Update the version: bump the badge in `README.md` and add a section to the
+   top of `CHANGELOG.md` (newest first). Commit to `main`.
+   ```
+   release: vX.Y.Z (one-line summary)
+   ```
+2. Tag and push:
+   ```bash
+   git tag -a vX.Y.Z -m "MFL vX.Y.Z" && git push origin vX.Y.Z
+   ```
+3. The workflow builds `machin-vX.Y.Z-<os>-<arch>` for **linux/{amd64,arm64}**,
+   **darwin/{amd64,arm64}**, and **windows/amd64** (`.exe`), plus
+   `SHA256SUMS.txt`, and publishes them. Watch it:
+   ```bash
+   gh run list --workflow=release.yml --limit 1
+   gh run watch <run-id> --exit-status
+   ```
+4. Verify the assets landed:
+   ```bash
+   gh release view vX.Y.Z --json assets -q '[.assets[].name]'
+   ```
+
+Notes:
+- The workflow is **idempotent for a tag**: if a release already exists for the
+  tag (e.g. hand-authored), it overwrites assets (`--clobber`); otherwise it
+  creates the release with `--generate-notes`. To re-run a build for an existing
+  tag, delete and re-push the tag.
+- machin is **pure Go** (no cgo), so binaries are static (~2 MB) and
+  cross-compile cleanly. The shipped binary is a **compiler frontend** — it
+  emits C and invokes `cc`/`gcc`/`clang` at build time, so end users still need
+  a C compiler on PATH. Say so in release notes.
+- Versioning: minor bump (`v0.X.0`) for new language/library features, patch
+  (`v0.X.Y`) for fixes and tooling/CI.


### PR DESCRIPTION
Two small things:

## `windows/amd64` release target
`release.yml` now also builds `machin-<tag>-windows-amd64.exe` (the loop appends `.exe` for the windows GOOS). So a `v*` tag ships **5** binaries: linux/{amd64,arm64}, darwin/{amd64,arm64}, windows/amd64 — plus `SHA256SUMS.txt`.

Verified locally: all five targets cross-compile (`windows-amd64` → PE32+ executable), and `sha256sum machin-*` picks them all up.

## `AGENTS.md`
A new orientation doc so an agent can work — and **release** — unaided. Covers:
- the compile pipeline + which file does what;
- the standing constraints (machine-first; the `.mfl` base64 **is** the source of truth — no readable form, landing page stays base64);
- dev/test commands and "thread a new feature through every pass";
- branch → PR → squash-merge norms (incl. the stacked-PR rebase gotcha we hit);
- a **step-by-step release runbook**: bump badge + CHANGELOG → tag → `gh run watch` → verify assets, plus the idempotent-per-tag and compiler-frontend caveats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Windows x86_64 binary builds now included with releases, alongside existing Linux and macOS distributions.

* **Documentation**
  * Added comprehensive contributor documentation outlining development workflow, contribution guidelines, and release conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->