### PR TITLE
feat: native GUI demo — raylib game menu via C FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@
   (pass and return). **Phase 3:** the `ptr` type — an opaque C handle (`void*`,
   e.g. `FILE*` or a window/texture handle) held as an MFL `int` and passed back
   to C, never dereferenced. New `examples/complex/ffi_math.mfl`, `ffi_struct.mfl`,
-  and `ffi_ptr.mfl`; the path to the C ecosystem and a future GUI.
+  and `ffi_ptr.mfl`; the path to the C ecosystem and a native GUI.
+- **Native GUI demo — `examples/gui/game_menu.mfl`.** A clickable Start / Settings
+  / Exit menu drawn with [raylib](https://www.raylib.com) through the FFI: opens a
+  real OpenGL window, draws rectangles/text with a `Color` cstruct, and polls the
+  mouse each frame — proving Phases 1–2 are enough to drive a real graphics
+  library. `extern` blocks may now have multiple `link` directives, kept in order
+  (`-lraylib -lGL -lm -lpthread -ldl -lrt -lX11`). A GUI binary links the system
+  graphics stack and needs a display — not a no-deps binary, as with any native GUI.
 - **Tightened canonical form (token-minimization).** The canonical `.mfl` now
   drops whitespace adjacent to operators/punctuation (`fib(n - 1)` →
   `fib(n-1)`), keeping only the spaces the lexer needs between word tokens. Zero

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ per-call-site arg struct + trampoline driven by `pthread_create`.
 | `complex/ffi_math` | C FFI: call `sqrt`/`pow` from libm via an `extern` block |
 | `complex/ffi_struct` | C FFI: marshal a C struct by value (`div_t` from libc) |
 | `complex/ffi_ptr` | C FFI: hold an opaque handle (`FILE*`) as a `ptr` |
+| `gui/game_menu` | **native GUI**: a clickable raylib Start/Settings/Exit window via FFI |
 | `complex/generics` | one source function specialized at int / string / float |
 | `complex/goroutines` | `go` spawns concurrent workers; `sleep` waits |
 | `complex/channels` | fan-in worker pool — goroutines communicate over a channel |
@@ -322,6 +323,7 @@ make install      # install to $(PREFIX)/bin  (default /usr/local)
 | Bounds / div-zero / overflow checks (`--safe`) | ✅ done |
 | Scoped arenas (`arena { }`) — bound a long-lived loop's memory | ✅ done |
 | C FFI — scalars + linking (P1), by-value structs (P2), opaque `ptr` handles (P3) | ✅ done |
+| Native GUI via FFI (raylib window — see `examples/gui/`) | ✅ done |
 | C FFI callbacks (MFL closures as C function pointers) | ⬜ planned |
 | Automatic tracing GC | ⬜ planned |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -390,7 +390,10 @@ extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) 
 - `"m"` — an informational library name.
 - `header "h.h"` — emits `#include <h.h>` so the real C prototype is in scope.
   If omitted, machin emits a prototype from the declared signature instead.
-- `link "l"` — passes `-l<l>` to the C compiler.
+- `link "l"` — passes `-l<l>` to the C compiler. May be repeated; the libraries
+  are emitted in declaration order (e.g. `link "raylib" link "GL" link "m"` for a
+  library with transitive dependencies). `link ":libname.a"` forces a static
+  archive over a shared `.so`.
 - `cflags "..."` — passes extra flags (e.g. `-I`/`-L` paths) to the C compiler.
 - `cstruct Name { field ctype ... }` — declares a C struct's layout (Phase 2).
   machin synthesizes a matching MFL struct `Name` (so MFL can construct and

--- a/ast.go
+++ b/ast.go
@@ -15,10 +15,10 @@ type Program struct {
 // Calls to the declared names compile to direct C calls; the header supplies the
 // real prototype and `link`/`cflags` are threaded into the cc invocation.
 type ExternDecl struct {
-	Lib     string // informational name after `extern`
-	Header  string // #include <Header> ("" if none)
-	Link    string // -l<Link> ("" if none)
-	CFlags  string // extra cc flags ("" if none)
+	Lib     string   // informational name after `extern`
+	Header  string   // #include <Header> ("" if none)
+	Links   []string // each becomes -l<Link>, in declaration order
+	CFlags  string   // extra cc flags ("" if none)
 	Structs []ExternStruct
 	Funcs   []ExternFunc
 }

--- a/build.go
+++ b/build.go
@@ -40,8 +40,8 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 		if ed.CFlags != "" {
 			args = append(args, strings.Fields(ed.CFlags)...)
 		}
-		if ed.Link != "" {
-			libs = append(libs, "-l"+ed.Link)
+		for _, l := range ed.Links {
+			libs = append(libs, "-l"+l)
 		}
 	}
 	args = append(args, "-o", outPath, tmp.Name())

--- a/examples/gui/README.md
+++ b/examples/gui/README.md
@@ -1,0 +1,60 @@
+# GUI example — a raylib game menu
+
+`game_menu.mfl` is a native desktop GUI (a clickable Start / Settings / Exit
+menu) drawn with [raylib](https://www.raylib.com/) through machin's C FFI. It
+shows that the FFI (scalars + by-value structs — `Color` here) is enough to drive
+a real graphics library: open an OpenGL window, draw rectangles and text, and
+poll the mouse each frame.
+
+```
++--------------------------------+
+|        MFL GAME MENU           |
+|     +--------------------+     |
+|     |       Start        |     |   <- hover highlights, left-click prints
+|     +--------------------+     |
+|     |      Settings      |     |
+|     +--------------------+     |
+|     |        Exit        |     |   <- click (or close the window) to quit
+|     +--------------------+     |
++--------------------------------+
+```
+
+## Build & run
+
+It is **not** a no-dependency binary — a native GUI links the system graphics
+stack (raylib + `libGL`/`libX11`) and needs a display, exactly like a raylib app
+in C/Rust/Zig. machin's self-contained-binary property holds for the headless
+domain, not for GUI.
+
+**With raylib installed system-wide** (the committed example assumes this):
+
+```bash
+sudo apt-get install -y libraylib-dev      # Debian/Ubuntu
+machin build examples/gui/game_menu.mfl -o game_menu
+./game_menu
+```
+
+**Without root** — use raylib's prebuilt static release and point the `extern`
+block at it. Download `raylib-5.0_linux_amd64.tar.gz` from the
+[raylib releases](https://github.com/raysan5/raylib/releases), then edit the
+`extern "raylib"` block's directives to:
+
+```
+cflags "-I/path/to/raylib/include -L/path/to/raylib/lib"
+link ":libraylib.a"     # force the static archive over the shared .so
+```
+
+(The other `link` lines — `GL m pthread dl rt X11` — stay; they are raylib's
+transitive dependencies, in link order.)
+
+## How it maps to the FFI
+
+| MFL | raylib C | FFI feature |
+|-----|----------|-------------|
+| `cstruct Color { r u8 ... }` | `Color { unsigned char r,g,b,a; }` | by-value struct (Phase 2) |
+| `fn DrawText(string,i32,i32,i32,Color)` | `void DrawText(const char*,int,int,int,Color)` | scalars + struct arg |
+| `fn IsMouseButtonPressed(i32) bool` | `bool IsMouseButtonPressed(int)` | scalar return |
+| `link "raylib" link "GL" ...` | `-lraylib -lGL ...` (in order) | multi-lib linking |
+
+raylib is immediate-mode and polls input via functions, so this needs no opaque
+handles (Phase 3) or callbacks (Phase 4) — Phases 1–2 of the FFI suffice.

--- a/examples/gui/game_menu.mfl
+++ b/examples/gui/game_menu.mfl
@@ -1,0 +1,10 @@
+extern "raylib"{header "raylib.h" link "raylib" link "GL" link "m" link "pthread" link "dl" link "rt" link "X11" cstruct Color{r u8 g u8 b u8 a u8}fn InitWindow(i32,i32,string)fn SetTargetFPS(i32)fn WindowShouldClose()bool fn BeginDrawing()fn EndDrawing()fn ClearBackground(Color)fn DrawText(string,i32,i32,i32,Color)fn DrawRectangle(i32,i32,i32,i32,Color)fn GetMouseX()i32 fn GetMouseY()i32 fn IsMouseButtonPressed(i32)bool fn CloseWindow()}
+
+func col(r,g,b){return Color{r,g,b,255}}
+
+func in_rect(mx,my,x,y,w,h){return mx>=x&&mx<x+w&&my>=y&&my<y+h}
+
+func button(label,y,mx,my){x:=300 w:=200 h:=56 hover:=in_rect(mx,my,x,y,w,h)bg:=col(58,58,70)if hover{bg=col(90,120,210)}DrawRectangle(x,y,w,h,bg)DrawText(label,x+24,y+18,22,col(238,238,238))return hover&&IsMouseButtonPressed(0)}
+
+func main(){InitWindow(800,600,"machin - MFL game menu")SetTargetFPS(60)bg:=col(22,22,28)running:=true while running{if WindowShouldClose(){running=false}mx:=GetMouseX()my:=GetMouseY()BeginDrawing()ClearBackground(bg)DrawText("MFL GAME MENU",250,120,32,col(120,220,170))if button("Start",230,mx,my){println("Start clicked")}if button("Settings",300,mx,my){println("Settings clicked")}if button("Exit",370,mx,my){println("Exit clicked")running=false}EndDrawing()}CloseWindow()}
+

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -8,6 +8,7 @@ go build -o machin .
 find examples -name '*.mfl' | sort | while read -r mfl; do
     case "$mfl" in
         *server*|*_api*) echo "########## $mfl (long-running — skipped) ##########"; echo; continue ;;
+        examples/gui/*) echo "########## $mfl (GUI — needs raylib + a display; see examples/gui/README.md) ##########"; echo; continue ;;
     esac
     echo "########## machin run $mfl ##########"
     ./machin run "$mfl"

--- a/ffi_test.go
+++ b/ffi_test.go
@@ -109,3 +109,15 @@ func TestFFIPointerHandle(t *testing.T) {
 		t.Fatalf("opaque handle round-trip: file has %q", got)
 	}
 }
+
+// TestFFIMultipleLink parses several `link` directives, in order — needed for a
+// real library like raylib (-lraylib -lGL -lm -lpthread -ldl -lrt -lX11).
+func TestFFIMultipleLink(t *testing.T) {
+	ed, err := ParseExtern(`extern "rl" { link "raylib" link "GL" link "m" fn f() }`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := strings.Join(ed.Links, ","); got != "raylib,GL,m" {
+		t.Fatalf("links: got %q, want \"raylib,GL,m\"", got)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -154,9 +154,11 @@ func (p *Parser) parseExternDecl() (*ExternDecl, error) {
 				return nil, err
 			}
 		case "link":
-			if err := str(&ed.Link); err != nil {
+			var l string
+			if err := str(&l); err != nil {
 				return nil, err
 			}
+			ed.Links = append(ed.Links, l)
 		case "cflags":
 			if err := str(&ed.CFlags); err != nil {
 				return nil, err


### PR DESCRIPTION
The destination use case, reached. A clickable **Start / Settings / Exit desktop window** drawn with [raylib](https://www.raylib.com) through machin's C FFI — `examples/gui/game_menu.mfl`.

## Verified live (raylib 5.0, real GPU)

I downloaded raylib's prebuilt static lib (no sudo), built the MFL → C → linked binary, and ran it on a live `DISPLAY=:0`. raylib's own log confirms a real OpenGL window opened and rendered:

```
INFO: Initializing raylib 5.0
INFO: DISPLAY: Device initialized successfully  (render 800x600)
INFO: GL: Renderer: Mesa Intel(R) Xe Graphics (TGL GT2)
INFO: PLATFORM: DESKTOP (GLFW): Initialized successfully
INFO: FONT: Default font loaded successfully (224 glyphs)
INFO: TIMER: Target time per frame: 16.667 milliseconds   (60 FPS)
```

The process stayed alive in the render loop (raylib `exit()`s on init failure, so this proves the window opened). It maps cleanly to the FFI:

| MFL | raylib | FFI feature |
|---|---|---|
| `cstruct Color { r u8 g u8 b u8 a u8 }` | `Color{unsigned char r,g,b,a}` | by-value struct (P2) |
| `fn DrawText(string,i32,i32,i32,Color)` | scalars + struct arg | P1+P2 |
| `fn IsMouseButtonPressed(i32) bool` | scalar return | P1 |
| `link "raylib" link "GL" ...` | `-lraylib -lGL …` in order | **new** |

**No handles or callbacks needed** — raylib is immediate-mode with polled input, so Phases 1–2 of the FFI suffice (Phase 3 went in just before, unused here).

## Toolchain change

`extern` blocks may now have **multiple `link` directives**, kept in declaration order — a real-library necessity (raylib needs `-lraylib -lGL -lm -lpthread -ldl -lrt -lX11`). `link ":libfoo.a"` forces a static archive over a shared `.so`. (`TestFFIMultipleLink`.)

## Honest scope: not a no-deps binary

Per your earlier question — a GUI binary links the system graphics stack (`libGL`/`libX11`) and needs a display, **inherent to native GUI in any language**. machin's self-contained-binary property holds for the headless/CLI/server domain; GUI inherits the platform's graphics deps. `examples/gui/README.md` covers both the system-raylib and prebuilt-static build paths.

## Verification

Full suite green; the GUI example is codegen-checked (the `--emit-c` path needs no raylib) and excluded from `examples/run.sh` (needs raylib + display). SPEC §15 + README + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)