### PR TITLE
release: v0.12.0 (JSON path queries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.12.0
 
 - **JSON path queries — `json_get(json, path)`.** Every machin tool used to dig
   into JSON with fragile substring search. `json_get` walks a jq-style path

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.11.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.12.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.11.0
+Version 0.12.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.12.0**, capturing the native JSON path engine (#124) already on `main`:

- **`json_get(json, path) -> (value, err)`** — a jq-style path query (`.key`, `[index]`, chained, `.` for whole doc); non-allocating scanner, the second `value, err :=` builtin.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.12.0). Full suite green. On merge I'll tag `v0.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)