### PR TITLE
release: v0.9.0 (native TLS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.9.0
 
 - **Native TLS — `https_get` and `https_post`.** machin's biggest networking
   gap is closed: an HTTPS client over real TLS (OpenSSL), no subprocess. `https_get(url)`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.8.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.9.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -42,7 +42,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Types** (all inferred, unboxed): `int` `float` `bool` `string`, slices `[]T`, maps `map[K]V`, structs, `func` values
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels; per-goroutine arena GC + scoped `arena{}`; `--safe` checks
-- **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server)
+- **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS `https_get`/`https_post` (OpenSSL, linked only when used)
 - **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`, `args`/`env`/`now`/`now_ms`/`parse_int`, string ops
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.8.0
+Version 0.9.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.9.0**, capturing native TLS (#118) already on `main`:

- **`https_get` / `https_post`** — OpenSSL-backed HTTPS client, no subprocess; cert verification, Content-Length, chunked, redirects. Emitted + linked (`-lssl -lcrypto`) only when used, so TLS-free programs stay libc-only.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.9.0), plus a README networking line. Full suite green. On merge I'll tag `v0.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)