### PR TITLE
feat: native WebSocket client — wss_* (RFC 6455 over TLS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- **Native WebSocket — `wss_open`, `wss_send`, `wss_recv`, `wss_close`.** A
+  `wss://` client (RFC 6455) over real TLS, no subprocess. `wss_open(url)` does
+  the HTTP/1.1 Upgrade handshake and returns a connection handle; `wss_send`
+  masks and writes a text frame; `wss_recv` blocks for the next message,
+  reassembling fragments and transparently answering pings and handling close;
+  `wss_close` tears down. Built on a shared TLS core refactored out of the HTTPS
+  client (one process-global `SSL_CTX`), emitted and linked (`-lssl -lcrypto`)
+  only when used. Surfaced dogfooding a streaming scraper that had to shell out
+  to `websocat` — this retires that crutch too: a Polymarket CLOB stream now runs
+  fully native (`https_get` to resolve the token, `wss_*` to stream).
+
 ## v0.9.0
 
 - **Native TLS — `https_get` and `https_post`.** machin's biggest networking

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Types** (all inferred, unboxed): `int` `float` `bool` `string`, slices `[]T`, maps `map[K]V`, structs, `func` values
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels; per-goroutine arena GC + scoped `arena{}`; `--safe` checks
-- **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS `https_get`/`https_post` (OpenSSL, linked only when used)
+- **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
 - **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`, `args`/`env`/`now`/`now_ms`/`parse_int`, string ops
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -243,6 +243,10 @@ throughout the function body).
 | `close` | `(int) -> ` | close a socket/fd |
 | `https_get` | `(string) -> string` | HTTPS GET over TLS; response body ("" on error) |
 | `https_post` | `(string, string) -> string` | HTTPS POST (JSON body) over TLS; response body |
+| `wss_open` | `(string) -> int` | open a `wss://` WebSocket; a connection handle, or 0 on failure |
+| `wss_send` | `(int, string) -> int` | send a text message on a WebSocket |
+| `wss_recv` | `(int) -> string` | next message (blocks); `""` on close (auto ping/pong) |
+| `wss_close` | `(int) -> int` | send close and tear down the connection |
 
 ---
 
@@ -363,8 +367,10 @@ id(42); id("hi"); id(3.14)   // → three native functions
   instances.
 - **Codegen** emits one C function per instance with unboxed value types, plus a
   small C runtime (slices, maps, channels, closures, sockets, JSON, strings).
-  `https_get`/`https_post` additionally emit a TLS runtime and link OpenSSL
-  (`-lssl -lcrypto`) — but only when used, so TLS-free programs stay libc-only.
+  `https_get`/`https_post` and `wss_open`/`wss_send`/`wss_recv`/`wss_close`
+  additionally emit a TLS runtime (HTTPS and/or RFC 6455 WebSocket framing over a
+  shared TLS core) and link OpenSSL (`-lssl -lcrypto`) — but only when used, so
+  programs that touch neither stay libc-only.
 
 ---
 

--- a/build.go
+++ b/build.go
@@ -44,9 +44,10 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 			libs = append(libs, "-l"+l)
 		}
 	}
-	// native TLS (https_get/https_post) links OpenSSL — only when actually used,
-	// so TLS-free programs keep machin's libc-only footprint.
-	if strings.Contains(csrc, "mfl_https_") {
+	// native TLS (https_* / wss_*) links OpenSSL — only when actually used, so
+	// TLS-free programs keep machin's libc-only footprint. mfl_tls_dial is in the
+	// shared TLS core, emitted whenever either the HTTPS or WSS runtime is used.
+	if strings.Contains(csrc, "mfl_tls_dial") {
 		libs = append(libs, "-lssl", "-lcrypto")
 	}
 	args = append(args, "-o", outPath, tmp.Name())

--- a/codegen.go
+++ b/codegen.go
@@ -61,6 +61,7 @@ type cgen struct {
 	curFn     string // name of the function currently being emitted
 	safe      bool   // emit runtime bounds / div-by-zero / overflow checks
 	usesTLS   bool   // program calls https_get/https_post -> emit + link OpenSSL
+	usesWSS   bool   // program calls wss_* -> emit WebSocket runtime + link OpenSSL
 }
 
 const cRuntime = `#define _GNU_SOURCE
@@ -458,14 +459,14 @@ static int64_t mfl_mkdir(const char* path) {
 }
 `
 
-// tlsRuntime is a minimal HTTPS/1.1 client over real TLS (OpenSSL). It is
-// appended to the C output and linked against -lssl -lcrypto only when a
-// program calls https_get/https_post, so TLS-free binaries stay libc-only.
-// Handles cert verification (SNI + hostname), Content-Length, chunked
-// transfer-encoding, and redirect following. Returns the response body ("" on
-// any error). machin's first native TLS — retires the popen("curl") crutch.
-const tlsRuntime = `#include <openssl/ssl.h>
+// tlsCoreRuntime holds the shared OpenSSL plumbing (a verified TLS dial) used by
+// both the HTTPS client and the WebSocket client. Emitted whenever a program
+// uses native TLS (https_* or wss_*); linked against -lssl -lcrypto. A single
+// process-global SSL_CTX is shared across all connections (OpenSSL makes SSL_new
+// on a shared CTX thread-safe), so per-connection setup is just SSL_new+connect.
+const tlsCoreRuntime = `#include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/rand.h>
 
 static char* mfl_dup_arena(const char* s, size_t n) {
     char* r = (char*)mfl_alloc(n + 1);
@@ -474,6 +475,62 @@ static char* mfl_dup_arena(const char* s, size_t n) {
     return r;
 }
 
+static SSL_CTX* mfl_ssl_ctx(void) {
+    static SSL_CTX* ctx = NULL;
+    static pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&mu);
+    if (!ctx) {
+        ctx = SSL_CTX_new(TLS_client_method());
+        if (ctx) SSL_CTX_set_default_verify_paths(ctx);
+    }
+    pthread_mutex_unlock(&mu);
+    return ctx;
+}
+
+/* dial host:port and complete a verified TLS handshake (SNI + hostname).
+   Returns a connected SSL* (fd retrievable via SSL_get_fd) or NULL. */
+static SSL* mfl_tls_dial(const char* host, int port) {
+    struct addrinfo hints, *res = NULL;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    char ports[16];
+    snprintf(ports, sizeof(ports), "%d", port);
+    if (getaddrinfo(host, ports, &hints, &res) != 0) return NULL;
+    int fd = -1;
+    for (struct addrinfo* a = res; a; a = a->ai_next) {
+        fd = socket(a->ai_family, a->ai_socktype, a->ai_protocol);
+        if (fd < 0) continue;
+        if (connect(fd, a->ai_addr, a->ai_addrlen) == 0) break;
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(res);
+    if (fd < 0) return NULL;
+    SSL_CTX* ctx = mfl_ssl_ctx();
+    if (!ctx) { close(fd); return NULL; }
+    SSL* ssl = SSL_new(ctx);
+    SSL_set_fd(ssl, fd);
+    SSL_set_tlsext_host_name(ssl, host);
+    SSL_set1_host(ssl, host);
+    SSL_set_verify(ssl, SSL_VERIFY_PEER, NULL);
+    if (SSL_connect(ssl) != 1) { SSL_free(ssl); close(fd); return NULL; }
+    return ssl;
+}
+
+static void mfl_tls_hangup(SSL* ssl) {
+    if (!ssl) return;
+    int fd = SSL_get_fd(ssl);
+    SSL_shutdown(ssl);
+    if (fd >= 0) close(fd);
+    SSL_free(ssl);
+}
+`
+
+// tlsRuntime is a minimal HTTPS/1.1 client built on tlsCoreRuntime. Emitted only
+// when a program calls https_get/https_post. Handles cert verification,
+// Content-Length, chunked transfer-encoding, and redirects; returns the body.
+const tlsRuntime = `
 /* read the whole TLS stream into a malloc'd buffer (caller frees); NUL-terminated */
 static char* mfl_tls_readall(SSL* ssl, size_t* outlen) {
     size_t cap = 16384, len = 0;
@@ -528,35 +585,10 @@ static char* mfl_https_request(const char* method, const char* url, const char* 
     if (*p == ':') { p++; port = atoi(p); while (*p && *p != '/') p++; }
     if (*p == '/') strncpy(path, p, sizeof(path) - 1);
     else { path[0] = '/'; path[1] = 0; }
-    if (port != 443 && strncmp(url, "http://", 7) == 0) return mfl_dup_arena("", 0); /* TLS only */
+    if (strncmp(url, "http://", 7) == 0) return mfl_dup_arena("", 0); /* TLS only */
 
-    struct addrinfo hints, *res = NULL;
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    char ports[16];
-    snprintf(ports, sizeof(ports), "%d", port);
-    if (getaddrinfo(host, ports, &hints, &res) != 0) return mfl_dup_arena("", 0);
-    int fd = -1;
-    for (struct addrinfo* a = res; a; a = a->ai_next) {
-        fd = socket(a->ai_family, a->ai_socktype, a->ai_protocol);
-        if (fd < 0) continue;
-        if (connect(fd, a->ai_addr, a->ai_addrlen) == 0) break;
-        close(fd);
-        fd = -1;
-    }
-    freeaddrinfo(res);
-    if (fd < 0) return mfl_dup_arena("", 0);
-
-    SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
-    if (!ctx) { close(fd); return mfl_dup_arena("", 0); }
-    SSL_CTX_set_default_verify_paths(ctx);
-    SSL* ssl = SSL_new(ctx);
-    SSL_set_fd(ssl, fd);
-    SSL_set_tlsext_host_name(ssl, host);
-    SSL_set1_host(ssl, host);
-    SSL_set_verify(ssl, SSL_VERIFY_PEER, NULL);
-    if (SSL_connect(ssl) != 1) { SSL_free(ssl); SSL_CTX_free(ctx); close(fd); return mfl_dup_arena("", 0); }
+    SSL* ssl = mfl_tls_dial(host, port);
+    if (!ssl) return mfl_dup_arena("", 0);
 
     size_t blen = reqbody ? strlen(reqbody) : 0;
     size_t reqcap = blen + strlen(path) + strlen(host) + 256 + (ctype ? strlen(ctype) : 0);
@@ -578,10 +610,7 @@ static char* mfl_https_request(const char* method, const char* url, const char* 
 
     size_t rlen;
     char* raw = mfl_tls_readall(ssl, &rlen);
-    SSL_shutdown(ssl);
-    SSL_free(ssl);
-    SSL_CTX_free(ctx);
-    close(fd);
+    mfl_tls_hangup(ssl);
 
     int status = 0;
     { const char* sp = strchr(raw, ' '); if (sp) status = atoi(sp + 1); }
@@ -634,6 +663,171 @@ static char* mfl_https_request(const char* method, const char* url, const char* 
 
 static char* mfl_https_get(const char* url) { return mfl_https_request("GET", url, NULL, NULL, 5); }
 static char* mfl_https_post(const char* url, const char* body) { return mfl_https_request("POST", url, body, "application/json", 5); }
+`
+
+// wssRuntime is a WebSocket (RFC 6455) client over TLS, built on tlsCoreRuntime.
+// Emitted only when a program calls wss_*. wss_open performs the HTTP/1.1 Upgrade
+// handshake; send/recv implement client frame masking, fragmentation reassembly,
+// and automatic ping->pong / close handling. The connection is held as an int64
+// handle (a pointer), matching how machin carries opaque FFI handles.
+const wssRuntime = `
+typedef struct { SSL* ssl; } mfl_ws;
+
+/* read exactly n bytes from the TLS stream; 0 ok, -1 on EOF/error */
+static int mfl_ssl_read_n(SSL* ssl, unsigned char* buf, size_t n) {
+    size_t got = 0;
+    while (got < n) {
+        int r = SSL_read(ssl, buf + got, (int)(n - got));
+        if (r <= 0) return -1;
+        got += (size_t)r;
+    }
+    return 0;
+}
+
+static void mfl_b64(const unsigned char* in, int len, char* out) {
+    static const char* t = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    int o = 0;
+    for (int i = 0; i < len; i += 3) {
+        int n = in[i] << 16;
+        if (i + 1 < len) n |= in[i+1] << 8;
+        if (i + 2 < len) n |= in[i+2];
+        out[o++] = t[(n >> 18) & 63];
+        out[o++] = t[(n >> 12) & 63];
+        out[o++] = (i + 1 < len) ? t[(n >> 6) & 63] : '=';
+        out[o++] = (i + 2 < len) ? t[n & 63] : '=';
+    }
+    out[o] = 0;
+}
+
+/* write one masked client frame (opcode, payload). Client frames must be masked. */
+static void mfl_ws_frame(mfl_ws* w, int opcode, const unsigned char* payload, size_t len) {
+    unsigned char hdr[14];
+    int h = 0;
+    hdr[h++] = (unsigned char)(0x80 | (opcode & 0x0f));
+    if (len < 126) {
+        hdr[h++] = (unsigned char)(0x80 | len);
+    } else if (len < 65536) {
+        hdr[h++] = 0x80 | 126;
+        hdr[h++] = (unsigned char)((len >> 8) & 0xff);
+        hdr[h++] = (unsigned char)(len & 0xff);
+    } else {
+        hdr[h++] = 0x80 | 127;
+        for (int s = 56; s >= 0; s -= 8) hdr[h++] = (unsigned char)((len >> s) & 0xff);
+    }
+    unsigned char mask[4];
+    RAND_bytes(mask, 4);
+    memcpy(hdr + h, mask, 4);
+    h += 4;
+    unsigned char* buf = (unsigned char*)malloc(h + len);
+    memcpy(buf, hdr, h);
+    for (size_t k = 0; k < len; k++) buf[h + k] = payload[k] ^ mask[k & 3];
+    SSL_write(w->ssl, buf, (int)(h + len));
+    free(buf);
+}
+
+static int64_t mfl_wss_open(const char* url) {
+    char host[256] = {0}, path[2048] = {0};
+    int port = 443;
+    const char* p = url;
+    if (strncmp(p, "wss://", 6) == 0) p += 6;
+    else if (strncmp(p, "ws://", 5) == 0) return 0; /* TLS only */
+    else return 0;
+    int i = 0;
+    while (*p && *p != '/' && *p != ':' && i < 255) host[i++] = *p++;
+    host[i] = 0;
+    if (*p == ':') { p++; port = atoi(p); while (*p && *p != '/') p++; }
+    if (*p == '/') strncpy(path, p, sizeof(path) - 1);
+    else { path[0] = '/'; path[1] = 0; }
+
+    SSL* ssl = mfl_tls_dial(host, port);
+    if (!ssl) return 0;
+
+    unsigned char rnd[16];
+    RAND_bytes(rnd, 16);
+    char key[32];
+    mfl_b64(rnd, 16, key);
+    char req[4096];
+    int rl = snprintf(req, sizeof(req),
+        "GET %s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\nUser-Agent: machin/0.9\r\n\r\n",
+        path, host, key);
+    SSL_write(ssl, req, rl);
+
+    /* read the handshake response one byte at a time so we stop exactly at the
+       blank line and never swallow the first data frame */
+    char resp[4096];
+    int ro = 0;
+    while (ro < (int)sizeof(resp) - 1) {
+        int r = SSL_read(ssl, resp + ro, 1);
+        if (r <= 0) break;
+        ro++;
+        if (ro >= 4 && resp[ro-4] == '\r' && resp[ro-3] == '\n' && resp[ro-2] == '\r' && resp[ro-1] == '\n') break;
+    }
+    resp[ro] = 0;
+    if (!strstr(resp, " 101")) { mfl_tls_hangup(ssl); return 0; }
+
+    mfl_ws* w = (mfl_ws*)malloc(sizeof(mfl_ws));
+    w->ssl = ssl;
+    return (int64_t)(intptr_t)w;
+}
+
+static int64_t mfl_wss_send(int64_t h, const char* msg) {
+    mfl_ws* w = (mfl_ws*)(intptr_t)h;
+    if (!w) return -1;
+    mfl_ws_frame(w, 0x1, (const unsigned char*)msg, strlen(msg));
+    return 0;
+}
+
+/* block until a full text/binary message arrives; "" on close or error.
+   Replies to pings, ignores pongs, and reassembles fragmented messages. */
+static char* mfl_wss_recv(int64_t h) {
+    mfl_ws* w = (mfl_ws*)(intptr_t)h;
+    if (!w) return mfl_dup_arena("", 0);
+    unsigned char* msg = NULL;
+    size_t mlen = 0;
+    for (;;) {
+        unsigned char hd[2];
+        if (mfl_ssl_read_n(w->ssl, hd, 2) < 0) { free(msg); return mfl_dup_arena("", 0); }
+        int fin = hd[0] & 0x80;
+        int opcode = hd[0] & 0x0f;
+        int masked = hd[1] & 0x80;
+        uint64_t len = hd[1] & 0x7f;
+        if (len == 126) {
+            unsigned char e[2];
+            if (mfl_ssl_read_n(w->ssl, e, 2) < 0) { free(msg); return mfl_dup_arena("", 0); }
+            len = ((uint64_t)e[0] << 8) | e[1];
+        } else if (len == 127) {
+            unsigned char e[8];
+            if (mfl_ssl_read_n(w->ssl, e, 8) < 0) { free(msg); return mfl_dup_arena("", 0); }
+            len = 0;
+            for (int s = 0; s < 8; s++) len = (len << 8) | e[s];
+        }
+        unsigned char mk[4] = {0,0,0,0};
+        if (masked && mfl_ssl_read_n(w->ssl, mk, 4) < 0) { free(msg); return mfl_dup_arena("", 0); }
+        unsigned char* pl = (unsigned char*)malloc(len ? len : 1);
+        if (len && mfl_ssl_read_n(w->ssl, pl, len) < 0) { free(pl); free(msg); return mfl_dup_arena("", 0); }
+        if (masked) for (uint64_t k = 0; k < len; k++) pl[k] ^= mk[k & 3];
+
+        if (opcode == 0x9) { mfl_ws_frame(w, 0xA, pl, len); free(pl); continue; } /* ping -> pong */
+        if (opcode == 0xA) { free(pl); continue; }                                /* pong */
+        if (opcode == 0x8) { mfl_ws_frame(w, 0x8, pl, len); free(pl); free(msg); return mfl_dup_arena("", 0); } /* close */
+
+        unsigned char* nm = (unsigned char*)realloc(msg, mlen + len);
+        msg = nm;
+        if (len) memcpy(msg + mlen, pl, len);
+        mlen += len;
+        free(pl);
+        if (fin) { char* r = mfl_dup_arena((char*)msg, mlen); free(msg); return r; }
+    }
+}
+
+static int64_t mfl_wss_close(int64_t h) {
+    mfl_ws* w = (mfl_ws*)(intptr_t)h;
+    if (!w) return -1;
+    mfl_ws_frame(w, 0x8, NULL, 0);
+    mfl_tls_hangup(w->ssl);
+    free(w);
+    return 0;
+}
 `
 
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
@@ -762,10 +956,18 @@ func (g *cgen) program(p *Program) (string, error) {
 	var out strings.Builder
 	out.WriteString(cRuntime)
 	out.WriteByte('\n')
+	if g.usesTLS || g.usesWSS {
+		// OpenSSL plumbing — emitted (and linked) only when a program uses native
+		// TLS (https_* or wss_*), so TLS-free programs stay libc-only.
+		out.WriteString(tlsCoreRuntime)
+		out.WriteByte('\n')
+	}
 	if g.usesTLS {
-		// Emitted (and linked against OpenSSL) only when a program calls
-		// https_get/https_post, so TLS-free programs stay libc-only.
 		out.WriteString(tlsRuntime)
+		out.WriteByte('\n')
+	}
+	if g.usesWSS {
+		out.WriteString(wssRuntime)
 		out.WriteByte('\n')
 	}
 	// foreign (extern) declarations. With a header, its prototypes + C structs are
@@ -1881,6 +2083,18 @@ func (g *cgen) call(ex *Call) (string, error) {
 	case "https_post":
 		g.usesTLS = true
 		return fmt.Sprintf("mfl_https_post(%s, %s)", args[0], args[1]), nil
+	case "wss_open":
+		g.usesWSS = true
+		return fmt.Sprintf("mfl_wss_open(%s)", args[0]), nil
+	case "wss_send":
+		g.usesWSS = true
+		return fmt.Sprintf("mfl_wss_send(%s, %s)", args[0], args[1]), nil
+	case "wss_recv":
+		g.usesWSS = true
+		return fmt.Sprintf("mfl_wss_recv(%s)", args[0]), nil
+	case "wss_close":
+		g.usesWSS = true
+		return fmt.Sprintf("mfl_wss_close(%s)", args[0]), nil
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
 	}

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -557,6 +557,31 @@ func TestHTTPSRuntimeGating(t *testing.T) {
 	}
 }
 
+// The WebSocket runtime is emitted only when a program calls wss_*; it shares
+// the TLS core (mfl_tls_dial) with HTTPS but pulls in the WS framing separately.
+func TestWSSRuntimeGating(t *testing.T) {
+	ws := &Program{Funcs: parseFuncs(t, `func main() { c := wss_open("wss://x") println(wss_recv(c)) }`)}
+	c, err := CompileToC(ws, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_wss_open") || !strings.Contains(c, "mfl_tls_dial") || !strings.Contains(c, "openssl/ssl.h") {
+		t.Fatal("a program using wss_* must emit the WebSocket runtime atop the TLS core")
+	}
+	// HTTPS-only must NOT pull in the WSS framing.
+	https := &Program{Funcs: parseFuncs(t, `func main() { println(https_get("https://x")) }`)}
+	c2, err := CompileToC(https, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(c2, "mfl_wss_") {
+		t.Fatal("an HTTPS-only program must not emit the WebSocket runtime")
+	}
+	if !strings.Contains(c2, "mfl_tls_dial") {
+		t.Fatal("HTTPS must build on the shared TLS core (mfl_tls_dial)")
+	}
+}
+
 // break exits the nearest loop; continue skips to the next iteration — in
 // bare for{}, condition for-loops, and range loops.
 func TestBreakContinue(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -1669,6 +1669,31 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cString)
 		c.addPair(argSlots[1], c.cString)
 		return c.cString, nil
+	case "wss_open":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("wss_open: 1 arg (url string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cInt, nil
+	case "wss_send":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("wss_send: 2 args (conn int, msg string)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cString)
+		return c.cInt, nil
+	case "wss_recv":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("wss_recv: 1 arg (conn int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cString, nil
+	case "wss_close":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("wss_close: 1 arg (conn int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cInt, nil
 	case "write":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("write: 2 args")


### PR DESCRIPTION
machin's last networking gap was **no `wss://`** — a streaming scraper had to shell out to `websocat`. This adds a native WebSocket client over the existing OpenSSL TLS, no subprocess.

## Surface
- `wss_open(url) -> int` — HTTP/1.1 Upgrade handshake; returns a connection handle (0 on failure)
- `wss_send(conn, msg) -> int` — masks + writes a text frame
- `wss_recv(conn) -> string` — blocks for the next message; `""` on close
- `wss_close(conn) -> int` — sends close, tears down

Implements client frame **masking**, extended length (126/127), **fragment reassembly**, and transparent **ping→pong** / close handling.

## Shared TLS core
Refactors the TLS connect out of the HTTPS client into `mfl_tls_dial` + one process-global `SSL_CTX`; HTTPS and WSS both build on it. Runtime + `-lssl -lcrypto` are emitted **only when `https_*` or `wss_*` are used** — verified a plain program stays libc-only, a wss program links OpenSSL.

## Verified live
- echo round-trip (`ws.postman-echo.com/raw`)
- a real **Polymarket CLOB stream** — token resolved with `https_get`, frames streamed with `wss_*`, **fully native** (no curl, no websocat). Received a 3.5 KB `book` snapshot + `price_change` frames.

`TestWSSRuntimeGating` + HTTPS regression green; full suite green. SPEC + CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)