### PR TITLE
feat: C FFI Phase 1 — extern blocks, scalar types + linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **C FFI (Phase 1).** An `extern "lib" { header "..." link "..." cflags "..."
+  fn name(types) ret }` declaration names foreign C functions; calls compile to
+  direct C calls and the `header`/`link`/`cflags` are threaded into `cc`. Scalar
+  types only (int, float, bool, string). Example: `extern "m" { header "math.h"
+  link "m" fn sqrt(float) float }` then `sqrt(2.0)`. New
+  `examples/complex/ffi_math.mfl`; the path to the C ecosystem (and a future GUI).
 - **Tightened canonical form (token-minimization).** The canonical `.mfl` now
   drops whitespace adjacent to operators/punctuation (`fib(n - 1)` →
   `fib(n-1)`), keeping only the spaces the lexer needs between word tokens. Zero

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ func main() {
 | **JSON** | `json(x)` serializes any value to JSON; `parse(s, T{})` parses JSON into a value of `T` |
 | **Networking** | `listen`, `accept`, `read`, `write`, `close` |
 | **I/O** | `print`, `println`, `input` (read a line from stdin) |
+| **C FFI** | `extern "lib" { header "..." link "..." fn name(types) ret }` — call foreign C functions (scalar types) |
 
 ---
 
@@ -216,6 +217,7 @@ per-call-site arg struct + trampoline driven by `pthread_create`.
 | `complex/counter` | by-reference capture: mutable closures sharing a cell |
 | `complex/arena` | scoped `arena { }`: flat memory across a long-lived loop |
 | `complex/game_menu` | native desktop CLI: a Start/Settings/Exit loop reading `input()` |
+| `complex/ffi_math` | C FFI: call `sqrt`/`pow` from libm via an `extern` block |
 | `complex/generics` | one source function specialized at int / string / float |
 | `complex/goroutines` | `go` spawns concurrent workers; `sleep` waits |
 | `complex/channels` | fan-in worker pool — goroutines communicate over a channel |
@@ -317,6 +319,8 @@ make install      # install to $(PREFIX)/bin  (default /usr/local)
 | By-reference closure capture (mutable captured state, Go semantics) | ✅ done |
 | Bounds / div-zero / overflow checks (`--safe`) | ✅ done |
 | Scoped arenas (`arena { }`) — bound a long-lived loop's memory | ✅ done |
+| C FFI — `extern` blocks, scalar types + linking (Phase 1) | ✅ done |
+| C FFI phases 2–4 (structs, opaque handles, callbacks) | ⬜ planned |
 | Automatic tracing GC | ⬜ planned |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -78,7 +78,7 @@ The decoded text of a declaration is tokenized as follows.
 - **Float literals.** digits with a `.`, e.g. `3.14`, `0.5`.
 - **String literals.** `"..."` with escapes `\n \t \r \" \\`.
 - **Keywords.** `func return if else while for range true false nil var go type
-  struct chan make map`.
+  struct chan make map arena extern`.
 - **Operators and punctuation.** `+ - * / % == != < <= > >= && || ! = := <- .
   : , ; ( ) { } [ ]`.
 
@@ -378,10 +378,41 @@ FuncLit     = "func" "(" [ identList ] ")" Block .
 
 ---
 
-## 15. Status and non-goals
+## 15. Foreign functions (C FFI)
+
+An `extern` declaration names foreign C functions and how to compile and link
+against them. It is a single top-level declaration (one line, like any other):
+
+```
+extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) float }
+```
+
+- `"m"` — an informational library name.
+- `header "h.h"` — emits `#include <h.h>` so the real C prototype is in scope.
+  If omitted, machin emits a prototype from the declared signature instead.
+- `link "l"` — passes `-l<l>` to the C compiler.
+- `cflags "..."` — passes extra flags (e.g. `-I`/`-L` paths) to the C compiler.
+- `fn Name(t, ...) ret` — a foreign function. Parameter and return types are the
+  FFI scalar types `int`, `float`, `bool`, `string`; a missing return type means
+  `void`.
+
+A call to a declared name compiles to a **direct C call**; its arguments and
+return value use the C representation of the FFI type (`int`→`int64_t`,
+`float`→`double`, `bool`→`int`, `string`→`const char*`). The call is type-checked
+against the declared arity/types like any other.
+
+This is **Phase 1** (scalar types). Structs, opaque handles/pointers, and
+callbacks are future phases. The FFI boundary is unchecked C: a value an MFL
+string passes to C is arena-allocated, so a C function that retains the pointer
+past the arena's lifetime would dangle — pass copies or keep it in scope.
+
+---
+
+## 16. Status and non-goals
 
 Implemented: the entire surface above, including arena memory management with
 scoped `arena { }` blocks (§12), named return values (§9), variadic parameters
-(§5.2), by-reference closure capture (§11.1), and opt-in bounds/overflow checks
-(`--safe`). Not yet implemented: polymorphic recursion and an automatic tracing
-GC. These are refinements, not core gaps.
+(§5.2), by-reference closure capture (§11.1), opt-in bounds/overflow checks
+(`--safe`), and scalar C FFI (§15). Not yet implemented: polymorphic recursion,
+an automatic tracing GC, and FFI phases 2–4 (structs, handles, callbacks). These
+are refinements, not core gaps.

--- a/ast.go
+++ b/ast.go
@@ -5,9 +5,32 @@ type Node interface{ node() }
 
 // Program is a whole MFL program: struct type declarations plus functions.
 type Program struct {
-	Types []*TypeDecl
-	Funcs []*FuncDecl
+	Types   []*TypeDecl
+	Funcs   []*FuncDecl
+	Externs []*ExternDecl
 }
+
+// ExternDecl declares foreign C functions and how to compile/link against them:
+//   extern "m" { header "math.h" link "m" fn sqrt(float) float }
+// Calls to the declared names compile to direct C calls; the header supplies the
+// real prototype and `link`/`cflags` are threaded into the cc invocation.
+type ExternDecl struct {
+	Lib    string // informational name after `extern`
+	Header string // #include <Header> ("" if none)
+	Link   string // -l<Link> ("" if none)
+	CFlags string // extra cc flags ("" if none)
+	Funcs  []ExternFunc
+}
+
+// ExternFunc is one foreign function signature. Param/return types are the FFI
+// scalar type names: int, float, bool, string (Ret "" means void).
+type ExternFunc struct {
+	Name   string
+	Params []string
+	Ret    string
+}
+
+func (ExternDecl) node() {}
 
 // Field is one struct field with an explicit type (int, float, bool, string,
 // []elem, or another struct name).

--- a/build.go
+++ b/build.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // ccPath is the C compiler used to turn emitted C into a native binary.
@@ -32,7 +33,21 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 	}
 	tmp.Close()
 
-	cmd := exec.Command(ccPath(), "-O2", "-std=c11", "-pthread", "-o", outPath, tmp.Name())
+	// foreign linkage: extern cflags go before the source; -l libs after it
+	args := []string{"-O2", "-std=c11", "-pthread"}
+	var libs []string
+	for _, ed := range prog.Externs {
+		if ed.CFlags != "" {
+			args = append(args, strings.Fields(ed.CFlags)...)
+		}
+		if ed.Link != "" {
+			libs = append(libs, "-l"+ed.Link)
+		}
+	}
+	args = append(args, "-o", outPath, tmp.Name())
+	args = append(args, libs...)
+
+	cmd := exec.Command(ccPath(), args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s failed: %v\n%s", ccPath(), err, out)
 	}

--- a/codegen.go
+++ b/codegen.go
@@ -385,6 +385,21 @@ static char* mfl_input(void) {
 }
 `
 
+// ffiCType maps an FFI scalar type name to its C type (for headerless prototypes).
+func ffiCType(t string) string {
+	switch t {
+	case "int":
+		return "int64_t"
+	case "float":
+		return "double"
+	case "bool":
+		return "int"
+	case "string":
+		return "const char*"
+	}
+	return "void"
+}
+
 func cType(k Kind) string {
 	switch k {
 	case KInt:
@@ -433,6 +448,25 @@ func (g *cgen) program(p *Program) (string, error) {
 	var out strings.Builder
 	out.WriteString(cRuntime)
 	out.WriteByte('\n')
+	// foreign (extern) declarations: include each header so the real C prototype
+	// is in scope; for headerless externs, emit a prototype from the signature.
+	for _, ed := range p.Externs {
+		if ed.Header != "" {
+			fmt.Fprintf(&out, "#include <%s>\n", ed.Header)
+			continue
+		}
+		for _, ef := range ed.Funcs {
+			params := make([]string, len(ef.Params))
+			for i, pt := range ef.Params {
+				params[i] = ffiCType(pt)
+			}
+			ps := strings.Join(params, ", ")
+			if ps == "" {
+				ps = "void"
+			}
+			fmt.Fprintf(&out, "extern %s %s(%s);\n", ffiCType(ef.Ret), ef.Name, ps)
+		}
+	}
 	// struct typedefs, in declaration order (a struct may reference earlier ones)
 	for _, td := range p.Types {
 		fmt.Fprintf(&out, "typedef struct {")
@@ -1475,6 +1509,10 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return "mfl_input()", nil
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
+	}
+	if ef := g.c.ExternFn(ex.Callee); ef != nil {
+		// a foreign C function: call it directly (the header gives the prototype)
+		return fmt.Sprintf("%s(%s)", ef.Name, strings.Join(args, ", ")), nil
 	}
 	if !g.c.IsTopFunc(ex.Callee) {
 		// a function-valued local variable, called by name

--- a/examples/complex/ffi_math.mfl
+++ b/examples/complex/ffi_math.mfl
@@ -1,0 +1,4 @@
+extern "m"{header "math.h" link "m" fn sqrt(float)float fn pow(float,float)float}
+
+func main(){println("sqrt(2) =",sqrt(2.0))println("2^10 =",pow(2.0,10.0))println("hypot(3,4) =",sqrt(pow(3.0,2.0)+pow(4.0,2.0)))}
+

--- a/ffi_test.go
+++ b/ffi_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFFIMath exercises Phase-1 C FFI end to end: an extern declaration with a
+// header + link, a direct call to the foreign function, and linking via -lm.
+func TestFFIMath(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) float }`,
+		`func main(){ println(sqrt(2.0)) println(pow(2.0, 10.0)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if want := "1.41421\n1024\n"; out != want {
+		t.Fatalf("FFI math: got %q, want %q", out, want)
+	}
+}
+
+// A foreign call with the wrong argument count is a clean MFL type error, not a
+// leaked cc failure.
+func TestFFIArgCountChecked(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`extern "m" { header "math.h" link "m" fn sqrt(float) float }`,
+		`func main(){ println(sqrt(1.0, 2.0)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "expected 1 args") {
+		t.Fatalf("expected an arg-count error, got %v", err)
+	}
+}

--- a/lexer.go
+++ b/lexer.go
@@ -29,7 +29,7 @@ var keywords = map[string]bool{
 	"while": true, "for": true, "true": true, "false": true,
 	"nil": true, "var": true, "go": true, "type": true, "struct": true,
 	"chan": true, "make": true, "map": true, "range": true,
-	"arena": true,
+	"arena": true, "extern": true,
 }
 
 type Lexer struct {

--- a/parser.go
+++ b/parser.go
@@ -68,6 +68,12 @@ func ParseProgram(decls []string) (*Program, error) {
 			}
 			prog.Types = append(prog.Types, td)
 			structs[td.Name] = true
+		} else if toks[0].Kind == TKeyword && toks[0].Val == "extern" {
+			ed, err := ParseExtern(src)
+			if err != nil {
+				return nil, err
+			}
+			prog.Externs = append(prog.Externs, ed)
 		} else {
 			funcSrcs = append(funcSrcs, src)
 		}
@@ -81,6 +87,104 @@ func ParseProgram(decls []string) (*Program, error) {
 	}
 	liftClosures(prog) // closure conversion: lift function literals to top level
 	return prog, nil
+}
+
+// ParseExtern parses a single extern declaration (foreign C functions).
+func ParseExtern(src string) (*ExternDecl, error) {
+	toks, err := Lex(src)
+	if err != nil {
+		return nil, err
+	}
+	p := &Parser{toks: toks}
+	ed, err := p.parseExternDecl()
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().Kind != TEOF {
+		return nil, fmt.Errorf("trailing tokens after extern: %q", p.peek().Val)
+	}
+	return ed, nil
+}
+
+func isFFIType(s string) bool {
+	return s == "int" || s == "float" || s == "bool" || s == "string"
+}
+
+// parseExternDecl parses:
+//   extern "lib" { header "h.h" link "l" cflags "..." fn Name(t, t) ret ... }
+func (p *Parser) parseExternDecl() (*ExternDecl, error) {
+	if _, err := p.expect(TKeyword, "extern"); err != nil {
+		return nil, err
+	}
+	lib, err := p.expect(TString, "")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TPunct, "{"); err != nil {
+		return nil, err
+	}
+	ed := &ExternDecl{Lib: lib.Val}
+	str := func(dst *string) error {
+		s, err := p.expect(TString, "")
+		if err != nil {
+			return err
+		}
+		*dst = s.Val
+		return nil
+	}
+	for p.peek().Val != "}" && p.peek().Kind != TEOF {
+		kw := p.next()
+		switch kw.Val {
+		case "header":
+			if err := str(&ed.Header); err != nil {
+				return nil, err
+			}
+		case "link":
+			if err := str(&ed.Link); err != nil {
+				return nil, err
+			}
+		case "cflags":
+			if err := str(&ed.CFlags); err != nil {
+				return nil, err
+			}
+		case "fn":
+			name, err := p.expect(TIdent, "")
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(TPunct, "("); err != nil {
+				return nil, err
+			}
+			var params []string
+			for p.peek().Val != ")" && p.peek().Kind != TEOF {
+				t := p.next()
+				if !isFFIType(t.Val) {
+					return nil, fmt.Errorf("extern fn %s: unsupported parameter type %q (use int/float/bool/string)", name.Val, t.Val)
+				}
+				params = append(params, t.Val)
+				for p.peek().Val == "," {
+					p.next()
+				}
+			}
+			if _, err := p.expect(TPunct, ")"); err != nil {
+				return nil, err
+			}
+			ret := ""
+			if isFFIType(p.peek().Val) {
+				ret = p.next().Val // an explicit return type; absence means void
+			}
+			ed.Funcs = append(ed.Funcs, ExternFunc{Name: name.Val, Params: params, Ret: ret})
+		default:
+			return nil, fmt.Errorf("extern: expected header/link/cflags/fn, got %q", kw.Val)
+		}
+	}
+	if _, err := p.expect(TPunct, "}"); err != nil {
+		return nil, err
+	}
+	if len(ed.Funcs) == 0 {
+		return nil, fmt.Errorf("extern %q: no fn declarations", ed.Lib)
+	}
+	return ed, nil
 }
 
 // ParseType parses a single decoded struct type declaration.

--- a/types.go
+++ b/types.go
@@ -82,7 +82,9 @@ type Checker struct {
 	nodeSlot   map[string]map[Node]int // instance -> expr node -> slot
 
 	// shared concrete slots (no inner type vars, safe to share)
-	cBool, cString, cVoid, cInt int
+	cBool, cString, cVoid, cInt, cFloat int
+
+	externs map[string]*ExternFunc // foreign C functions, by name
 
 	pairs []int      // flattened pairs: pairs[2i], pairs[2i+1]
 	plus  []plusCons // overloaded '+' constraints, resolved by fixpoint
@@ -576,11 +578,13 @@ func Check(p *Program) (*Checker, error) {
 		instStack:  map[string]string{},
 		callInst:   map[string]map[*Call]string{},
 		closureInst: map[string]map[*MakeClosure]string{},
+		externs:    map[string]*ExternFunc{},
 	}
 	c.cBool = newSlot(c, KBool)
 	c.cString = newSlot(c, KString)
 	c.cVoid = newSlot(c, KVoid)
 	c.cInt = newSlot(c, KInt)
+	c.cFloat = newSlot(c, KFloat)
 
 	// 0. register struct types and validate their field types
 	for _, td := range p.Types {
@@ -603,6 +607,19 @@ func Check(p *Program) (*Checker, error) {
 	}
 	if _, ok := c.funcs["main"]; !ok {
 		return nil, fmt.Errorf("no main function defined")
+	}
+	// register foreign (extern) functions; their signatures are fixed, not inferred
+	for _, ed := range p.Externs {
+		for _, ef := range ed.Funcs {
+			f := ef
+			if _, dup := c.externs[f.Name]; dup {
+				return nil, fmt.Errorf("duplicate extern fn %q", f.Name)
+			}
+			if _, clash := c.funcs[f.Name]; clash {
+				return nil, fmt.Errorf("extern fn %q clashes with a function", f.Name)
+			}
+			c.externs[f.Name] = &f
+		}
 	}
 	// 2. instantiate from main; every reachable function is specialized per
 	//    concrete call-site type (monomorphization).
@@ -1368,6 +1385,24 @@ func (c *Checker) genStructLit(fn *FuncDecl, ex *StructLit) (int, error) {
 	return res, nil
 }
 
+// ffiSlot maps an FFI scalar type name to its concrete checker slot.
+func (c *Checker) ffiSlot(t string) int {
+	switch t {
+	case "int":
+		return c.cInt
+	case "float":
+		return c.cFloat
+	case "bool":
+		return c.cBool
+	case "string":
+		return c.cString
+	}
+	return c.cVoid // "" -> void
+}
+
+// ExternFn returns the foreign-function signature for name, or nil.
+func (c *Checker) ExternFn(name string) *ExternFunc { return c.externs[name] }
+
 func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 	argSlots := make([]int, len(ex.Args))
 	for i, a := range ex.Args {
@@ -1545,6 +1580,16 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return c.cVoid, nil
+	}
+	if ef, ok := c.externs[ex.Callee]; ok {
+		// a foreign C function: fixed signature, compiled to a direct C call
+		if len(argSlots) != len(ef.Params) {
+			return 0, fmt.Errorf("%s: expected %d args, got %d", ef.Name, len(ef.Params), len(argSlots))
+		}
+		for i, pt := range ef.Params {
+			c.addPair(argSlots[i], c.ffiSlot(pt))
+		}
+		return c.ffiSlot(ef.Ret), nil
 	}
 	if _, isFunc := c.funcs[ex.Callee]; !isFunc {
 		// not a top-level function — maybe a function-valued local variable


### PR DESCRIPTION
Starts the C FFI from issue #94. machin already compiles to C, so calling foreign C is a natural extension — one capability that unlocks the whole C ecosystem (and is the prerequisite for a graphical desktop GUI) instead of growing the builtin runtime one function at a time.

## Surface

An `extern` declaration (one canonical line) names foreign functions + how to build against them:

```
extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) float }

func main(){ println(sqrt(2.0)) }     // -> 1.41421
```

- `header "h.h"` → `#include <h.h>` (real prototype in scope); omit it and machin emits a prototype from the signature.
- `link "l"` → `-l<l>`; `cflags "..."` → extra `cc` flags.
- `fn name(t, ...) ret` → scalar FFI types `int`/`float`/`bool`/`string`; missing return = void.

A call compiles to a **direct C call**, type-checked for arity/types like any builtin.

## Implementation

- `extern` keyword + `ExternDecl`/`ExternFunc` AST + parser.
- Checker registers foreign functions with fixed signatures; `genCall` checks args and returns the declared type.
- Codegen emits the include (or prototype) and the direct call; `build.go` threads `link`/`cflags` into the `cc` invocation (libs after the source, cflags before).

## Verification

- **Milestone (issue #94 acceptance):** `extern "m" { header "math.h" link "m" fn sqrt(float) float }`, `sqrt(2.0)` → `1.41421`, linked with `-lm`. ✅
- Multi-fn, `strlen` (string→int), and the headerless-prototype path all work; wrong arity is a clean MFL error (`sqrt: expected 1 args, got 2`), not a leaked `cc` failure.
- `TestFFIMath` + `TestFFIArgCountChecked`; new `examples/complex/ffi_math.mfl` (canonical, guarded by `TestExamplesAreCanonical`).
- Full suite + all examples green; no regressions. SPEC §15 + README + CHANGELOG updated.

## Scope

Phase 1 = scalar types. Phases 2–4 (structs, opaque handles/pointers, callbacks) remain in #94. The FFI boundary is unchecked C; the arena-lifetime caveat for strings handed to C is documented.

Closes Phase 1 of #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)