### PR TITLE
feat: C FFI Phase 2 — by-value struct marshaling + sized scalar types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
-- **C FFI (Phase 1).** An `extern "lib" { header "..." link "..." cflags "..."
-  fn name(types) ret }` declaration names foreign C functions; calls compile to
-  direct C calls and the `header`/`link`/`cflags` are threaded into `cc`. Scalar
-  types only (int, float, bool, string). Example: `extern "m" { header "math.h"
-  link "m" fn sqrt(float) float }` then `sqrt(2.0)`. New
-  `examples/complex/ffi_math.mfl`; the path to the C ecosystem (and a future GUI).
+- **C FFI (Phases 1–2).** An `extern "lib" { header "..." link "..." cflags "..."
+  cstruct T { f ctype ... } fn name(types) ret }` declaration names foreign C
+  functions; calls compile to direct C calls and `header`/`link`/`cflags` are
+  threaded into `cc`. **Phase 1:** scalar types — `int`/`float`/`bool`/`string`
+  plus sized `i8…u64`/`f32`/`f64` (sizes matter for ABI: raylib takes 32-bit
+  `int`/`float`). **Phase 2:** `cstruct` declares a C struct's layout; machin
+  synthesizes a matching MFL struct and marshals it by value across the boundary
+  (pass and return). New `examples/complex/ffi_math.mfl` and `ffi_struct.mfl`;
+  the path to the C ecosystem and a future GUI.
 - **Tightened canonical form (token-minimization).** The canonical `.mfl` now
   drops whitespace adjacent to operators/punctuation (`fib(n - 1)` →
   `fib(n-1)`), keeping only the spaces the lexer needs between word tokens. Zero

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ func main() {
 | **JSON** | `json(x)` serializes any value to JSON; `parse(s, T{})` parses JSON into a value of `T` |
 | **Networking** | `listen`, `accept`, `read`, `write`, `close` |
 | **I/O** | `print`, `println`, `input` (read a line from stdin) |
-| **C FFI** | `extern "lib" { header "..." link "..." fn name(types) ret }` — call foreign C functions (scalar types) |
+| **C FFI** | `extern "lib" { header "..." link "..." cstruct T {...} fn name(types) ret }` — call foreign C functions; scalar + by-value struct types |
 
 ---
 
@@ -218,6 +218,7 @@ per-call-site arg struct + trampoline driven by `pthread_create`.
 | `complex/arena` | scoped `arena { }`: flat memory across a long-lived loop |
 | `complex/game_menu` | native desktop CLI: a Start/Settings/Exit loop reading `input()` |
 | `complex/ffi_math` | C FFI: call `sqrt`/`pow` from libm via an `extern` block |
+| `complex/ffi_struct` | C FFI: marshal a C struct by value (`div_t` from libc) |
 | `complex/generics` | one source function specialized at int / string / float |
 | `complex/goroutines` | `go` spawns concurrent workers; `sleep` waits |
 | `complex/channels` | fan-in worker pool — goroutines communicate over a channel |
@@ -319,8 +320,8 @@ make install      # install to $(PREFIX)/bin  (default /usr/local)
 | By-reference closure capture (mutable captured state, Go semantics) | ✅ done |
 | Bounds / div-zero / overflow checks (`--safe`) | ✅ done |
 | Scoped arenas (`arena { }`) — bound a long-lived loop's memory | ✅ done |
-| C FFI — `extern` blocks, scalar types + linking (Phase 1) | ✅ done |
-| C FFI phases 2–4 (structs, opaque handles, callbacks) | ⬜ planned |
+| C FFI — `extern` blocks: scalars + linking (Phase 1), by-value structs (Phase 2) | ✅ done |
+| C FFI phases 3–4 (opaque handles, callbacks) | ⬜ planned |
 | Automatic tracing GC | ⬜ planned |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -392,19 +392,30 @@ extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) 
   If omitted, machin emits a prototype from the declared signature instead.
 - `link "l"` — passes `-l<l>` to the C compiler.
 - `cflags "..."` — passes extra flags (e.g. `-I`/`-L` paths) to the C compiler.
-- `fn Name(t, ...) ret` — a foreign function. Parameter and return types are the
-  FFI scalar types `int`, `float`, `bool`, `string`; a missing return type means
+- `cstruct Name { field ctype ... }` — declares a C struct's layout (Phase 2).
+  machin synthesizes a matching MFL struct `Name` (so MFL can construct and
+  field-access it) and marshals between the MFL value and the C struct by value
+  at the boundary. Field types are sized C scalars (below).
+- `fn Name(t, ...) ret` — a foreign function. Parameter and return types are FFI
+  scalar types, or the name of a declared `cstruct`; a missing return type means
   `void`.
 
-A call to a declared name compiles to a **direct C call**; its arguments and
-return value use the C representation of the FFI type (`int`→`int64_t`,
-`float`→`double`, `bool`→`int`, `string`→`const char*`). The call is type-checked
-against the declared arity/types like any other.
+**FFI scalar types** → C: `int`/`i64`→`int64_t`, `i32`→`int32_t`, `i16`→`int16_t`,
+`i8`→`int8_t`, `u64`→`uint64_t` … `u8`→`uint8_t`, `float`/`f64`→`double`,
+`f32`→`float`, `bool`→`int`, `string`→`const char*`. The sized types matter for
+ABI correctness (e.g. raylib takes 32-bit `float`/`int`). In MFL, every integer
+width is `int` and `f32`/`f64` are `float`.
 
-This is **Phase 1** (scalar types). Structs, opaque handles/pointers, and
-callbacks are future phases. The FFI boundary is unchecked C: a value an MFL
-string passes to C is arena-allocated, so a C function that retains the pointer
-past the arena's lifetime would dangle — pass copies or keep it in scope.
+A call to a declared name compiles to a **direct C call**: scalar arguments are
+cast to their C type and struct arguments are marshaled into the C layout (a
+struct return is marshaled back). The call is type-checked against the declared
+arity/types like any other.
+
+Phases 1–2 (scalars and **by-value structs**) are implemented. Opaque
+handles/pointers and callbacks are future phases. The FFI boundary is unchecked
+C: a value an MFL string passes to C is arena-allocated, so a C function that
+retains the pointer past the arena's lifetime would dangle — pass copies or keep
+it in scope.
 
 ---
 
@@ -413,6 +424,6 @@ past the arena's lifetime would dangle — pass copies or keep it in scope.
 Implemented: the entire surface above, including arena memory management with
 scoped `arena { }` blocks (§12), named return values (§9), variadic parameters
 (§5.2), by-reference closure capture (§11.1), opt-in bounds/overflow checks
-(`--safe`), and scalar C FFI (§15). Not yet implemented: polymorphic recursion,
-an automatic tracing GC, and FFI phases 2–4 (structs, handles, callbacks). These
-are refinements, not core gaps.
+(`--safe`), and C FFI scalars + by-value structs (§15). Not yet implemented:
+polymorphic recursion, an automatic tracing GC, and FFI phases 3–4 (opaque
+handles, callbacks). These are refinements, not core gaps.

--- a/ast.go
+++ b/ast.go
@@ -15,15 +15,32 @@ type Program struct {
 // Calls to the declared names compile to direct C calls; the header supplies the
 // real prototype and `link`/`cflags` are threaded into the cc invocation.
 type ExternDecl struct {
-	Lib    string // informational name after `extern`
-	Header string // #include <Header> ("" if none)
-	Link   string // -l<Link> ("" if none)
-	CFlags string // extra cc flags ("" if none)
-	Funcs  []ExternFunc
+	Lib     string // informational name after `extern`
+	Header  string // #include <Header> ("" if none)
+	Link    string // -l<Link> ("" if none)
+	CFlags  string // extra cc flags ("" if none)
+	Structs []ExternStruct
+	Funcs   []ExternFunc
 }
 
-// ExternFunc is one foreign function signature. Param/return types are the FFI
-// scalar type names: int, float, bool, string (Ret "" means void).
+// ExternStruct declares a C struct's layout for by-value marshaling:
+//   cstruct Color { r u8  g u8  b u8  a u8 }
+// machin synthesizes a matching MFL struct (int/float fields) and marshals
+// between the MFL value and the C struct at the FFI boundary.
+type ExternStruct struct {
+	Name   string
+	Fields []ExternField
+}
+
+// ExternField is one C struct field with a sized C scalar type (i8..u64, f32, f64).
+type ExternField struct {
+	Name  string
+	CType string
+}
+
+// ExternFunc is one foreign function signature. Param/return types are FFI
+// scalar type names (int, float, bool, string, i8..u64, f32, f64) or the name of
+// a declared cstruct; Ret "" means void.
 type ExternFunc struct {
 	Name   string
 	Params []string

--- a/codegen.go
+++ b/codegen.go
@@ -385,19 +385,72 @@ static char* mfl_input(void) {
 }
 `
 
-// ffiCType maps an FFI scalar type name to its C type (for headerless prototypes).
+// isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
+func isFFIScalar(t string) bool {
+	switch t {
+	case "int", "float", "bool", "string",
+		"i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64":
+		return true
+	}
+	return false
+}
+
+// ffiCType maps an FFI scalar type name to its C type (for headerless prototypes
+// and struct-field casts). Returns "void" for "" or anything non-scalar.
 func ffiCType(t string) string {
 	switch t {
-	case "int":
+	case "int", "i64":
 		return "int64_t"
-	case "float":
+	case "i32":
+		return "int32_t"
+	case "i16":
+		return "int16_t"
+	case "i8":
+		return "int8_t"
+	case "u64":
+		return "uint64_t"
+	case "u32":
+		return "uint32_t"
+	case "u16":
+		return "uint16_t"
+	case "u8":
+		return "uint8_t"
+	case "float", "f64":
 		return "double"
+	case "f32":
+		return "float"
 	case "bool":
 		return "int"
 	case "string":
 		return "const char*"
 	}
 	return "void"
+}
+
+// externCType is the C type used in a foreign prototype: a scalar's C type, the
+// cstruct's own C name, or void.
+func externCType(t string) string {
+	if t == "" {
+		return "void"
+	}
+	if isFFIScalar(t) {
+		return ffiCType(t)
+	}
+	return t // a cstruct: its C struct name
+}
+
+// ffiMFLType maps an FFI scalar type to the MFL type name used for the synthesized
+// struct field: every integer width is MFL int; f32/f64/float are float.
+func ffiMFLType(t string) string {
+	switch t {
+	case "f32", "f64", "float":
+		return "float"
+	case "bool":
+		return "bool"
+	case "string":
+		return "string"
+	}
+	return "int"
 }
 
 func cType(k Kind) string {
@@ -448,23 +501,31 @@ func (g *cgen) program(p *Program) (string, error) {
 	var out strings.Builder
 	out.WriteString(cRuntime)
 	out.WriteByte('\n')
-	// foreign (extern) declarations: include each header so the real C prototype
-	// is in scope; for headerless externs, emit a prototype from the signature.
+	// foreign (extern) declarations. With a header, its prototypes + C structs are
+	// in scope. Without one, emit C struct typedefs and function prototypes from
+	// the declared signatures.
 	for _, ed := range p.Externs {
 		if ed.Header != "" {
 			fmt.Fprintf(&out, "#include <%s>\n", ed.Header)
 			continue
 		}
+		for _, cs := range ed.Structs {
+			fmt.Fprintf(&out, "typedef struct {")
+			for _, f := range cs.Fields {
+				fmt.Fprintf(&out, " %s %s;", ffiCType(f.CType), f.Name)
+			}
+			fmt.Fprintf(&out, " } %s;\n", cs.Name)
+		}
 		for _, ef := range ed.Funcs {
 			params := make([]string, len(ef.Params))
 			for i, pt := range ef.Params {
-				params[i] = ffiCType(pt)
+				params[i] = externCType(pt)
 			}
 			ps := strings.Join(params, ", ")
 			if ps == "" {
 				ps = "void"
 			}
-			fmt.Fprintf(&out, "extern %s %s(%s);\n", ffiCType(ef.Ret), ef.Name, ps)
+			fmt.Fprintf(&out, "extern %s %s(%s);\n", externCType(ef.Ret), ef.Name, ps)
 		}
 	}
 	// struct typedefs, in declaration order (a struct may reference earlier ones)
@@ -474,6 +535,22 @@ func (g *cgen) program(p *Program) (string, error) {
 			fmt.Fprintf(&out, " %s f_%s;", cTypeName(f.Type), f.Name)
 		}
 		fmt.Fprintf(&out, " } mfl_%s;\n", td.Name)
+	}
+	// FFI struct marshaling: convert each cstruct between its MFL value (mfl_Name,
+	// with int64/double fields) and the C layout (Name) at the boundary.
+	for _, ed := range p.Externs {
+		for _, cs := range ed.Structs {
+			fmt.Fprintf(&out, "static mfl_%s mfl_from_%s(%s c) { return (mfl_%s){", cs.Name, cs.Name, cs.Name, cs.Name)
+			for _, f := range cs.Fields {
+				fmt.Fprintf(&out, " .f_%s = c.%s,", f.Name, f.Name)
+			}
+			out.WriteString(" }; }\n")
+			fmt.Fprintf(&out, "static %s mfl_to_%s(mfl_%s m) { return (%s){", cs.Name, cs.Name, cs.Name, cs.Name)
+			for _, f := range cs.Fields {
+				fmt.Fprintf(&out, " .%s = (%s)m.f_%s,", f.Name, ffiCType(f.CType), f.Name)
+			}
+			out.WriteString(" }; }\n")
+		}
 	}
 	// closure environment + multi-return result structs (one per instance)
 	for _, inst := range g.c.Reps() {
@@ -1511,8 +1588,21 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return "", fmt.Errorf("print/println may only be used as a statement")
 	}
 	if ef := g.c.ExternFn(ex.Callee); ef != nil {
-		// a foreign C function: call it directly (the header gives the prototype)
-		return fmt.Sprintf("%s(%s)", ef.Name, strings.Join(args, ", ")), nil
+		// a foreign C function: cast scalar args to their C type and marshal
+		// struct args into the C layout; marshal a struct return back to MFL.
+		parts := make([]string, len(args))
+		for i, a := range args {
+			if pt := ef.Params[i]; isFFIScalar(pt) {
+				parts[i] = fmt.Sprintf("(%s)(%s)", ffiCType(pt), a)
+			} else {
+				parts[i] = fmt.Sprintf("mfl_to_%s(%s)", pt, a)
+			}
+		}
+		call := fmt.Sprintf("%s(%s)", ef.Name, strings.Join(parts, ", "))
+		if ef.Ret != "" && !isFFIScalar(ef.Ret) {
+			return fmt.Sprintf("mfl_from_%s(%s)", ef.Ret, call), nil
+		}
+		return call, nil
 	}
 	if !g.c.IsTopFunc(ex.Callee) {
 		// a function-valued local variable, called by name

--- a/examples/complex/ffi_struct.mfl
+++ b/examples/complex/ffi_struct.mfl
@@ -1,0 +1,4 @@
+extern "c"{header "stdlib.h" cstruct div_t{quot i32 rem i32}fn div(i32,i32)div_t}
+
+func main(){r:=div(17,5)println("17 / 5 =",r.quot,"remainder",r.rem)}
+

--- a/ffi_test.go
+++ b/ffi_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -36,5 +38,51 @@ func TestFFIArgCountChecked(t *testing.T) {
 	}
 	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "expected 1 args") {
 		t.Fatalf("expected an arg-count error, got %v", err)
+	}
+}
+
+// TestFFIStructReturn marshals a C struct returned by value: libc's
+// div_t div(int, int) (no external library needed).
+func TestFFIStructReturn(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`extern "c" { header "stdlib.h" cstruct div_t { quot i32  rem i32 } fn div(i32, i32) div_t }`,
+		`func main(){ r := div(17, 5) println(r.quot, r.rem) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out != "3 2\n" {
+		t.Fatalf("struct return: got %q, want \"3 2\\n\"", out)
+	}
+}
+
+// TestFFIStructPass marshals an MFL struct into a C struct passed by value (and
+// back). It compiles against a header written into a temp dir via `cflags -I`.
+func TestFFIStructPass(t *testing.T) {
+	dir := t.TempDir()
+	hdr := `typedef struct { int x; int y; } Pt;
+static int pt_sum(Pt p){ return p.x + p.y; }
+static Pt pt_make(int x, int y){ Pt p; p.x = x; p.y = y; return p; }
+`
+	if err := os.WriteFile(filepath.Join(dir, "pt.h"), []byte(hdr), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prog, err := ParseProgram([]string{
+		`extern "pt" { cflags "-I` + dir + `" header "pt.h" cstruct Pt { x i32  y i32 } fn pt_sum(Pt) i32 fn pt_make(i32, i32) Pt }`,
+		`func main(){ p := pt_make(3, 4) println(pt_sum(p)) println(pt_sum(Pt{10, 20})) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out != "7\n30\n" {
+		t.Fatalf("struct pass: got %q, want \"7\\n30\\n\"", out)
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -78,6 +78,18 @@ func ParseProgram(decls []string) (*Program, error) {
 			funcSrcs = append(funcSrcs, src)
 		}
 	}
+	// a cstruct is also a first-class MFL struct (int/float fields); synthesize
+	// its TypeDecl so MFL code can construct and field-access it.
+	for _, ed := range prog.Externs {
+		for _, cs := range ed.Structs {
+			fields := make([]Field, len(cs.Fields))
+			for i, f := range cs.Fields {
+				fields[i] = Field{Name: f.Name, Type: ffiMFLType(f.CType)}
+			}
+			prog.Types = append(prog.Types, &TypeDecl{Name: cs.Name, Fields: fields})
+			structs[cs.Name] = true
+		}
+	}
 	for _, src := range funcSrcs {
 		fn, err := ParseFuncWith(src, structs)
 		if err != nil {
@@ -106,8 +118,10 @@ func ParseExtern(src string) (*ExternDecl, error) {
 	return ed, nil
 }
 
-func isFFIType(s string) bool {
-	return s == "int" || s == "float" || s == "bool" || s == "string"
+// isExternDirective reports whether a word starts an extern-block directive
+// (and so cannot be a function's return type).
+func isExternDirective(s string) bool {
+	return s == "header" || s == "link" || s == "cflags" || s == "fn" || s == "cstruct"
 }
 
 // parseExternDecl parses:
@@ -147,6 +161,33 @@ func (p *Parser) parseExternDecl() (*ExternDecl, error) {
 			if err := str(&ed.CFlags); err != nil {
 				return nil, err
 			}
+		case "cstruct":
+			name, err := p.expect(TIdent, "")
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(TPunct, "{"); err != nil {
+				return nil, err
+			}
+			var fields []ExternField
+			for p.peek().Val != "}" && p.peek().Kind != TEOF {
+				fname, err := p.expect(TIdent, "") // field name, then its C type
+				if err != nil {
+					return nil, err
+				}
+				ct := p.next()
+				if ct.Kind != TIdent {
+					return nil, fmt.Errorf("cstruct %s: expected a C type for field %s, got %q", name.Val, fname.Val, ct.Val)
+				}
+				fields = append(fields, ExternField{Name: fname.Val, CType: ct.Val})
+				for p.peek().Val == "," || p.peek().Val == ";" {
+					p.next()
+				}
+			}
+			if _, err := p.expect(TPunct, "}"); err != nil {
+				return nil, err
+			}
+			ed.Structs = append(ed.Structs, ExternStruct{Name: name.Val, Fields: fields})
 		case "fn":
 			name, err := p.expect(TIdent, "")
 			if err != nil {
@@ -157,9 +198,9 @@ func (p *Parser) parseExternDecl() (*ExternDecl, error) {
 			}
 			var params []string
 			for p.peek().Val != ")" && p.peek().Kind != TEOF {
-				t := p.next()
-				if !isFFIType(t.Val) {
-					return nil, fmt.Errorf("extern fn %s: unsupported parameter type %q (use int/float/bool/string)", name.Val, t.Val)
+				t := p.next() // a scalar FFI type or a cstruct name; validated by the checker
+				if t.Kind != TIdent {
+					return nil, fmt.Errorf("extern fn %s: expected a parameter type, got %q", name.Val, t.Val)
 				}
 				params = append(params, t.Val)
 				for p.peek().Val == "," {
@@ -170,12 +211,12 @@ func (p *Parser) parseExternDecl() (*ExternDecl, error) {
 				return nil, err
 			}
 			ret := ""
-			if isFFIType(p.peek().Val) {
+			if p.peek().Kind == TIdent && !isExternDirective(p.peek().Val) {
 				ret = p.next().Val // an explicit return type; absence means void
 			}
 			ed.Funcs = append(ed.Funcs, ExternFunc{Name: name.Val, Params: params, Ret: ret})
 		default:
-			return nil, fmt.Errorf("extern: expected header/link/cflags/fn, got %q", kw.Val)
+			return nil, fmt.Errorf("extern: expected header/link/cflags/cstruct/fn, got %q", kw.Val)
 		}
 	}
 	if _, err := p.expect(TPunct, "}"); err != nil {

--- a/types.go
+++ b/types.go
@@ -609,7 +609,21 @@ func Check(p *Program) (*Checker, error) {
 		return nil, fmt.Errorf("no main function defined")
 	}
 	// register foreign (extern) functions; their signatures are fixed, not inferred
+	ffiTypeOK := func(t string) bool {
+		if t == "" || isFFIScalar(t) {
+			return true
+		}
+		_, ok := c.structs[t]
+		return ok
+	}
 	for _, ed := range p.Externs {
+		for _, cs := range ed.Structs {
+			for _, f := range cs.Fields {
+				if !isFFIScalar(f.CType) {
+					return nil, fmt.Errorf("cstruct %s field %s: %q is not a scalar C type", cs.Name, f.Name, f.CType)
+				}
+			}
+		}
 		for _, ef := range ed.Funcs {
 			f := ef
 			if _, dup := c.externs[f.Name]; dup {
@@ -617,6 +631,14 @@ func Check(p *Program) (*Checker, error) {
 			}
 			if _, clash := c.funcs[f.Name]; clash {
 				return nil, fmt.Errorf("extern fn %q clashes with a function", f.Name)
+			}
+			for _, pt := range f.Params {
+				if !ffiTypeOK(pt) {
+					return nil, fmt.Errorf("extern fn %s: unknown parameter type %q", f.Name, pt)
+				}
+			}
+			if !ffiTypeOK(f.Ret) {
+				return nil, fmt.Errorf("extern fn %s: unknown return type %q", f.Name, f.Ret)
 			}
 			c.externs[f.Name] = &f
 		}
@@ -1385,19 +1407,23 @@ func (c *Checker) genStructLit(fn *FuncDecl, ex *StructLit) (int, error) {
 	return res, nil
 }
 
-// ffiSlot maps an FFI scalar type name to its concrete checker slot.
+// ffiSlot maps an FFI type name to its checker slot: a scalar's shared slot, a
+// fresh struct slot for a cstruct name, or void for "".
 func (c *Checker) ffiSlot(t string) int {
 	switch t {
-	case "int":
-		return c.cInt
-	case "float":
+	case "":
+		return c.cVoid
+	case "float", "f32", "f64":
 		return c.cFloat
 	case "bool":
 		return c.cBool
 	case "string":
 		return c.cString
 	}
-	return c.cVoid // "" -> void
+	if isFFIScalar(t) {
+		return c.cInt // every integer width is MFL int
+	}
+	return newStructSlot(c, t) // a cstruct value
 }
 
 // ExternFn returns the foreign-function signature for name, or nil.


### PR DESCRIPTION
Phase 2 of issue #94, toward the raylib/SDL desktop GUI (the destination use case) — which is fundamentally struct-based (`Color`, `Vector2`, `Rectangle`).

## What's new

**`cstruct` — C struct layout + by-value marshaling.**
```
extern "c" { header "stdlib.h" cstruct div_t { quot i32 rem i32 } fn div(i32, i32) div_t }
func main(){ r := div(17, 5) println(r.quot, r.rem) }   // -> 3 2
```
machin synthesizes a matching MFL struct (so MFL can construct & field-access it) and marshals between the MFL value (int64/double fields) and the C layout **by value** — both pass and return.

**Sized scalar types** `i8…u64`, `f32`, `f64` (plus the `int`/`float`/`bool`/`string` aliases). These are not cosmetic — they're **required for ABI correctness**: raylib takes 32-bit `int`/`float`, and MFL's native `int64`/`double` would mismatch. Scalar args are now cast to their declared C type at the call (verified with `hypotf` taking real 32-bit `float` → `5`).

## Verification (no external libs needed)

- **Struct return** via libc `div_t div(int,int)` → `3 2`.
- **Struct pass** + MFL-constructed `cstruct` (`Pt{10,20}`) via a temp header → `7`, `30`.
- **Headerless** `f32` cstruct emits a C typedef; `hypotf(3,4)` → `5` (correct float width).
- `TestFFIStructReturn` + `TestFFIStructPass`; new `examples/complex/ffi_struct.mfl` (canonical). Full suite + all examples green; Phase 1 unaffected. SPEC §15 + README + CHANGELOG updated.

## Toward the GUI

With scalars (Phase 1) + by-value structs (Phase 2), the remaining gaps for a real raylib window are **opaque handles/pointers** (Phase 3 — textures, the window is mostly implicit in raylib) and eventually **callbacks** (Phase 4). raylib's core immediate-mode API (`InitWindow`, `BeginDrawing`, `ClearBackground(Color)`, `DrawText(...)`, `DrawRectangle(...)`, `WindowShouldClose`) is now *expressible* — it just needs raylib installed to link. A graphical `game_menu` is within reach once Phase 3 lands (or even now for draw-only demos).

Implements Phase 2 of #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * C FFI now supports passing and returning C structs by value alongside scalar types
  * Declare C struct layouts directly within `extern` blocks for cross-boundary marshaling

* **Documentation**
  * Updated specification and examples; FFI Phase 1–2 (scalars + by-value structs) now complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->