### PR TITLE
docs: link awesome-machin (ecosystem list) from AGENTS/README/landing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,17 @@
 Orientation for agents working on **machin** (the toolchain) / **MFL** (the
 language). Humans state intent; the machine reads and writes the code.
 
+## Current direction: dogfood
+
+The POC goal is met; machin is now grown by **building real things** and letting
+real use surface the gaps, which then get filled in the language. Recent
+examples: a concurrent HTTP health checker added `dial`/`now_ms`/`parse_int`; a
+static-site generator added native file I/O (`read_file`/`write_file`/`list_dir`/
+`mkdir`) and a parser fix. **When you ship a real app/tool built with machin,
+add it to [awesome-machin](https://github.com/javimosch/awesome-machin)** (the
+curated ecosystem list). Each app is its own public repo under `javimosch` with
+a `build.sh` (`machin encode src/*.src > app.mfl && machin build app.mfl`).
+
 ## What this is
 
 machin compiles MFL to native code through C:

--- a/README.md
+++ b/README.md
@@ -329,6 +329,18 @@ make install      # install to $(PREFIX)/bin  (default /usr/local)
 
 ---
 
+## Ecosystem
+
+Things built with machin live in **[awesome-machin](https://github.com/javimosch/awesome-machin)** — the curated list. Highlights:
+
+- **[boilerplate-cli-ui-machin](https://github.com/javimosch/boilerplate-cli-ui-machin)** — single-binary CLI + embedded React web UI + daemon (via FFI)
+- **[machin-healthcheck](https://github.com/javimosch/machin-healthcheck)** — concurrent HTTP status/latency checker
+- **[machin-ssg](https://github.com/javimosch/machin-ssg)** — static-site generator (markdown → HTML)
+
+Each is its own native binary. Built something? Add it to [awesome-machin](https://github.com/javimosch/awesome-machin).
+
+---
+
 ## License
 
 MIT — <a href="https://www.linkedin.com/in/arancibiajav/" target="_blank">Javier Leandro Arancibia</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -135,6 +135,7 @@ bin/machin build examples/complex/primes.mfl -o primes &amp;&amp; ./primes</pre>
   <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Specification</a> ·
   <a href="changelog.html">Changelog</a> ·
   <a href="https://github.com/javimosch/machin/tree/main/framework">Framework</a> ·
+  <a href="https://github.com/javimosch/awesome-machin">Awesome machin</a> ·
   <a href="https://github.com/javimosch/machin/releases">Releases</a>
   <p>MIT — <a href="https://www.linkedin.com/in/arancibiajav/">Javier Leandro Arancibia</a></p>
 </div></footer>


### PR DESCRIPTION
[awesome-machin](https://github.com/javimosch/awesome-machin) is the new curated list of things built with machin. This makes it discoverable and tells future agents about it:

- **AGENTS.md** — a "Current direction: dogfood" section: the POC is met; grow machin by building real things and filling the gaps that surface. **When you ship a real app, add it to awesome-machin.** (Records the recent examples: healthcheck → `dial`/`now_ms`/`parse_int`; ssg → file I/O + a parser fix.)
- **README.md** — an Ecosystem section linking awesome-machin + the three apps.
- **docs/index.html** — a footer link.

Docs-only; `go vet` clean.