### PR TITLE
release: v0.8.0 (break/continue, encode brace fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.0
 
 More dogfooding: building a streaming WebSocket scraper drove these in.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.7.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.8.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -40,7 +40,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 ## Capabilities
 
 - **Types** (all inferred, unboxed): `int` `float` `bool` `string`, slices `[]T`, maps `map[K]V`, structs, `func` values
-- **Flow**: `if`/`for`/`while`/`range`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
+- **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels; per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server)
 - **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`, `args`/`env`/`now`/`now_ms`/`parse_int`, string ops

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.7.0
+Version 0.8.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.8.0**, capturing the two features already on `main`:

- **`break` / `continue`** (#116) — loop control; works in `for cond`, `for {}`, `range`.
- **`encode` string/comment-aware splitting** (#115) — JSON-emitting MFL no longer fails with `unbalanced braces`.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.8.0), plus break/continue added to the README capabilities. Full suite green. On merge I'll tag `v0.8.0` to trigger the cross-compile/release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version badges and documentation to reflect v0.8.0 release.
  * Documented `break` and `continue` support in Flow features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->