### PR TITLE
feat: native file I/O — read_file, write_file, list_dir, mkdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - **`now_ms()` and `parse_int()`.** Wall-clock milliseconds (for measuring
   latency) and string→int parsing (`0` on non-numeric). Both surfaced building
   the same tool — a concurrent HTTP health checker.
+- **File I/O — `read_file`, `write_file`, `list_dir`, `mkdir`.** Read/write whole
+  files, list a directory (excludes `.`/`..`), make a directory. Native builtins
+  (no FFI), surfaced building a static-site generator.
 
 - **CLI builtins — `args()`, `env()`, `now()`.** `args()` returns the
   command-line arguments (`[]string`; `args()[0]` is the program path) — the

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ func main() {
 | **Generics** | functions are implicitly generic — specialized per concrete call-site type (monomorphization), no annotations |
 | **Concurrency** | `go f(args)`, channels `make(chan T)` / `ch <- v` / `<-ch`, `sleep(ms)` |
 | **Operators** | `+ - * / %`, `== != < <= > >=`, `&& \|\| !`; `+` concatenates strings |
-| **Builtins** | `print`, `println`, `input`, `args`, `env`, `now`, `now_ms`, `parse_int`, `len`, `str`, `int`, `append`, `sleep`, `has`, `delete`, `keys`, `json`, `parse`, `http_body` |
+| **Builtins** | `print`, `println`, `input`, `args`, `env`, `now`, `now_ms`, `parse_int`, `read_file`, `write_file`, `list_dir`, `mkdir`, `len`, `str`, `int`, `append`, `sleep`, `has`, `delete`, `keys`, `json`, `parse`, `http_body` |
 | **String ops** | `substr`, `index`, `contains`, `has_prefix`, `has_suffix`, `charat`, `to_upper`, `to_lower`, `trim`, `replace`, `split`, `join` |
 | **JSON** | `json(x)` serializes any value to JSON; `parse(s, T{})` parses JSON into a value of `T` |
 | **Networking** | `dial` (outbound), `listen`, `accept`, `read`, `write`, `close` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -214,6 +214,10 @@ throughout the function body).
 | `now` | `() -> int` | wall-clock time in Unix seconds |
 | `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
+| `read_file` | `(string) -> string` | read a whole file ("" on error) |
+| `write_file` | `(string, string) -> int` | write a file (bytes written; -1 on error) |
+| `list_dir` | `(string) -> []string` | directory entries (excludes `.`/`..`) |
+| `mkdir` | `(string) -> int` | create a directory (0 ok; -1 on error) |
 | `len` | `(string\|slice\|map) -> int` | length |
 | `str` | `(int\|float) -> string` | format a number |
 | `int` | `(number) -> int` | truncate to int |

--- a/cli_test.go
+++ b/cli_test.go
@@ -40,3 +40,14 @@ func TestParseIntAndNowMs(t *testing.T) {
 		t.Fatalf("parse_int/now_ms: got %q, want %q", got, want)
 	}
 }
+
+// TestFileIO covers write_file/read_file/list_dir/mkdir — surfaced building a
+// static-site generator.
+func TestFileIO(t *testing.T) {
+	dir := t.TempDir()
+	src := `func main(){ mkdir("` + dir + `/sub") write_file("` + dir + `/sub/a.txt", "hi there") println(read_file("` + dir + `/sub/a.txt")) println(len(list_dir("` + dir + `/sub"))) println(read_file("` + dir + `/missing")) }`
+	got := runNative(t, src)
+	if want := "hi there\n1\n\n"; got != want {
+		t.Fatalf("file I/O: got %q, want %q", got, want)
+	}
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -41,6 +41,16 @@ func TestParseIntAndNowMs(t *testing.T) {
 	}
 }
 
+// TestStringLiteralPunct guards against a parser bug surfaced building the SSG:
+// a string literal whose value is a structural token (")", "}", ",") was
+// mistaken for that token, terminating an argument/element list early.
+func TestStringLiteralPunct(t *testing.T) {
+	got := runNative(t, `func main(){ println(index("a)b", ")")) xs := []string{"}", ","} println(len(xs)) println(xs[0]) }`)
+	if want := "1\n2\n}\n"; got != want {
+		t.Fatalf("string-literal punct: got %q, want %q", got, want)
+	}
+}
+
 // TestFileIO covers write_file/read_file/list_dir/mkdir — surfaced building a
 // static-site generator.
 func TestFileIO(t *testing.T) {

--- a/codegen.go
+++ b/codegen.go
@@ -76,6 +76,9 @@ const cRuntime = `#define _GNU_SOURCE
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <errno.h>
 
 /* slices: a Go-style header over an unboxed backing array */
 typedef struct { void* data; int64_t len; int64_t cap; } mfl_slice;
@@ -417,6 +420,41 @@ static char* mfl_env(const char* k) { char* v = getenv(k); return v ? v : ""; }
 static int64_t mfl_now(void) { return (int64_t)time(NULL); }
 static int64_t mfl_now_ms(void) { struct timeval tv; gettimeofday(&tv, NULL); return (int64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000; }
 static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 10); }
+
+/* file system: read/write whole files, list a directory, make a directory */
+static char* mfl_read_file(const char* path) {
+    FILE* f = fopen(path, "rb");
+    if (!f) return mfl_dup("");
+    fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);
+    if (n < 0) n = 0;
+    char* buf = mfl_alloc((size_t)n + 1);
+    size_t r = fread(buf, 1, (size_t)n, f); buf[r] = 0;
+    fclose(f); return buf;
+}
+static int64_t mfl_write_file(const char* path, const char* content) {
+    FILE* f = fopen(path, "wb");
+    if (!f) return -1;
+    size_t len = strlen(content);
+    size_t w = fwrite(content, 1, len, f);
+    fclose(f); return (int64_t)w;
+}
+static mfl_slice mfl_list_dir(const char* path) {
+    mfl_slice out = {0};
+    DIR* d = opendir(path);
+    if (!d) return out;
+    struct dirent* e;
+    while ((e = readdir(d))) {
+        if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0) continue;
+        char* name = mfl_dup(e->d_name);
+        out = mfl_append(out, &name, sizeof(char*));
+    }
+    closedir(d); return out;
+}
+static int64_t mfl_mkdir(const char* path) {
+    int r = mkdir(path, 0755);
+    if (r < 0 && errno == EEXIST) return 0;
+    return r;
+}
 `
 
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
@@ -1640,6 +1678,14 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return "mfl_now_ms()", nil
 	case "parse_int":
 		return fmt.Sprintf("mfl_parse_int(%s)", args[0]), nil
+	case "read_file":
+		return fmt.Sprintf("mfl_read_file(%s)", args[0]), nil
+	case "write_file":
+		return fmt.Sprintf("mfl_write_file(%s, %s)", args[0], args[1]), nil
+	case "list_dir":
+		return fmt.Sprintf("mfl_list_dir(%s)", args[0]), nil
+	case "mkdir":
+		return fmt.Sprintf("mfl_mkdir(%s)", args[0]), nil
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
 	}

--- a/parser.go
+++ b/parser.go
@@ -568,7 +568,7 @@ func (p *Parser) parseExprList() ([]Expr, error) {
 			return nil, err
 		}
 		list = append(list, e)
-		if p.peek().Val != "," {
+		if !p.atPunct(",") {
 			break
 		}
 		p.next()
@@ -870,7 +870,7 @@ func (p *Parser) parseStructLit(typeName string) (Expr, error) {
 		return nil, err
 	}
 	lit := &StructLit{Type: typeName}
-	for p.peek().Val != "}" && p.peek().Kind != TEOF {
+	for !p.atPunct("}") && p.peek().Kind != TEOF {
 		// keyed?  ident ':' expr
 		if p.peek().Kind == TIdent && p.toks[p.pos+1].Val == ":" {
 			name := p.next().Val
@@ -888,7 +888,7 @@ func (p *Parser) parseStructLit(typeName string) (Expr, error) {
 			}
 			lit.Vals = append(lit.Vals, val)
 		}
-		if p.peek().Val == "," {
+		if p.atPunct(",") {
 			p.next()
 		} else {
 			break
@@ -919,13 +919,13 @@ func (p *Parser) parseSliceLit() (Expr, error) {
 		return nil, err
 	}
 	var elems []Expr
-	for p.peek().Val != "}" {
+	for !p.atPunct("}") && p.peek().Kind != TEOF {
 		e, err := p.parseExpr()
 		if err != nil {
 			return nil, err
 		}
 		elems = append(elems, e)
-		if p.peek().Val == "," {
+		if p.atPunct(",") {
 			p.next()
 		} else {
 			break
@@ -947,24 +947,31 @@ func (p *Parser) parseCall(callee string) (Expr, error) {
 
 // parseCallArgs parses a parenthesized argument list, reporting whether the
 // final argument is spread (`expr...`).
+// atPunct reports whether the next token is the given punctuation/operator —
+// distinct from a string literal that merely has the same value (e.g. ")").
+func (p *Parser) atPunct(val string) bool {
+	t := p.peek()
+	return (t.Kind == TPunct || t.Kind == TOp) && t.Val == val
+}
+
 func (p *Parser) parseCallArgs() ([]Expr, bool, error) {
 	if _, err := p.expect(TPunct, "("); err != nil {
 		return nil, false, err
 	}
 	var args []Expr
 	spread := false
-	for p.peek().Val != ")" {
+	for !p.atPunct(")") && p.peek().Kind != TEOF {
 		a, err := p.parseExpr()
 		if err != nil {
 			return nil, false, err
 		}
 		args = append(args, a)
-		if p.peek().Val == "..." { // spread: must be the last argument
+		if p.atPunct("...") { // spread: must be the last argument
 			p.next()
 			spread = true
 			break
 		}
-		if p.peek().Val == "," {
+		if p.atPunct(",") {
 			p.next()
 		} else {
 			break

--- a/types.go
+++ b/types.go
@@ -1627,6 +1627,31 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cString)
 		return c.cInt, nil
+	case "read_file":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("read_file: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cString, nil
+	case "write_file":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("write_file: 2 args (path, content)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
+		return c.cInt, nil
+	case "list_dir":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("list_dir: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return newSliceSlot(c, c.cString), nil
+	case "mkdir":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("mkdir: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cInt, nil
 	case "write":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("write: 2 args")


### PR DESCRIPTION
The next gap surfaced by "build real things" — this time a **static-site generator** (read content files → render → write HTML). machin had no native file access (only FFI `open` + fd builtins); now it has the basics:

- **`read_file(path) -> string`** — whole file, `""` on error
- **`write_file(path, content) -> int`** — bytes written, `-1` on error
- **`list_dir(path) -> []string`** — entries, excludes `.`/`..`
- **`mkdir(path) -> int`** — `0` ok (idempotent on EEXIST), `-1` on error

```
mkdir("public")
for _, f := range list_dir("content") {
    write_file("public/" + f, render(read_file("content/" + f)))
}
```

Native builtins (no FFI). `TestFileIO` (hermetic, `t.TempDir`); no regressions; full suite green. SPEC §8 + README + CHANGELOG updated. The SSG ships next as its own repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)