### PR TITLE
release: v0.11.0 (error handling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.11.0
 
 - **Error handling reaches the builtins — `http_get` returns `(status, body, err)`.**
   machin's HTTP builtins collapsed every failure to `""`: a 404, a 503, an

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.10.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.11.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.10.0
+Version 0.11.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.11.0**, capturing builtin-layer error handling (#122) already on `main`:

- **`http_get(url) -> (status, body, err)`** — the `value, err :=` idiom at the builtin layer; a 404, a 503, and an unreachable host are all distinguishable.
- **`exit(code)`** — terminate with a status code.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.11.0). Full suite green. On merge I'll tag `v0.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)