### PR TITLE
encode: string- and comment-aware function splitting

### DIFF
--- a/main.go
+++ b/main.go
@@ -348,8 +348,26 @@ func splitFunctions(src string) ([]string, error) {
 		}
 		cur.WriteString(line)
 		cur.WriteByte('\n')
-		for _, c := range line {
+		// Count braces, but skip those inside string literals or after a // comment
+		// (a JSON-building function has "{"/"}" in strings — they are not blocks).
+		inStr := false
+		for i := 0; i < len(line); i++ {
+			c := line[i]
+			if inStr {
+				if c == '\\' {
+					i++
+				} else if c == '"' {
+					inStr = false
+				}
+				continue
+			}
 			switch c {
+			case '"':
+				inStr = true
+			case '/':
+				if i+1 < len(line) && line[i+1] == '/' {
+					i = len(line) // rest of the line is a comment
+				}
 			case '{':
 				depth++
 			case '}':

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -534,3 +534,17 @@ func TestSplitFunctions(t *testing.T) {
 		t.Fatalf("expected 2 funcs, got %d", len(fns))
 	}
 }
+
+// Braces inside string literals (e.g. a function that builds JSON) and after
+// // comments must not be counted as block delimiters when splitting.
+func TestSplitFunctionsBracesInStrings(t *testing.T) {
+	src := "func j(v) (s) { s = \"{\\\"x\\\":\" + v + \"}\" }\n\n" +
+		"func k() (s) { s = index(b, \"}\") // trailing } in a comment\n}\n"
+	fns, err := splitFunctions(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fns) != 2 {
+		t.Fatalf("expected 2 funcs, got %d: %v", len(fns), fns)
+	}
+}


### PR DESCRIPTION
`splitFunctions` (behind `machin encode`) counted every `{`/`}` to find declaration boundaries — including braces inside **string literals** and `//` comments. Any function that builds JSON (`"{...}"`) or searches for a brace (`index(s, "}")`) unbalanced the depth counter, so `encode` aborted with `unbalanced braces near: }`.

The fix tracks string state (honoring `\` escapes) and stops scanning at `//`, so only real block braces count. Surfaced while dogfooding a JSON-emitting tool.

- string-aware + comment-aware brace counting in `splitFunctions`
- `TestSplitFunctionsBracesInStrings` covers both cases; full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)