### PR TITLE
tools: reliability harness + drop-func experiment

### DIFF
--- a/tools/reliability/README.md
+++ b/tools/reliability/README.md
@@ -1,0 +1,53 @@
+# reliability harness
+
+The second half of machin's write/edit-cost metric. `tokcost`/`tokmin` measure
+**tokens**; they cannot see whether a syntax form makes an agent get the code
+*wrong* more often. This measures that. The real cost is `tokens × tries`, so a
+token saving that raises the error rate can be a net loss — this harness is how
+we tell.
+
+## How it works
+
+1. **Task bank** — `tasks.json`: small programs with a precise spec and the
+   exact expected stdout.
+2. **Generate** — a model (run as independent subagents) writes a solution to
+   each task in two surface forms: a **control** and a **candidate**, given an
+   identical MFL primer that differs *only* in the rule under test. Generation
+   is first-try: no repo access, no compiler feedback.
+3. **Score** — `score.py` compiles and runs every program and reports, per form,
+   the compile rate, the correctness rate (exact stdout match), and (for the
+   candidate) how often the model actually adopted the change.
+
+```bash
+go build -o /tmp/machin .
+MACHIN=/tmp/machin python3 tools/reliability/score.py <outdir>
+```
+
+Output files are named `<variant>_<trial>.txt`, each holding `### <task-id>`
+blocks. For a candidate that *removes* a construct the current compiler still
+needs (e.g. drop-`func`), the scorer reinserts it mechanically before compiling,
+so it measures "does dropping the marker make the model write worse logic?"
+separately from "is the new grammar implemented yet?".
+
+## Experiment 1 — drop the `func` keyword (issue #101)
+
+Hypothesis: removing the `func` marker (−1.7% tokens) might hurt reliability —
+the model could write worse logic, or keep emitting `func` out of habit.
+
+13 tasks × 3 trials × 2 forms = **78 programs** (frontier model):
+
+| form | n | compile | correct | func-dropped |
+|------|---|---------|---------|--------------|
+| control (`func name(){}`) | 39 | 100% | 100% | — |
+| treat (`name(){}`)        | 39 | 100% | 100% | 100% |
+
+**Δ correctness: 0.0 points.** No measurable reliability cost, and full
+adherence (the model never fought the instruction). Verdict: drop-`func` is
+de-risked at this model capability.
+
+**Limitation — ceiling effect.** Both forms scored 100%, so the suite can't
+resolve a *small* penalty; it rules out a large one. A definitive answer would
+need a harder bank (base error rate > 0) or a weaker model. The honest reading:
+no evidence of a reliability cost, strong evidence of compliance — but the win
+itself is small (1.7%), so whether to spend a language change on it is a product
+call (see issue #101's open question on how far from in-distribution to go).

--- a/tools/reliability/score.py
+++ b/tools/reliability/score.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""reliability scorer — the second half of machin's write/edit-cost metric.
+
+tokcost/tokmin measure tokens; they cannot see whether a syntax form makes an
+agent get the code *wrong* more often. This does. Given model-written programs
+for a bank of tasks in two surface forms (a control and a candidate), it
+compiles and runs each, and reports per-form compile + correctness rates so a
+token saving can be weighed against a reliability cost.
+
+Usage:
+    MACHIN=/path/to/machin python3 score.py <outdir>
+
+<outdir> holds files named "<variant>_<trial>.txt", variant in {control,treat}.
+Each file contains, for each task, a block:
+
+    ### <task-id>
+    <one MFL declaration per line>
+
+For the `treat` (drop-func) variant, declarations omit the `func` keyword; the
+scorer reinserts it (prepending `func ` to each non-`type` declaration line) so
+the *current* compiler can build it — isolating the question "does dropping the
+marker make the model write worse logic?" from "is the grammar implemented yet?"
+It also reports func-adherence: how often the model actually dropped `func`.
+"""
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MACHIN = os.environ.get("MACHIN", "machin")
+
+
+def load_tasks():
+    with open(os.path.join(HERE, "tasks.json")) as f:
+        return {t["id"]: t for t in json.load(f)}
+
+
+def parse_blocks(text):
+    """Split a model output file into {task-id: program-text}."""
+    blocks, cur, buf = {}, None, []
+    for line in text.splitlines():
+        m = re.match(r"^\s*#{2,3}\s*([\w-]+)\s*$", line)
+        if m:
+            if cur:
+                blocks[cur] = "\n".join(buf).strip()
+            cur, buf = m.group(1), []
+        elif cur:
+            buf.append(line)
+    if cur:
+        blocks[cur] = "\n".join(buf).strip()
+    return blocks
+
+
+def canonicalize(program, variant):
+    """Return (mfl_source, dropped_func_count, total_decls) ready to compile."""
+    lines = [l.strip() for l in program.splitlines() if l.strip()]
+    # ignore stray markdown fences the model may add
+    lines = [l for l in lines if not l.startswith("```")]
+    dropped = total = 0
+    out = []
+    for l in lines:
+        if l.startswith("type "):
+            out.append(l)
+            continue
+        total += 1
+        if l.startswith("func "):
+            out.append(l)  # already has the marker
+        else:
+            if variant == "treat":
+                dropped += 1
+            out.append("func " + l)  # reinsert for the current grammar
+    return "\n".join(out) + "\n", dropped, total
+
+
+def run(src):
+    """Compile+run an MFL source string; return (compiled, stdout)."""
+    path = os.path.join(os.environ.get("TMPDIR", "/tmp"), "_rel.mfl")
+    with open(path, "w") as f:
+        f.write(src)
+    try:
+        p = subprocess.run([MACHIN, "run", path], input=b"",
+                           capture_output=True, timeout=30)
+    except Exception:
+        return False, ""
+    return p.returncode == 0, p.stdout.decode("utf-8", "replace")
+
+
+def main():
+    outdir = sys.argv[1] if len(sys.argv) > 1 else "/tmp/rel/out"
+    tasks = load_tasks()
+    agg = {}  # variant -> counters
+    for path in sorted(glob.glob(os.path.join(outdir, "*.txt"))):
+        variant = os.path.basename(path).split("_")[0]
+        a = agg.setdefault(variant, dict(n=0, compiled=0, correct=0, dropped=0, decls=0, missing=0))
+        blocks = parse_blocks(open(path).read())
+        for tid, task in tasks.items():
+            a["n"] += 1
+            prog = blocks.get(tid, "")
+            if not prog:
+                a["missing"] += 1
+                continue
+            src, dropped, total = canonicalize(prog, variant)
+            a["dropped"] += dropped
+            a["decls"] += total
+            compiled, out = run(src)
+            if compiled:
+                a["compiled"] += 1
+            if compiled and out == task["expected"]:
+                a["correct"] += 1
+
+    print(f"task bank: {len(tasks)} tasks | binary: {MACHIN}\n")
+    print(f"{'variant':9} {'n':>3} {'compile%':>9} {'correct%':>9} {'func-dropped%':>14}")
+    for variant in ("control", "treat"):
+        a = agg.get(variant)
+        if not a:
+            continue
+        n = a["n"] or 1
+        comp = 100 * a["compiled"] / n
+        corr = 100 * a["correct"] / n
+        adher = 100 * a["dropped"] / (a["decls"] or 1) if variant == "treat" else float("nan")
+        adher_s = "      n/a" if variant == "control" else f"{adher:13.0f}%"
+        print(f"{variant:9} {a['n']:>3} {comp:8.0f}% {corr:8.0f}% {adher_s:>14}")
+
+    c, t = agg.get("control"), agg.get("treat")
+    if c and t:
+        dc = 100 * c["correct"] / (c["n"] or 1)
+        dt = 100 * t["correct"] / (t["n"] or 1)
+        print(f"\nΔ correctness (treat - control): {dt - dc:+.1f} points")
+        print("interpretation: a negative Δ is the reliability cost of the form;"
+              " weigh it against the token saving (drop-func ≈ -1.7%).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/reliability/tasks.json
+++ b/tools/reliability/tasks.json
@@ -1,0 +1,15 @@
+[
+  {"id": "fib",       "spec": "Define fib(n) with fib(0)=0, fib(1)=1, fib(n)=fib(n-1)+fib(n-2). In main, print fib(10).", "expected": "55\n"},
+  {"id": "sumslice",  "spec": "In main, build the slice []int{1,2,3,4,5}, sum its elements, and print the sum.", "expected": "15\n"},
+  {"id": "fizzbuzz",  "spec": "In main, for i from 1 to 5 inclusive, print one value per line: \"Fizz\" if i is divisible by 3, \"Buzz\" if divisible by 5, otherwise the number i. (So the lines are: 1, 2, Fizz, 4, Buzz.)", "expected": "1\n2\nFizz\n4\nBuzz\n"},
+  {"id": "factorial", "spec": "Define fact(n) computing n! iteratively (fact(0)=1). In main, print fact(5).", "expected": "120\n"},
+  {"id": "vowels",    "spec": "Define count_vowels(s) returning how many characters of the string s are vowels (one of a,e,i,o,u, lowercase). In main, print count_vowels(\"machine\").", "expected": "3\n"},
+  {"id": "maxof",     "spec": "Define max_of(xs) returning the largest int in the slice xs. In main, print max_of([]int{3,7,2,9,4}).", "expected": "9\n"},
+  {"id": "point",     "spec": "Define a struct type Point with int fields x and y. Define sum_point(p) returning p.x + p.y. In main, print sum_point(Point{3,4}).", "expected": "7\n"},
+  {"id": "counter",   "spec": "Define make_counter() that returns a closure over an internal integer starting at 0; each call increments it and returns the new value (first call returns 1). In main, create one counter, call it three times, and print the value returned by the third call.", "expected": "3\n"},
+  {"id": "divmod",    "spec": "Define divmod(a, b) that returns TWO values: the quotient a/b and the remainder a%b. In main, do `q, r := divmod(17, 5)` and print q and r (so the line is `3 2`).", "expected": "3 2\n"},
+  {"id": "wordcount", "spec": "In main, given xs := []string{\"a\",\"b\",\"a\",\"c\",\"a\"}, build a map[string]int counting how many times each string occurs, then print the count for \"a\".", "expected": "3\n"},
+  {"id": "structslice", "spec": "Define a struct type Item with fields name (string) and qty (int). In main, build a slice of two Items, Item{\"pen\",3} and Item{\"cup\",5}, sum their qty fields, and print the total. (Note: non-empty struct-slice literals are not supported; start from []Item{} and append.)", "expected": "8\n"},
+  {"id": "haskey",    "spec": "In main, create a map[string]int and set key \"x\" to 10. Using the has(map, key) builtin, check whether key \"y\" is present: print its value if present, otherwise print \"missing\".", "expected": "missing\n"},
+  {"id": "reverse",   "spec": "Define reverse(s) returning the string s with its characters in reverse order. In main, print reverse(\"abc\").", "expected": "cba\n"}
+]


### PR DESCRIPTION
The missing instrument from issue #101: token cost is mechanical, but reliability — does a form make a model write *wrong* code more often — needs a model in the loop. The real metric is **tokens × tries**.

## The harness (`tools/reliability/`)

- `tasks.json` — small programs with precise specs + exact expected stdout.
- `score.py` — compiles/runs model-written solutions and reports per-form compile rate, correctness rate, and adoption rate.
- Model-in-the-loop = independent subagents writing **first-try** solutions (no repo access, no compiler feedback) from an identical primer that differs *only* in the rule under test.

For a candidate that removes something the current compiler still needs (drop-`func`), the scorer reinserts it before compiling — isolating "does dropping the marker hurt the logic?" from "is the grammar implemented yet?".

## Experiment 1 — drop `func` (−1.7% tokens)

13 tasks × 3 trials × 2 forms = **78 programs**, frontier model:

| form | n | compile | correct | func-dropped |
|---|---|---|---|---|
| control (`func name(){}`) | 39 | 100% | 100% | — |
| treat (`name(){}`) | 39 | 100% | 100% | 100% |

**Δ correctness: 0.0.** No measurable reliability cost; the model adopted the terse form 100% of the time (it did *not* habitually re-add `func`, which was my hypothesised failure mode).

**Honest limitation:** ceiling effect — both at 100%, so the bank rules out a *large* penalty, not a small one. A definitive result needs a harder bank (base error rate > 0) or a weaker model.

## So what

drop-`func` is **de-risked** but the win is small (1.7%). Whether to spend a language change on it is the product call flagged in #101 (how far from in-distribution to go). I did **not** implement drop-`func` — that's your decision; this PR just adds the instrument and the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)