### PR TITLE
release: v0.10.0 (native WebSocket)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.10.0
 
 - **Native WebSocket — `wss_open`, `wss_send`, `wss_recv`, `wss_close`.** A
   `wss://` client (RFC 6455) over real TLS, no subprocess. `wss_open(url)` does

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.9.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.10.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.9.0
+Version 0.10.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.10.0**, capturing the native WebSocket client (#120) already on `main`:

- **`wss_open` / `wss_send` / `wss_recv` / `wss_close`** — an RFC 6455 `wss://` client over the shared OpenSSL TLS core; masking, fragment reassembly, ping/pong, close. Emitted + linked (`-lssl -lcrypto`) only when used.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.10.0). Full suite green. On merge I'll tag `v0.10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)