### PR TITLE
feat: C FFI Phase 3 — opaque handles/pointers (ptr type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ## Unreleased
 
-- **C FFI (Phases 1–2).** An `extern "lib" { header "..." link "..." cflags "..."
+- **C FFI (Phases 1–3).** An `extern "lib" { header "..." link "..." cflags "..."
   cstruct T { f ctype ... } fn name(types) ret }` declaration names foreign C
   functions; calls compile to direct C calls and `header`/`link`/`cflags` are
   threaded into `cc`. **Phase 1:** scalar types — `int`/`float`/`bool`/`string`
   plus sized `i8…u64`/`f32`/`f64` (sizes matter for ABI: raylib takes 32-bit
   `int`/`float`). **Phase 2:** `cstruct` declares a C struct's layout; machin
   synthesizes a matching MFL struct and marshals it by value across the boundary
-  (pass and return). New `examples/complex/ffi_math.mfl` and `ffi_struct.mfl`;
-  the path to the C ecosystem and a future GUI.
+  (pass and return). **Phase 3:** the `ptr` type — an opaque C handle (`void*`,
+  e.g. `FILE*` or a window/texture handle) held as an MFL `int` and passed back
+  to C, never dereferenced. New `examples/complex/ffi_math.mfl`, `ffi_struct.mfl`,
+  and `ffi_ptr.mfl`; the path to the C ecosystem and a future GUI.
 - **Tightened canonical form (token-minimization).** The canonical `.mfl` now
   drops whitespace adjacent to operators/punctuation (`fib(n - 1)` →
   `fib(n-1)`), keeping only the spaces the lexer needs between word tokens. Zero

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ func main() {
 | **JSON** | `json(x)` serializes any value to JSON; `parse(s, T{})` parses JSON into a value of `T` |
 | **Networking** | `listen`, `accept`, `read`, `write`, `close` |
 | **I/O** | `print`, `println`, `input` (read a line from stdin) |
-| **C FFI** | `extern "lib" { header "..." link "..." cstruct T {...} fn name(types) ret }` — call foreign C functions; scalar + by-value struct types |
+| **C FFI** | `extern "lib" { header "..." link "..." cstruct T {...} fn name(types) ret }` — foreign C calls; scalars, by-value structs, opaque `ptr` handles |
 
 ---
 
@@ -219,6 +219,7 @@ per-call-site arg struct + trampoline driven by `pthread_create`.
 | `complex/game_menu` | native desktop CLI: a Start/Settings/Exit loop reading `input()` |
 | `complex/ffi_math` | C FFI: call `sqrt`/`pow` from libm via an `extern` block |
 | `complex/ffi_struct` | C FFI: marshal a C struct by value (`div_t` from libc) |
+| `complex/ffi_ptr` | C FFI: hold an opaque handle (`FILE*`) as a `ptr` |
 | `complex/generics` | one source function specialized at int / string / float |
 | `complex/goroutines` | `go` spawns concurrent workers; `sleep` waits |
 | `complex/channels` | fan-in worker pool — goroutines communicate over a channel |
@@ -320,8 +321,8 @@ make install      # install to $(PREFIX)/bin  (default /usr/local)
 | By-reference closure capture (mutable captured state, Go semantics) | ✅ done |
 | Bounds / div-zero / overflow checks (`--safe`) | ✅ done |
 | Scoped arenas (`arena { }`) — bound a long-lived loop's memory | ✅ done |
-| C FFI — `extern` blocks: scalars + linking (Phase 1), by-value structs (Phase 2) | ✅ done |
-| C FFI phases 3–4 (opaque handles, callbacks) | ⬜ planned |
+| C FFI — scalars + linking (P1), by-value structs (P2), opaque `ptr` handles (P3) | ✅ done |
+| C FFI callbacks (MFL closures as C function pointers) | ⬜ planned |
 | Automatic tracing GC | ⬜ planned |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -402,20 +402,24 @@ extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) 
 
 **FFI scalar types** → C: `int`/`i64`→`int64_t`, `i32`→`int32_t`, `i16`→`int16_t`,
 `i8`→`int8_t`, `u64`→`uint64_t` … `u8`→`uint8_t`, `float`/`f64`→`double`,
-`f32`→`float`, `bool`→`int`, `string`→`const char*`. The sized types matter for
-ABI correctness (e.g. raylib takes 32-bit `float`/`int`). In MFL, every integer
-width is `int` and `f32`/`f64` are `float`.
+`f32`→`float`, `bool`→`int`, `string`→`const char*`, `ptr`→`void*`. The sized
+types matter for ABI correctness (e.g. raylib takes 32-bit `float`/`int`). In
+MFL, every integer width is `int`, `f32`/`f64` are `float`, and **`ptr` is an
+opaque handle held as an `int`** (the pointer value, round-tripped through
+`intptr_t`) that MFL passes back to C but never dereferences — for `FILE*`,
+window/texture handles, etc. `ptr` and `string` may not be `cstruct` fields
+(only numeric scalars).
 
 A call to a declared name compiles to a **direct C call**: scalar arguments are
-cast to their C type and struct arguments are marshaled into the C layout (a
-struct return is marshaled back). The call is type-checked against the declared
-arity/types like any other.
+cast to their C type, `ptr` arguments to `void*`, and struct arguments are
+marshaled into the C layout (struct/`ptr` returns are converted back). The call
+is type-checked against the declared arity/types like any other.
 
-Phases 1–2 (scalars and **by-value structs**) are implemented. Opaque
-handles/pointers and callbacks are future phases. The FFI boundary is unchecked
-C: a value an MFL string passes to C is arena-allocated, so a C function that
-retains the pointer past the arena's lifetime would dangle — pass copies or keep
-it in scope.
+Phases 1–3 (scalars, **by-value structs**, **opaque handles/pointers**) are
+implemented. Callbacks (passing an MFL closure as a C function pointer) are a
+future phase. The FFI boundary is unchecked C: a value an MFL string passes to C
+is arena-allocated, so a C function that retains the pointer past the arena's
+lifetime would dangle — pass copies or keep it in scope.
 
 ---
 
@@ -424,6 +428,6 @@ it in scope.
 Implemented: the entire surface above, including arena memory management with
 scoped `arena { }` blocks (§12), named return values (§9), variadic parameters
 (§5.2), by-reference closure capture (§11.1), opt-in bounds/overflow checks
-(`--safe`), and C FFI scalars + by-value structs (§15). Not yet implemented:
-polymorphic recursion, an automatic tracing GC, and FFI phases 3–4 (opaque
-handles, callbacks). These are refinements, not core gaps.
+(`--safe`), and C FFI scalars + by-value structs + opaque handles (§15). Not yet
+implemented: polymorphic recursion, an automatic tracing GC, and FFI callbacks
+(MFL closures as C function pointers). These are refinements, not core gaps.

--- a/codegen.go
+++ b/codegen.go
@@ -388,17 +388,25 @@ static char* mfl_input(void) {
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
 func isFFIScalar(t string) bool {
 	switch t {
-	case "int", "float", "bool", "string",
+	case "int", "float", "bool", "string", "ptr",
 		"i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64":
 		return true
 	}
 	return false
 }
 
+// isFFINumeric reports whether t is a numeric scalar usable as a cstruct field
+// (excludes string and the opaque ptr, which aren't laid out as plain numbers).
+func isFFINumeric(t string) bool {
+	return isFFIScalar(t) && t != "string" && t != "ptr"
+}
+
 // ffiCType maps an FFI scalar type name to its C type (for headerless prototypes
 // and struct-field casts). Returns "void" for "" or anything non-scalar.
 func ffiCType(t string) string {
 	switch t {
+	case "ptr":
+		return "void*"
 	case "int", "i64":
 		return "int64_t"
 	case "i32":
@@ -443,6 +451,8 @@ func externCType(t string) string {
 // struct field: every integer width is MFL int; f32/f64/float are float.
 func ffiMFLType(t string) string {
 	switch t {
+	case "ptr":
+		return "int" // an opaque handle, held as an int
 	case "f32", "f64", "float":
 		return "float"
 	case "bool":
@@ -1592,14 +1602,20 @@ func (g *cgen) call(ex *Call) (string, error) {
 		// struct args into the C layout; marshal a struct return back to MFL.
 		parts := make([]string, len(args))
 		for i, a := range args {
-			if pt := ef.Params[i]; isFFIScalar(pt) {
+			switch pt := ef.Params[i]; {
+			case pt == "ptr": // MFL int -> opaque void*
+				parts[i] = fmt.Sprintf("(void*)(intptr_t)(%s)", a)
+			case isFFIScalar(pt):
 				parts[i] = fmt.Sprintf("(%s)(%s)", ffiCType(pt), a)
-			} else {
+			default: // a cstruct, marshaled into the C layout
 				parts[i] = fmt.Sprintf("mfl_to_%s(%s)", pt, a)
 			}
 		}
 		call := fmt.Sprintf("%s(%s)", ef.Name, strings.Join(parts, ", "))
-		if ef.Ret != "" && !isFFIScalar(ef.Ret) {
+		switch {
+		case ef.Ret == "ptr": // void* -> MFL int
+			return fmt.Sprintf("(int64_t)(intptr_t)(%s)", call), nil
+		case ef.Ret != "" && !isFFIScalar(ef.Ret):
 			return fmt.Sprintf("mfl_from_%s(%s)", ef.Ret, call), nil
 		}
 		return call, nil

--- a/examples/complex/ffi_ptr.mfl
+++ b/examples/complex/ffi_ptr.mfl
@@ -1,0 +1,4 @@
+extern "c"{header "stdio.h" fn fopen(string,string)ptr fn fputs(string,ptr)i32 fn fclose(ptr)i32}
+
+func main(){f:=fopen("/tmp/machin_ffi_ptr.txt","w")if f==0{println("could not open file")}else{fputs("written by C through an MFL opaque handle\n",f)fclose(f)println("wrote /tmp/machin_ffi_ptr.txt")}}
+

--- a/ffi_test.go
+++ b/ffi_test.go
@@ -86,3 +86,26 @@ static Pt pt_make(int x, int y){ Pt p; p.x = x; p.y = y; return p; }
 		t.Fatalf("struct pass: got %q, want \"7\\n30\\n\"", out)
 	}
 }
+
+// TestFFIPointerHandle round-trips an opaque C handle (a FILE*) through MFL as a
+// `ptr`: open, write, close — then Go verifies the file C actually wrote.
+func TestFFIPointerHandle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.txt")
+	prog, err := ParseProgram([]string{
+		`extern "c" { header "stdio.h" fn fopen(string, string) ptr fn fputs(string, ptr) i32 fn fclose(ptr) i32 }`,
+		`func main(){ f := fopen("` + path + `", "w") fputs("via void* handle", f) fclose(f) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := RunCaptured(prog); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "via void* handle" {
+		t.Fatalf("opaque handle round-trip: file has %q", got)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -619,8 +619,8 @@ func Check(p *Program) (*Checker, error) {
 	for _, ed := range p.Externs {
 		for _, cs := range ed.Structs {
 			for _, f := range cs.Fields {
-				if !isFFIScalar(f.CType) {
-					return nil, fmt.Errorf("cstruct %s field %s: %q is not a scalar C type", cs.Name, f.Name, f.CType)
+				if !isFFINumeric(f.CType) {
+					return nil, fmt.Errorf("cstruct %s field %s: %q is not a numeric C type", cs.Name, f.Name, f.CType)
 				}
 			}
 		}


### PR DESCRIPTION
Phase 3 of issue #94. Adds the `ptr` FFI type: an opaque C handle (`void*`) held in MFL as an `int` and passed back to C, never dereferenced — for `FILE*`, window/texture handles, SDL/sqlite resources, etc.

```
extern "c" { header "stdio.h" fn fopen(string, string) ptr fn fputs(string, ptr) i32 fn fclose(ptr) i32 }
func main(){ f := fopen("/tmp/x", "w") if f == 0 { ... } else { fputs("hi", f) fclose(f) } }
```

- `ptr` → `void*` (C) / `int` (MFL). Args cast `(void*)(intptr_t)`, returns cast `(int64_t)(intptr_t)` — correct round-trip, no warnings.
- `ptr`/`string` rejected as `cstruct` fields (numeric layout only) with a clean error.

## Verified
- **Real opaque handle round-trip** with libc `FILE*`: MFL holds the `fopen` pointer, hands it to `fputs`/`fclose`, and Go reads back the file C actually wrote → exact match. (`TestFFIPointerHandle`)
- Null check (`if f == 0`) works. New `examples/complex/ffi_ptr.mfl` (canonical). Full suite + all examples green; Phases 1–2 unaffected. SPEC §15 + README + CHANGELOG updated.

## Where the FFI stands

| Phase | Capability | Status |
|---|---|---|
| 1 | scalars (incl. sized i*/u*/f*) + linking | ✅ |
| 2 | by-value structs (`cstruct`) | ✅ |
| 3 | opaque handles (`ptr`) | ✅ (this PR) |
| 4 | callbacks (MFL closures as C fn pointers) | planned |

This unblocks files/SDL/sqlite-style APIs. **raylib's value-struct API needs only Phases 1–2**, so the GUI game-menu demo is fully unblocked — next step is wiring it (needs raylib installed to link).

Implements Phase 3 of #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)