### PR TITLE
feat: now_ms() and parse_int() builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   `read`/`write`/`close`. machin was server-only (`listen`/`accept`); `dial` makes
   it a client too — HTTP clients, health checkers, anything that reaches out.
   Surfaced and filled while building a real tool (the "build real things" goal).
+- **`now_ms()` and `parse_int()`.** Wall-clock milliseconds (for measuring
+  latency) and string→int parsing (`0` on non-numeric). Both surfaced building
+  the same tool — a concurrent HTTP health checker.
 
 - **CLI builtins — `args()`, `env()`, `now()`.** `args()` returns the
   command-line arguments (`[]string`; `args()[0]` is the program path) — the

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ func main() {
 | **Generics** | functions are implicitly generic — specialized per concrete call-site type (monomorphization), no annotations |
 | **Concurrency** | `go f(args)`, channels `make(chan T)` / `ch <- v` / `<-ch`, `sleep(ms)` |
 | **Operators** | `+ - * / %`, `== != < <= > >=`, `&& \|\| !`; `+` concatenates strings |
-| **Builtins** | `print`, `println`, `input`, `args`, `env`, `now`, `len`, `str`, `int`, `append`, `sleep`, `has`, `delete`, `keys`, `json`, `parse`, `http_body` |
+| **Builtins** | `print`, `println`, `input`, `args`, `env`, `now`, `now_ms`, `parse_int`, `len`, `str`, `int`, `append`, `sleep`, `has`, `delete`, `keys`, `json`, `parse`, `http_body` |
 | **String ops** | `substr`, `index`, `contains`, `has_prefix`, `has_suffix`, `charat`, `to_upper`, `to_lower`, `trim`, `replace`, `split`, `join` |
 | **JSON** | `json(x)` serializes any value to JSON; `parse(s, T{})` parses JSON into a value of `T` |
 | **Networking** | `dial` (outbound), `listen`, `accept`, `read`, `write`, `close` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -212,6 +212,8 @@ throughout the function body).
 | `args` | `() -> []string` | command-line arguments (`args()[0]` is the program path) |
 | `env` | `(string) -> string` | environment variable (`""` if unset) |
 | `now` | `() -> int` | wall-clock time in Unix seconds |
+| `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
+| `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
 | `len` | `(string\|slice\|map) -> int` | length |
 | `str` | `(int\|float) -> string` | format a number |
 | `int` | `(number) -> int` | truncate to int |

--- a/cli_test.go
+++ b/cli_test.go
@@ -31,3 +31,12 @@ func TestCLIBuiltins(t *testing.T) {
 		t.Fatalf("CLI builtins: got %q, want %q", got, want)
 	}
 }
+
+// TestParseIntAndNowMs covers parse_int (string -> int, 0 on garbage) and now_ms
+// (monotone-ish wall-clock ms) — surfaced while building a real CLI tool.
+func TestParseIntAndNowMs(t *testing.T) {
+	got := runNative(t, `func main(){ println(parse_int("8080")) println(parse_int("x")) a := now_ms() sleep(20) println((now_ms() - a) >= 15) }`)
+	if want := "8080\n0\ntrue\n"; got != want {
+		t.Fatalf("parse_int/now_ms: got %q, want %q", got, want)
+	}
+}

--- a/codegen.go
+++ b/codegen.go
@@ -71,6 +71,7 @@ const cRuntime = `#define _GNU_SOURCE
 #include <ctype.h>
 #include <unistd.h>
 #include <time.h>
+#include <sys/time.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -414,6 +415,8 @@ static mfl_slice mfl_args(void) {
 }
 static char* mfl_env(const char* k) { char* v = getenv(k); return v ? v : ""; }
 static int64_t mfl_now(void) { return (int64_t)time(NULL); }
+static int64_t mfl_now_ms(void) { struct timeval tv; gettimeofday(&tv, NULL); return (int64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000; }
+static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 10); }
 `
 
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
@@ -1633,6 +1636,10 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return fmt.Sprintf("mfl_env(%s)", args[0]), nil
 	case "now":
 		return "mfl_now()", nil
+	case "now_ms":
+		return "mfl_now_ms()", nil
+	case "parse_int":
+		return fmt.Sprintf("mfl_parse_int(%s)", args[0]), nil
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
 	}

--- a/types.go
+++ b/types.go
@@ -1616,6 +1616,17 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("now: no args")
 		}
 		return c.cInt, nil
+	case "now_ms":
+		if len(argSlots) != 0 {
+			return 0, fmt.Errorf("now_ms: no args")
+		}
+		return c.cInt, nil
+	case "parse_int":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("parse_int: 1 arg (string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cInt, nil
 	case "write":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("write: 2 args")


### PR DESCRIPTION
Two more gaps surfaced by the "build real things" goal — both while writing a concurrent HTTP **health-checker** in machin:

- **`now_ms() -> int`** — wall-clock milliseconds, for measuring request latency (`now()` is seconds, too coarse).
- **`parse_int(string) -> int`** — string→int (`0` on non-numeric), to read a port out of a `host:port`. (The boilerplate previously reached for FFI `atoi`; now it's native.)

```
t0 := now_ms()
fd := dial(host, parse_int(port_str))
... ; ms := now_ms() - t0
```

`TestParseIntAndNowMs`; no regressions; full suite green. SPEC §8 + README + CHANGELOG updated.

With `dial` (#110) + these, the health-checker is fully buildable in pure machin — concurrent checks via goroutines + channels, real latencies, DOWN detection. The tool itself ships next as its own repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)