### PR TITLE
feat: outbound networking — dial(host, port)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Outbound networking — `dial(host, port)`.** Connect a TCP socket to a remote
+  host (DNS-resolved via `getaddrinfo`), returning an fd used with the existing
+  `read`/`write`/`close`. machin was server-only (`listen`/`accept`); `dial` makes
+  it a client too — HTTP clients, health checkers, anything that reaches out.
+  Surfaced and filled while building a real tool (the "build real things" goal).
+
 - **CLI builtins — `args()`, `env()`, `now()`.** `args()` returns the
   command-line arguments (`[]string`; `args()[0]` is the program path) — the
   generated `main` now takes `argc`/`argv`. `env(name)` reads an environment

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ override with `$CC`) on PATH at compile time.
 - 🏎️ **Native codegen** — `.mfl → parse → infer types → emit C → cc -O2 → binary`
 - 🧮 **Inferred static types** — `int`, `float`, `bool`, `string`, slices `[]T` — unified, no boxing
 - 🧵 **Concurrency** — `go f(args)` spawns a pthread-backed goroutine; channels (`make(chan T)`, `<-`) for communication
-- 🌐 **Networking** — `listen / accept / read / write / close`, the low-level shape of Go's `net`
+- 🌐 **Networking** — `dial` (client) + `listen / accept / read / write / close` (server) — Go's `net`, low-level
 - 🧹 **Memory** — per-goroutine arena, plus scoped `arena { }` blocks to keep a long-lived loop's memory flat
 - ✅ **Compile-time type errors** — a type clash is a build failure, not a runtime surprise
 
@@ -164,7 +164,7 @@ func main() {
 | **Builtins** | `print`, `println`, `input`, `args`, `env`, `now`, `len`, `str`, `int`, `append`, `sleep`, `has`, `delete`, `keys`, `json`, `parse`, `http_body` |
 | **String ops** | `substr`, `index`, `contains`, `has_prefix`, `has_suffix`, `charat`, `to_upper`, `to_lower`, `trim`, `replace`, `split`, `join` |
 | **JSON** | `json(x)` serializes any value to JSON; `parse(s, T{})` parses JSON into a value of `T` |
-| **Networking** | `listen`, `accept`, `read`, `write`, `close` |
+| **Networking** | `dial` (outbound), `listen`, `accept`, `read`, `write`, `close` |
 | **I/O** | `print`, `println`, `input` (read a line from stdin) |
 | **C FFI** | `extern "lib" { header "..." link "..." cstruct T {...} fn name(types) ret }` — foreign C calls; scalars, by-value structs, opaque `ptr` handles |
 
@@ -317,7 +317,7 @@ make install      # install to $(PREFIX)/bin  (default /usr/local)
 | Arena memory management (per-goroutine; bounds servers) | ✅ done |
 | Scoped arenas (`arena { }`; bounds long-lived loops) | ✅ done |
 | Goroutines (`go`) + `sleep` | ✅ done |
-| Networking (`listen`/`accept`/`read`/`write`/`close`) | ✅ done |
+| Networking — `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server) | ✅ done |
 | Concurrent HTTP server example | ✅ done |
 | By-reference closure capture (mutable captured state, Go semantics) | ✅ done |
 | Bounds / div-zero / overflow checks (`--safe`) | ✅ done |

--- a/SPEC.md
+++ b/SPEC.md
@@ -230,9 +230,10 @@ throughout the function body).
 | `split` | `(string, string) -> []string` | split |
 | `join` | `([]string, string) -> string` | join |
 | `sleep` | `(int) -> ` | pause (milliseconds) |
+| `dial` | `(string, int) -> int` | connect to host:port; an fd, or -1 on failure |
 | `listen`, `accept` | `(int) -> int` | open / accept on a TCP socket |
-| `read`, `write` | `(int[, string]) -> string\|int` | socket I/O |
-| `close` | `(int) -> ` | close a socket |
+| `read`, `write` | `(int[, string]) -> string\|int` | socket/fd I/O |
+| `close` | `(int) -> ` | close a socket/fd |
 
 ---
 

--- a/codegen.go
+++ b/codegen.go
@@ -62,7 +62,8 @@ type cgen struct {
 	safe      bool   // emit runtime bounds / div-by-zero / overflow checks
 }
 
-const cRuntime = `#include <stdio.h>
+const cRuntime = `#define _GNU_SOURCE
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
@@ -73,6 +74,7 @@ const cRuntime = `#include <stdio.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netdb.h>
 
 /* slices: a Go-style header over an unboxed backing array */
 typedef struct { void* data; int64_t len; int64_t cap; } mfl_slice;
@@ -361,6 +363,24 @@ static int64_t mfl_listen(int64_t port) {
     return fd;
 }
 static int64_t mfl_accept(int64_t fd) { return accept((int)fd, NULL, NULL); }
+/* dial: connect a TCP socket to host:port, returning an fd (-1 on failure).
+   The fd is used with the same read/write/close as an accepted connection. */
+static int64_t mfl_dial(const char* host, int64_t port) {
+    struct addrinfo hints, *res, *rp;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC; hints.ai_socktype = SOCK_STREAM;
+    char ps[16]; snprintf(ps, sizeof(ps), "%lld", (long long)port);
+    if (getaddrinfo(host, ps, &hints, &res) != 0) return -1;
+    int fd = -1;
+    for (rp = res; rp; rp = rp->ai_next) {
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) continue;
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) break;
+        close(fd); fd = -1;
+    }
+    freeaddrinfo(res);
+    return fd;
+}
 static char* mfl_read(int64_t fd) {
     char* buf = mfl_alloc(65536);
     ssize_t n = read((int)fd, buf, 65535);
@@ -1593,6 +1613,8 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return fmt.Sprintf("mfl_str_i(%s)", args[0]), nil
 	case "int":
 		return fmt.Sprintf("((int64_t)(%s))", args[0]), nil
+	case "dial":
+		return fmt.Sprintf("mfl_dial(%s, %s)", args[0], args[1]), nil
 	case "listen":
 		return fmt.Sprintf("mfl_listen(%s)", args[0]), nil
 	case "accept":

--- a/operators_net_test.go
+++ b/operators_net_test.go
@@ -293,6 +293,46 @@ func TestNetworkingRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDialOutbound exercises client networking: a Go server listens, an MFL
+// program dials it with dial(host, port), writes a request, reads the reply.
+func TestDialOutbound(t *testing.T) {
+	const port = 47656
+	ln, err := net.Listen("tcp", "127.0.0.1:"+itoa(port))
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		buf := make([]byte, 64)
+		c.Read(buf)
+		c.Write([]byte("pong-from-server"))
+		c.Close()
+	}()
+
+	fns := parseFuncs(t,
+		`func main() { fd := dial("127.0.0.1", `+itoa(port)+`) if fd < 0 { print("dial failed") return } write(fd, "ping") r := read(fd) close(fd) print(r) }`)
+	bin, err := os.CreateTemp("", "mfl-dial-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fns}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	out, err := exec.Command(bin.Name()).Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := string(out); got != "pong-from-server" {
+		t.Fatalf("dial round trip: got %q, want \"pong-from-server\"", got)
+	}
+}
+
 // itoa is a tiny dependency-free int->string for embedding ports in MFL source.
 func itoa(n int) string {
 	if n == 0 {

--- a/types.go
+++ b/types.go
@@ -1582,6 +1582,13 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return c.cInt, nil
+	case "dial":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("dial: 2 args (host string, port int)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cInt, nil
 	case "read":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("read: 1 arg")


### PR DESCRIPTION
The first gap surfaced by the new "build real things" direction: machin could `listen`/`accept` (server) but had **no way to connect out** — so it couldn't be an HTTP client, health checker, or any program that reaches a remote host.

`dial(host, port) -> int` connects a TCP socket (DNS-resolved via `getaddrinfo`) and returns an fd used with the existing `read`/`write`/`close`:

```
fd := dial("example.com", 80)
write(fd, "GET / HTTP/1.0\r\nHost: example.com\r\nConnection: close\r\n\r\n")
resp := read(fd)
close(fd)
```

## Verified
- **Real host:** the above prints `HTTP/1.1 200 OK`, 828 bytes, body contains "Example Domain".
- **Hermetic:** `TestDialOutbound` — a Go listener, an MFL client dialing `127.0.0.1`, round-trip asserted.
- `_GNU_SOURCE` added so POSIX `getaddrinfo`/`addrinfo` are in scope under `-std=c11` (other POSIX socket calls already compiled; addrinfo needed the feature macro). No regressions; full suite green. SPEC §8 + README + CHANGELOG updated.

This is dogfooding in action — building a concurrent HTTP health-checker CLI in machin immediately required client networking, so it got added. Next: the tool itself (concurrent checks via goroutines + `dial` + `now()` for latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)