### PR TITLE
feat: error handling at the builtin layer — http_get (status, body, err) + exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+- **Error handling reaches the builtins — `http_get` returns `(status, body, err)`.**
+  machin's HTTP builtins collapsed every failure to `""`: a 404, a 503, an
+  empty-but-OK body, and an unreachable host were indistinguishable, so a program
+  couldn't *handle* errors. `http_get(url)` brings the Go-style `value, err :=`
+  idiom to the builtin layer — `status, body, err := http_get(url)`, where a
+  non-empty `err` is a transport failure (`"dns"`/`"connect"`/`"tls"`/`"scheme"`)
+  and otherwise `status` is the real HTTP code. The multi-assign destructure path
+  now recognizes multi-return builtins; the existing `https_get`/`https_post`
+  (body-only) are unchanged, both now built on the same status-aware core.
+  Surfaced building a link checker that has to classify why a URL is broken.
+- **`exit(code)`.** Terminate the process with a status code — so a CLI can fail
+  CI on a bad result (the link checker exits non-zero on a broken link).
+
 ## v0.10.0
 
 - **Native WebSocket — `wss_open`, `wss_send`, `wss_recv`, `wss_close`.** A

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels; per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`, `args`/`env`/`now`/`now_ms`/`parse_int`, string ops
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`, `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`, string ops
+- **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -215,6 +215,7 @@ throughout the function body).
 | `now` | `() -> int` | wall-clock time in Unix seconds |
 | `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
+| `exit` | `(int) -> ` | terminate the process with a status code |
 | `read_file` | `(string) -> string` | read a whole file ("" on error) |
 | `write_file` | `(string, string) -> int` | write a file (bytes written; -1 on error) |
 | `list_dir` | `(string) -> []string` | directory entries (excludes `.`/`..`) |
@@ -243,6 +244,7 @@ throughout the function body).
 | `close` | `(int) -> ` | close a socket/fd |
 | `https_get` | `(string) -> string` | HTTPS GET over TLS; response body ("" on error) |
 | `https_post` | `(string, string) -> string` | HTTPS POST (JSON body) over TLS; response body |
+| `http_get` | `(string) -> (int, string, string)` | GET returning `(status, body, err)`; `err==""` ⇒ a response, else `"dns"`/`"connect"`/`"tls"`/`"scheme"`. Multi-assign only. |
 | `wss_open` | `(string) -> int` | open a `wss://` WebSocket; a connection handle, or 0 on failure |
 | `wss_send` | `(int, string) -> int` | send a text message on a WebSocket |
 | `wss_recv` | `(int) -> string` | next message (blocks); `""` on close (auto ping/pong) |

--- a/codegen.go
+++ b/codegen.go
@@ -157,6 +157,7 @@ static mfl_slice mfl_lit_str(int64_t n, ...) {
     for (int64_t i = 0; i < n; i++) ((char**)s.data)[i] = va_arg(ap, char*);
     va_end(ap); return s;
 }
+static int64_t mfl_exit(int64_t code) { exit((int)code); return 0; }
 static void mfl_sleep(int64_t ms) {
     struct timespec ts = { ms / 1000, (ms % 1000) * 1000000L };
     nanosleep(&ts, NULL);
@@ -488,15 +489,16 @@ static SSL_CTX* mfl_ssl_ctx(void) {
 }
 
 /* dial host:port and complete a verified TLS handshake (SNI + hostname).
-   Returns a connected SSL* (fd retrievable via SSL_get_fd) or NULL. */
-static SSL* mfl_tls_dial(const char* host, int port) {
+   Returns a connected SSL* (fd retrievable via SSL_get_fd) or NULL. On failure,
+   *stage (if non-NULL) is set to why: "dns", "connect", or "tls". */
+static SSL* mfl_tls_dial_e(const char* host, int port, const char** stage) {
     struct addrinfo hints, *res = NULL;
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     char ports[16];
     snprintf(ports, sizeof(ports), "%d", port);
-    if (getaddrinfo(host, ports, &hints, &res) != 0) return NULL;
+    if (getaddrinfo(host, ports, &hints, &res) != 0) { if (stage) *stage = "dns"; return NULL; }
     int fd = -1;
     for (struct addrinfo* a = res; a; a = a->ai_next) {
         fd = socket(a->ai_family, a->ai_socktype, a->ai_protocol);
@@ -506,17 +508,19 @@ static SSL* mfl_tls_dial(const char* host, int port) {
         fd = -1;
     }
     freeaddrinfo(res);
-    if (fd < 0) return NULL;
+    if (fd < 0) { if (stage) *stage = "connect"; return NULL; }
     SSL_CTX* ctx = mfl_ssl_ctx();
-    if (!ctx) { close(fd); return NULL; }
+    if (!ctx) { if (stage) *stage = "tls"; close(fd); return NULL; }
     SSL* ssl = SSL_new(ctx);
     SSL_set_fd(ssl, fd);
     SSL_set_tlsext_host_name(ssl, host);
     SSL_set1_host(ssl, host);
     SSL_set_verify(ssl, SSL_VERIFY_PEER, NULL);
-    if (SSL_connect(ssl) != 1) { SSL_free(ssl); close(fd); return NULL; }
+    if (SSL_connect(ssl) != 1) { if (stage) *stage = "tls"; SSL_free(ssl); close(fd); return NULL; }
     return ssl;
 }
+
+static SSL* mfl_tls_dial(const char* host, int port) { return mfl_tls_dial_e(host, port, NULL); }
 
 static void mfl_tls_hangup(SSL* ssl) {
     if (!ssl) return;
@@ -571,24 +575,34 @@ static char* mfl_chunk_decode(const char* body, size_t blen, size_t* outlen) {
     return out;
 }
 
-static char* mfl_https_request(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects);
+/* (status, body, err) — err is "" on an HTTP response (status is the code), or a
+   transport-failure reason ("dns"/"connect"/"tls"/"scheme") with status 0. */
+typedef struct { int64_t status; char* body; char* err; } mfl_http_result;
 
-static char* mfl_https_request(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects) {
+static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects);
+
+static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects) {
+    mfl_http_result R;
+    R.status = 0;
+    R.body = mfl_dup_arena("", 0);
+    R.err = mfl_dup_arena("", 0);
+
     char host[256] = {0}, path[2048] = {0};
     int port = 443;
     const char* p = url;
     if (strncmp(p, "https://", 8) == 0) p += 8;
-    else if (strncmp(p, "http://", 7) == 0) { p += 7; port = 80; }
+    else if (strncmp(p, "http://", 7) == 0) { R.err = mfl_dup_arena("scheme", 6); return R; } /* TLS only */
+    /* else: no scheme — assume https */
     int i = 0;
     while (*p && *p != '/' && *p != ':' && i < 255) host[i++] = *p++;
     host[i] = 0;
     if (*p == ':') { p++; port = atoi(p); while (*p && *p != '/') p++; }
     if (*p == '/') strncpy(path, p, sizeof(path) - 1);
     else { path[0] = '/'; path[1] = 0; }
-    if (strncmp(url, "http://", 7) == 0) return mfl_dup_arena("", 0); /* TLS only */
 
-    SSL* ssl = mfl_tls_dial(host, port);
-    if (!ssl) return mfl_dup_arena("", 0);
+    const char* stage = "connect";
+    SSL* ssl = mfl_tls_dial_e(host, port, &stage);
+    if (!ssl) { R.err = mfl_dup_arena(stage, strlen(stage)); return R; }
 
     size_t blen = reqbody ? strlen(reqbody) : 0;
     size_t reqcap = blen + strlen(path) + strlen(host) + 256 + (ctype ? strlen(ctype) : 0);
@@ -614,8 +628,9 @@ static char* mfl_https_request(const char* method, const char* url, const char* 
 
     int status = 0;
     { const char* sp = strchr(raw, ' '); if (sp) status = atoi(sp + 1); }
+    R.status = status;
     char* hb = strstr(raw, "\r\n\r\n");
-    if (!hb) { char* r = mfl_dup_arena(raw, rlen); free(raw); return r; }
+    if (!hb) { R.body = mfl_dup_arena(raw, rlen); free(raw); return R; }
     size_t hdrlen = (size_t)(hb - raw);
     char* body = hb + 4;
     size_t bodylen = rlen - (size_t)(body - raw);
@@ -637,17 +652,16 @@ static char* mfl_https_request(const char* method, const char* url, const char* 
                 free(raw);
                 const char* m = (status == 307 || status == 308) ? method : "GET";
                 const char* rb = (status == 307 || status == 308) ? reqbody : NULL;
-                return mfl_https_request(m, locurl, rb, ctype, redirects - 1);
+                return mfl_http_do(m, locurl, rb, ctype, redirects - 1);
             }
         }
     }
 
     char* hdrs = mfl_dup_arena(raw, hdrlen);
-    char* result;
     if (strcasestr(hdrs, "transfer-encoding: chunked") || strcasestr(hdrs, "transfer-encoding:chunked")) {
         size_t dl;
         char* dec = mfl_chunk_decode(body, bodylen, &dl);
-        result = mfl_dup_arena(dec, dl);
+        R.body = mfl_dup_arena(dec, dl);
         free(dec);
     } else {
         char* cl = strcasestr(hdrs, "content-length:");
@@ -655,14 +669,15 @@ static char* mfl_https_request(const char* method, const char* url, const char* 
             size_t want = (size_t)strtoul(cl + strlen("content-length:"), NULL, 10);
             if (want < bodylen) bodylen = want;
         }
-        result = mfl_dup_arena(body, bodylen);
+        R.body = mfl_dup_arena(body, bodylen);
     }
     free(raw);
-    return result;
+    return R;
 }
 
-static char* mfl_https_get(const char* url) { return mfl_https_request("GET", url, NULL, NULL, 5); }
-static char* mfl_https_post(const char* url, const char* body) { return mfl_https_request("POST", url, body, "application/json", 5); }
+static char* mfl_https_get(const char* url) { return mfl_http_do("GET", url, NULL, NULL, 5).body; }
+static char* mfl_https_post(const char* url, const char* body) { return mfl_http_do("POST", url, body, "application/json", 5).body; }
+static mfl_http_result mfl_http_get(const char* url) { return mfl_http_do("GET", url, NULL, NULL, 5); }
 `
 
 // wssRuntime is a WebSocket (RFC 6455) client over TLS, built on tlsCoreRuntime.
@@ -1316,6 +1331,25 @@ func (g *cgen) multiAssign(st *MultiAssign, depth int) error {
 	}
 
 	if len(st.Rhs) == 1 {
+		// multi-return builtin: http_get -> (status, body, err)
+		if call, isCall := st.Rhs[0].(*Call); isCall && call.Callee == "http_get" {
+			g.usesTLS = true
+			arg, err := g.expr(call.Args[0])
+			if err != nil {
+				return err
+			}
+			id := g.tmpID
+			g.tmpID++
+			g.buf.WriteString("{\n")
+			indentC(&g.buf, depth+1)
+			fmt.Fprintf(&g.buf, "mfl_http_result _t%d = mfl_http_get(%s);\n", id, arg)
+			assign(st.Names[0], fmt.Sprintf("_t%d.status", id))
+			assign(st.Names[1], fmt.Sprintf("_t%d.body", id))
+			assign(st.Names[2], fmt.Sprintf("_t%d.err", id))
+			indentC(&g.buf, depth)
+			g.buf.WriteString("}\n")
+			return nil
+		}
 		call, isCall := st.Rhs[0].(*Call)
 		if isCall && g.c.CalleeInst(g.curFn, call) != "" && g.c.RetArity(g.c.CalleeInst(g.curFn, call)) >= 2 {
 			args := make([]string, len(call.Args))
@@ -2038,6 +2072,8 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return fmt.Sprintf("mfl_append(%s, &((%s[1]){%s})[0], sizeof(%s))", args[0], ct, args[1], ct), nil
 	case "sleep":
 		return fmt.Sprintf("mfl_sleep(%s)", args[0]), nil
+	case "exit":
+		return fmt.Sprintf("mfl_exit(%s)", args[0]), nil
 	case "str":
 		if g.c.NodeKind(g.curFn, ex.Args[0]) == KFloat {
 			return fmt.Sprintf("mfl_str_d(%s)", args[0]), nil

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -544,7 +544,7 @@ func TestHTTPSRuntimeGating(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(c, "mfl_https_request") || !strings.Contains(c, "openssl/ssl.h") {
+	if !strings.Contains(c, "mfl_http_do") || !strings.Contains(c, "openssl/ssl.h") {
 		t.Fatal("a program using https_get must emit the OpenSSL TLS runtime")
 	}
 	plain := &Program{Funcs: parseFuncs(t, `func main() { println("hi") }`)}
@@ -554,6 +554,25 @@ func TestHTTPSRuntimeGating(t *testing.T) {
 	}
 	if strings.Contains(c2, "mfl_https_") || strings.Contains(c2, "openssl") {
 		t.Fatal("a TLS-free program must stay libc-only (no OpenSSL emitted)")
+	}
+}
+
+// http_get returns (status, body, err) via the v, err := idiom — the multi-return
+// builtin path. Compiling must wire the destructure; using it as a single value
+// must fail with a helpful message.
+func TestHTTPGetMultiReturn(t *testing.T) {
+	prog := &Program{Funcs: parseFuncs(t, `func main() { s, b, e := http_get("https://x") println(str(s) + b + e) }`)}
+	c, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_http_result") || !strings.Contains(c, "mfl_http_get") {
+		t.Fatal("http_get multi-return must emit the result struct + accessor")
+	}
+	// single-value misuse is a clear typecheck error, not a silent miscompile
+	bad := &Program{Funcs: parseFuncs(t, `func main() { x := http_get("https://x") println(x) }`)}
+	if _, err := CompileToC(bad, false); err == nil || !strings.Contains(err.Error(), "returns 3 values") {
+		t.Fatalf("single-value http_get should error helpfully, got: %v", err)
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -1292,6 +1292,18 @@ func (c *Checker) genBinary(fn *FuncDecl, ex *Binary) (int, error) {
 	return 0, fmt.Errorf("unknown operator %q", ex.Op)
 }
 
+// multiRetBuiltin reports the argument and return type slots for builtins that
+// return multiple values via the Go-style `v, err := f()` idiom (err == "" means
+// success). This is how error handling reaches the builtin layer: a call like
+// http_get gives back (status, body, err) instead of collapsing failure to "".
+func (c *Checker) multiRetBuiltin(name string) (args []int, rets []int, ok bool) {
+	switch name {
+	case "http_get":
+		return []int{c.cString}, []int{c.cInt, c.cString, c.cString}, true
+	}
+	return nil, nil, false
+}
+
 func (c *Checker) genMultiAssign(fn *FuncDecl, st *MultiAssign) error {
 	env := c.vars[fn.Name]
 	nameSlots := make([]int, len(st.Names))
@@ -1313,6 +1325,28 @@ func (c *Checker) genMultiAssign(fn *FuncDecl, st *MultiAssign) error {
 	}
 
 	if len(st.Rhs) == 1 {
+		// a multi-return builtin (e.g. http_get -> status, body, err)
+		if call, ok := st.Rhs[0].(*Call); ok {
+			if aks, rks, isMRB := c.multiRetBuiltin(call.Callee); isMRB {
+				if len(call.Args) != len(aks) {
+					return fmt.Errorf("%s: expected %d args, got %d", call.Callee, len(aks), len(call.Args))
+				}
+				for i, a := range call.Args {
+					as, err := c.genExpr(fn, a)
+					if err != nil {
+						return err
+					}
+					c.addPair(as, aks[i])
+				}
+				if len(rks) != len(st.Names) {
+					return fmt.Errorf("%s returns %d values but %d are assigned", call.Callee, len(rks), len(st.Names))
+				}
+				for i := range rks {
+					c.addPair(nameSlots[i], rks[i])
+				}
+				return nil
+			}
+		}
 		// a single call returning multiple values destructures across the names
 		if call, ok := st.Rhs[0].(*Call); ok {
 			if srcFn, isUser := c.funcs[call.Callee]; isUser && funcArity(srcFn) >= 2 {
@@ -1669,6 +1703,14 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cString)
 		c.addPair(argSlots[1], c.cString)
 		return c.cString, nil
+	case "exit":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("exit: 1 arg (status code int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cInt, nil
+	case "http_get":
+		return 0, fmt.Errorf("http_get returns 3 values; use: status, body, err := http_get(url)")
 	case "wss_open":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("wss_open: 1 arg (url string)")


### PR DESCRIPTION
machin's HTTP builtins collapsed every failure to `""` — a 404, a 503, an empty-but-OK body, and an unreachable host were **indistinguishable**, so programs couldn't *handle* errors. This brings Go's `value, err :=` idiom to the builtin layer.

## Surface
- `http_get(url) -> (status, body, err)` — `err == ""` means a response arrived (`status` is the real HTTP code); a non-empty `err` is a transport failure (`"dns"`/`"connect"`/`"tls"`/`"scheme"`). Multi-assign only; single-value use is a clear typecheck error.
- `exit(code)` — terminate with a status code (fail CI on a bad result).

## How
- The multi-assign destructure path now recognizes **multi-return builtins** (`multiRetBuiltin`), emitting a result struct + field destructure — the first builtin to return `(value, err)`, a pattern future builtins can adopt.
- `mfl_tls_dial` reports its failure stage (dns/connect/tls); `https_get`/`https_post` are refactored onto the same status-aware core (`mfl_http_do`) with **unchanged signatures**.

## Verified live
`200 OK` · `404 CLIENT ERROR` (with body) · `503 SERVER ERROR` (empty body) · `UNREACHABLE (dns)` · `scheme` — all distinguishable, driving a concurrent link checker that exits non-zero on broken links.

`TestHTTPGetMultiReturn` + HTTPS/WSS regressions green; full suite green. SPEC + CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `http_get()` now returns status code, body, and error information in a single call using multi-assignment syntax.
  * Added `exit()` function to terminate the process with a specified status code.

* **Improvements**
  * Enhanced error handling distinguishes between transport failures (DNS, connection, TLS, scheme) and HTTP status codes.
  * Requests to unreachable hosts are now distinguishable from HTTP error responses (404, 503, etc.).

* **Documentation**
  * Updated language specification with new builtin functions and error handling semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->