### PR TITLE
feat: native TLS — https_get / https_post (OpenSSL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **Native TLS — `https_get` and `https_post`.** machin's biggest networking
+  gap is closed: an HTTPS client over real TLS (OpenSSL), no subprocess. `https_get(url)`
+  and `https_post(url, jsonBody)` return the response body, handling cert
+  verification (SNI + hostname), `Content-Length`, chunked transfer-encoding, and
+  redirects. The OpenSSL runtime is emitted and linked (`-lssl -lcrypto`) **only
+  when used**, so TLS-free programs keep their libc-only footprint. Surfaced
+  building a Polymarket scraper that had to shell out to `curl`/`websocat` because
+  machin couldn't open a TLS socket — this retires the `curl` crutch for REST.
+
 ## v0.8.0
 
 More dogfooding: building a streaming WebSocket scraper drove these in.

--- a/SPEC.md
+++ b/SPEC.md
@@ -241,6 +241,8 @@ throughout the function body).
 | `listen`, `accept` | `(int) -> int` | open / accept on a TCP socket |
 | `read`, `write` | `(int[, string]) -> string\|int` | socket/fd I/O |
 | `close` | `(int) -> ` | close a socket/fd |
+| `https_get` | `(string) -> string` | HTTPS GET over TLS; response body ("" on error) |
+| `https_post` | `(string, string) -> string` | HTTPS POST (JSON body) over TLS; response body |
 
 ---
 
@@ -361,6 +363,8 @@ id(42); id("hi"); id(3.14)   // → three native functions
   instances.
 - **Codegen** emits one C function per instance with unboxed value types, plus a
   small C runtime (slices, maps, channels, closures, sockets, JSON, strings).
+  `https_get`/`https_post` additionally emit a TLS runtime and link OpenSSL
+  (`-lssl -lcrypto`) — but only when used, so TLS-free programs stay libc-only.
 
 ---
 

--- a/build.go
+++ b/build.go
@@ -44,6 +44,11 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 			libs = append(libs, "-l"+l)
 		}
 	}
+	// native TLS (https_get/https_post) links OpenSSL — only when actually used,
+	// so TLS-free programs keep machin's libc-only footprint.
+	if strings.Contains(csrc, "mfl_https_") {
+		libs = append(libs, "-lssl", "-lcrypto")
+	}
 	args = append(args, "-o", outPath, tmp.Name())
 	args = append(args, libs...)
 

--- a/codegen.go
+++ b/codegen.go
@@ -60,6 +60,7 @@ type cgen struct {
 	arenaID   int    // unique temp names for scoped-arena blocks
 	curFn     string // name of the function currently being emitted
 	safe      bool   // emit runtime bounds / div-by-zero / overflow checks
+	usesTLS   bool   // program calls https_get/https_post -> emit + link OpenSSL
 }
 
 const cRuntime = `#define _GNU_SOURCE
@@ -457,6 +458,184 @@ static int64_t mfl_mkdir(const char* path) {
 }
 `
 
+// tlsRuntime is a minimal HTTPS/1.1 client over real TLS (OpenSSL). It is
+// appended to the C output and linked against -lssl -lcrypto only when a
+// program calls https_get/https_post, so TLS-free binaries stay libc-only.
+// Handles cert verification (SNI + hostname), Content-Length, chunked
+// transfer-encoding, and redirect following. Returns the response body ("" on
+// any error). machin's first native TLS — retires the popen("curl") crutch.
+const tlsRuntime = `#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+static char* mfl_dup_arena(const char* s, size_t n) {
+    char* r = (char*)mfl_alloc(n + 1);
+    if (n) memcpy(r, s, n);
+    r[n] = 0;
+    return r;
+}
+
+/* read the whole TLS stream into a malloc'd buffer (caller frees); NUL-terminated */
+static char* mfl_tls_readall(SSL* ssl, size_t* outlen) {
+    size_t cap = 16384, len = 0;
+    char* buf = (char*)malloc(cap);
+    for (;;) {
+        if (len + 8192 > cap) { cap *= 2; buf = (char*)realloc(buf, cap); }
+        int n = SSL_read(ssl, buf + len, 8192);
+        if (n <= 0) break;
+        len += (size_t)n;
+    }
+    buf[len] = 0;
+    *outlen = len;
+    return buf;
+}
+
+/* decode HTTP/1.1 chunked transfer-encoding (caller frees) */
+static char* mfl_chunk_decode(const char* body, size_t blen, size_t* outlen) {
+    char* out = (char*)malloc(blen + 1);
+    size_t o = 0;
+    const char* p = body;
+    const char* end = body + blen;
+    while (p < end) {
+        char* nl;
+        long sz = strtol(p, &nl, 16);
+        if (nl == p) break;
+        while (nl < end && *nl != '\n') nl++;
+        if (nl < end) nl++;
+        p = nl;
+        if (sz <= 0) break;
+        if (p + sz > end) sz = end - p;
+        memcpy(out + o, p, (size_t)sz);
+        o += (size_t)sz;
+        p += sz;
+        while (p < end && (*p == '\r' || *p == '\n')) p++;
+    }
+    out[o] = 0;
+    *outlen = o;
+    return out;
+}
+
+static char* mfl_https_request(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects);
+
+static char* mfl_https_request(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects) {
+    char host[256] = {0}, path[2048] = {0};
+    int port = 443;
+    const char* p = url;
+    if (strncmp(p, "https://", 8) == 0) p += 8;
+    else if (strncmp(p, "http://", 7) == 0) { p += 7; port = 80; }
+    int i = 0;
+    while (*p && *p != '/' && *p != ':' && i < 255) host[i++] = *p++;
+    host[i] = 0;
+    if (*p == ':') { p++; port = atoi(p); while (*p && *p != '/') p++; }
+    if (*p == '/') strncpy(path, p, sizeof(path) - 1);
+    else { path[0] = '/'; path[1] = 0; }
+    if (port != 443 && strncmp(url, "http://", 7) == 0) return mfl_dup_arena("", 0); /* TLS only */
+
+    struct addrinfo hints, *res = NULL;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    char ports[16];
+    snprintf(ports, sizeof(ports), "%d", port);
+    if (getaddrinfo(host, ports, &hints, &res) != 0) return mfl_dup_arena("", 0);
+    int fd = -1;
+    for (struct addrinfo* a = res; a; a = a->ai_next) {
+        fd = socket(a->ai_family, a->ai_socktype, a->ai_protocol);
+        if (fd < 0) continue;
+        if (connect(fd, a->ai_addr, a->ai_addrlen) == 0) break;
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+    if (fd < 0) return mfl_dup_arena("", 0);
+
+    SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+    if (!ctx) { close(fd); return mfl_dup_arena("", 0); }
+    SSL_CTX_set_default_verify_paths(ctx);
+    SSL* ssl = SSL_new(ctx);
+    SSL_set_fd(ssl, fd);
+    SSL_set_tlsext_host_name(ssl, host);
+    SSL_set1_host(ssl, host);
+    SSL_set_verify(ssl, SSL_VERIFY_PEER, NULL);
+    if (SSL_connect(ssl) != 1) { SSL_free(ssl); SSL_CTX_free(ctx); close(fd); return mfl_dup_arena("", 0); }
+
+    size_t blen = reqbody ? strlen(reqbody) : 0;
+    size_t reqcap = blen + strlen(path) + strlen(host) + 256 + (ctype ? strlen(ctype) : 0);
+    char* req = (char*)malloc(reqcap);
+    int rl;
+    if (blen > 0) {
+        rl = snprintf(req, reqcap,
+            "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\nContent-Type: %s\r\nContent-Length: %zu\r\nConnection: close\r\n\r\n",
+            method, path, host, ctype ? ctype : "application/octet-stream", blen);
+        memcpy(req + rl, reqbody, blen);
+        rl += (int)blen;
+    } else {
+        rl = snprintf(req, reqcap,
+            "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\nConnection: close\r\n\r\n",
+            method, path, host);
+    }
+    SSL_write(ssl, req, rl);
+    free(req);
+
+    size_t rlen;
+    char* raw = mfl_tls_readall(ssl, &rlen);
+    SSL_shutdown(ssl);
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    close(fd);
+
+    int status = 0;
+    { const char* sp = strchr(raw, ' '); if (sp) status = atoi(sp + 1); }
+    char* hb = strstr(raw, "\r\n\r\n");
+    if (!hb) { char* r = mfl_dup_arena(raw, rlen); free(raw); return r; }
+    size_t hdrlen = (size_t)(hb - raw);
+    char* body = hb + 4;
+    size_t bodylen = rlen - (size_t)(body - raw);
+
+    if (redirects > 0 && (status == 301 || status == 302 || status == 303 || status == 307 || status == 308)) {
+        char* hdrs = mfl_dup_arena(raw, hdrlen);
+        char* loc = strcasestr(hdrs, "\nlocation:");
+        if (loc) {
+            loc += strlen("\nlocation:");
+            while (*loc == ' ' || *loc == '\t') loc++;
+            char* e = loc;
+            while (*e && *e != '\r' && *e != '\n') e++;
+            char locurl[2048];
+            size_t ll = (size_t)(e - loc);
+            if (ll > sizeof(locurl) - 1) ll = sizeof(locurl) - 1;
+            memcpy(locurl, loc, ll);
+            locurl[ll] = 0;
+            if (strncmp(locurl, "http", 4) == 0) {
+                free(raw);
+                const char* m = (status == 307 || status == 308) ? method : "GET";
+                const char* rb = (status == 307 || status == 308) ? reqbody : NULL;
+                return mfl_https_request(m, locurl, rb, ctype, redirects - 1);
+            }
+        }
+    }
+
+    char* hdrs = mfl_dup_arena(raw, hdrlen);
+    char* result;
+    if (strcasestr(hdrs, "transfer-encoding: chunked") || strcasestr(hdrs, "transfer-encoding:chunked")) {
+        size_t dl;
+        char* dec = mfl_chunk_decode(body, bodylen, &dl);
+        result = mfl_dup_arena(dec, dl);
+        free(dec);
+    } else {
+        char* cl = strcasestr(hdrs, "content-length:");
+        if (cl) {
+            size_t want = (size_t)strtoul(cl + strlen("content-length:"), NULL, 10);
+            if (want < bodylen) bodylen = want;
+        }
+        result = mfl_dup_arena(body, bodylen);
+    }
+    free(raw);
+    return result;
+}
+
+static char* mfl_https_get(const char* url) { return mfl_https_request("GET", url, NULL, NULL, 5); }
+static char* mfl_https_post(const char* url, const char* body) { return mfl_https_request("POST", url, body, "application/json", 5); }
+`
+
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
 func isFFIScalar(t string) bool {
 	switch t {
@@ -583,6 +762,12 @@ func (g *cgen) program(p *Program) (string, error) {
 	var out strings.Builder
 	out.WriteString(cRuntime)
 	out.WriteByte('\n')
+	if g.usesTLS {
+		// Emitted (and linked against OpenSSL) only when a program calls
+		// https_get/https_post, so TLS-free programs stay libc-only.
+		out.WriteString(tlsRuntime)
+		out.WriteByte('\n')
+	}
 	// foreign (extern) declarations. With a header, its prototypes + C structs are
 	// in scope. Without one, emit C struct typedefs and function prototypes from
 	// the declared signatures.
@@ -1690,6 +1875,12 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return fmt.Sprintf("mfl_list_dir(%s)", args[0]), nil
 	case "mkdir":
 		return fmt.Sprintf("mfl_mkdir(%s)", args[0]), nil
+	case "https_get":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_https_get(%s)", args[0]), nil
+	case "https_post":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_https_post(%s, %s)", args[0], args[1]), nil
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
 	}

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 )
 
@@ -532,6 +533,27 @@ func TestSplitFunctions(t *testing.T) {
 	}
 	if len(fns) != 2 {
 		t.Fatalf("expected 2 funcs, got %d", len(fns))
+	}
+}
+
+// The OpenSSL/TLS runtime is emitted only when a program calls https_get/
+// https_post; TLS-free programs must stay libc-only (no OpenSSL pulled in).
+func TestHTTPSRuntimeGating(t *testing.T) {
+	tls := &Program{Funcs: parseFuncs(t, `func main() { println(https_get("https://example.com")) }`)}
+	c, err := CompileToC(tls, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_https_request") || !strings.Contains(c, "openssl/ssl.h") {
+		t.Fatal("a program using https_get must emit the OpenSSL TLS runtime")
+	}
+	plain := &Program{Funcs: parseFuncs(t, `func main() { println("hi") }`)}
+	c2, err := CompileToC(plain, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(c2, "mfl_https_") || strings.Contains(c2, "openssl") {
+		t.Fatal("a TLS-free program must stay libc-only (no OpenSSL emitted)")
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -1656,6 +1656,19 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cString)
 		return c.cInt, nil
+	case "https_get":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("https_get: 1 arg (url string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cString, nil
+	case "https_post":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("https_post: 2 args (url string, body string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
+		return c.cString, nil
 	case "write":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("write: 2 args")


### PR DESCRIPTION
machin's biggest networking gap was **no TLS** — a faithful HTTPS/WSS client had to shell out to `curl`/`websocat` (proven while dogfooding a Polymarket scraper). This adds a real TLS HTTPS client over **OpenSSL**, no subprocess.

## Surface
- `https_get(url) -> string` — response body ("" on error)
- `https_post(url, jsonBody) -> string` — POST with `application/json`

Handles cert verification (SNI + hostname via `SSL_set1_host`), `Content-Length`, **chunked** transfer-encoding decode, and redirect following (up to 5).

## Stays libc-only when unused
The OpenSSL runtime and `-lssl -lcrypto` link are emitted **only when a program calls `https_*`** — codegen tracks `usesTLS`, `build.go` adds the libs when the C references `mfl_https_`. Verified: a `println("hi")` binary links no OpenSSL; an `https_get` binary links `libssl`/`libcrypto`.

## Verified live
- Gamma API (the scraper's endpoint) — real `bestBid`/`clobTokenIds` over native TLS
- GitHub API — cert-verified, chunked
- httpbin POST — JSON body echoed back

`TestHTTPSRuntimeGating` covers both emit directions (no network). Full suite green. SPEC + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)