### PR TITLE
feat: channel close + range-over-channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- **Channel `close` + range-over-channel.** Channels could be made and used but
+  never closed, so a consumer had no clean "no more data" signal — pools stopped
+  via sentinel values and a stray `range`/receive blocked forever. `close(ch)`
+  now marks a channel done (waking every blocked receiver); a receive drains the
+  buffer then yields the zero value, and **`for v := range ch`** loops until the
+  channel is closed and drained. `close` dispatches on its argument — a channel
+  closes the channel, an fd still closes the fd. Built on a new `mfl_chan_recv2`
+  (receive-with-ok) primitive. Surfaced building a streaming fetch pipeline whose
+  stages terminate by closing their channels.
+
 ## v0.13.0
 
 - **`select` — wait on multiple channels.** machin had goroutines and channels

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 
 - **Types** (all inferred, unboxed): `int` `float` `bool` `string`, slices `[]T`, maps `map[K]V`, structs, `func` values
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
-- **Concurrency**: goroutines (`go`), channels, `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
+- **Concurrency**: goroutines (`go`), channels (`close` + `for v := range ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
 - **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`, string ops
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)

--- a/SPEC.md
+++ b/SPEC.md
@@ -196,6 +196,8 @@ throughout the function body).
   - `for cond { ... }` and `for { ... }` (infinite)
   - `for k, v := range x { ... }` over a slice (index, element), map (key,
     value), or string (index, 1-char). Either variable may be `_`.
+  - `for v := range ch { ... }` over a channel: receives each value until the
+    channel is closed and drained, then ends. One variable (the element).
   - `break` exits the innermost loop; `continue` skips to its next iteration.
 - `return`, `return e`, `return e1, e2`.
 - `x[i] = v`, `x.f = v`.
@@ -247,7 +249,7 @@ throughout the function body).
 | `dial` | `(string, int) -> int` | connect to host:port; an fd, or -1 on failure |
 | `listen`, `accept` | `(int) -> int` | open / accept on a TCP socket |
 | `read`, `write` | `(int[, string]) -> string\|int` | socket/fd I/O |
-| `close` | `(int) -> ` | close a socket/fd |
+| `close` | `(int\|chan) -> ` | close a socket/fd, or a channel (dispatched by argument) |
 | `https_get` | `(string) -> string` | HTTPS GET over TLS; response body ("" on error) |
 | `https_post` | `(string, string) -> string` | HTTPS POST (JSON body) over TLS; response body |
 | `http_get` | `(string) -> (int, string, string)` | GET returning `(status, body, err)`; `err==""` ⇒ a response, else `"dns"`/`"connect"`/`"tls"`/`"scheme"`. Multi-assign only. |

--- a/codegen.go
+++ b/codegen.go
@@ -167,13 +167,21 @@ static void mfl_sleep(int64_t ms) {
 typedef struct mfl_cnode { struct mfl_cnode* next; void* data; } mfl_cnode;
 typedef struct {
     pthread_mutex_t mu; pthread_cond_t cnd;
-    mfl_cnode *head, *tail; int64_t es;
+    mfl_cnode *head, *tail; int64_t es; int closed;
 } mfl_chan;
 static mfl_chan* mfl_make_chan(int64_t es) {
     mfl_chan* c = malloc(sizeof(mfl_chan));
     pthread_mutex_init(&c->mu, NULL); pthread_cond_init(&c->cnd, NULL);
-    c->head = c->tail = NULL; c->es = es;
+    c->head = c->tail = NULL; c->es = es; c->closed = 0;
     return c;
+}
+/* close a channel: receivers drain the buffer then get "not ok". Wakes every
+   blocked receiver so range/recv stop instead of hanging forever. */
+static void mfl_chan_close(mfl_chan* c) {
+    pthread_mutex_lock(&c->mu);
+    c->closed = 1;
+    pthread_cond_broadcast(&c->cnd);
+    pthread_mutex_unlock(&c->mu);
 }
 static void mfl_chan_send(mfl_chan* c, const void* v) {
     mfl_cnode* n = malloc(sizeof(mfl_cnode));
@@ -184,14 +192,23 @@ static void mfl_chan_send(mfl_chan* c, const void* v) {
     pthread_cond_signal(&c->cnd);
     pthread_mutex_unlock(&c->mu);
 }
-static void mfl_chan_recv(mfl_chan* c, void* out) {
+/* blocking receive with ok: 1 and fills out if a value arrived; 0 if the channel
+   is closed and drained (out left untouched). The primitive behind range-over-
+   channel and the comma-ok receive. */
+static int mfl_chan_recv2(mfl_chan* c, void* out) {
     pthread_mutex_lock(&c->mu);
-    while (!c->head) pthread_cond_wait(&c->cnd, &c->mu);
-    mfl_cnode* n = c->head; c->head = n->next;
+    while (!c->head && !c->closed) pthread_cond_wait(&c->cnd, &c->mu);
+    mfl_cnode* n = c->head;
+    if (!n) { pthread_mutex_unlock(&c->mu); return 0; }
+    c->head = n->next;
     if (!c->head) c->tail = NULL;
     pthread_mutex_unlock(&c->mu);
     memcpy(out, n->data, c->es);
     free(n->data); free(n);
+    return 1;
+}
+static void mfl_chan_recv(mfl_chan* c, void* out) {
+    if (!mfl_chan_recv2(c, out)) memset(out, 0, c->es);
 }
 /* non-blocking receive: 1 and fills out if an element was ready, else 0. The
    primitive behind select's poll over multiple channels. */
@@ -1714,6 +1731,18 @@ func (g *cgen) rangeStmt(st *RangeStmt, depth int) error {
 			indentC(&g.buf, depth+2)
 			fmt.Fprintf(&g.buf, "%s _v%d; mfl_map_get(_m%d, %s, %s, &_v%d); %s = _v%d;\n", vct, id, id, ik, sk, id, g.varRef(st.Val), id)
 		}
+	case KChan:
+		ect := g.c.ElemCType(g.curFn, st.X)
+		indentC(&g.buf, depth+1)
+		fmt.Fprintf(&g.buf, "mfl_chan* _ch%d = %s;\n", id, x)
+		indentC(&g.buf, depth+1)
+		// receive into the loop variable each iteration; stop when the channel is
+		// closed and drained (mfl_chan_recv2 returns 0).
+		if hasKey {
+			fmt.Fprintf(&g.buf, "while (mfl_chan_recv2(_ch%d, &%s)) {\n", id, g.varRef(st.Key))
+		} else {
+			fmt.Fprintf(&g.buf, "%s _cd%d; while (mfl_chan_recv2(_ch%d, &_cd%d)) {\n", ect, id, id, id)
+		}
 	default:
 		return fmt.Errorf("codegen: cannot range over %s", g.c.NodeKind(g.curFn, st.X))
 	}
@@ -2331,6 +2360,9 @@ func (g *cgen) call(ex *Call) (string, error) {
 	case "write":
 		return fmt.Sprintf("mfl_write(%s, %s)", args[0], args[1]), nil
 	case "close":
+		if g.c.NodeKind(g.curFn, ex.Args[0]) == KChan {
+			return fmt.Sprintf("mfl_chan_close(%s)", args[0]), nil
+		}
 		return fmt.Sprintf("mfl_close(%s)", args[0]), nil
 	case "input":
 		return "mfl_input()", nil

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -576,6 +576,28 @@ func TestHTTPGetMultiReturn(t *testing.T) {
 	}
 }
 
+// close(ch) ends a range-over-channel: workers draining a closed jobs channel
+// stop cleanly, and a closed buffered channel is drained before the range ends.
+func TestChannelClose(t *testing.T) {
+	sq := `func sq(jobs, out) { for j := range jobs { out <- j*j } out <- -1 }`
+	main := `func main() {
+	jobs := make(chan int) out := make(chan int)
+	go sq(jobs, out)
+	n := 1 for n <= 4 { jobs <- n n = n + 1 }
+	close(jobs)
+	sum := 0 done := false
+	for done == false { r := <- out if r == -1 { done = true } if r != -1 { sum = sum + r } }
+	println(str(sum))
+	buf := make(chan int) buf <- 10 buf <- 20 close(buf)
+	t := 0 for v := range buf { t = t + v }
+	println(str(t))
+}`
+	out, _ := buildRun(t, main, sq)
+	if out != "30\n30\n" { // 1+4+9+16=30 ; 10+20=30
+		t.Fatalf("close/range: got %q, want %q", out, "30\n30\n")
+	}
+}
+
 // select waits on multiple channels: it takes a ready receive, falls to default
 // when nothing is ready, and supports the timer/result timeout pattern.
 func TestSelect(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -825,7 +825,7 @@ func (c *Checker) resolveDeferred() error {
 	}
 	for i := range c.rangeUses {
 		if !rangeDone[i] {
-			return fmt.Errorf("cannot range over this value (need a slice, map, or string)")
+			return fmt.Errorf("cannot range over this value (need a slice, map, string, or channel)")
 		}
 	}
 	return nil
@@ -870,6 +870,20 @@ func (c *Checker) tryRange(ru rangeUse) (bool, error) {
 			if _, err := c.union(ru.val, vs); err != nil {
 				return false, err
 			}
+		}
+		return true, nil
+	case KChan:
+		// for v := range ch — the single variable is the received element; the
+		// loop ends when the channel is closed and drained.
+		if ru.hasVal {
+			return false, fmt.Errorf("range over a channel takes a single variable")
+		}
+		e, err := c.chanElem(ru.base)
+		if err != nil {
+			return false, err
+		}
+		if _, err := c.union(ru.key, e); err != nil {
+			return false, err
 		}
 		return true, nil
 	}
@@ -1800,7 +1814,8 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("close: 1 arg")
 		}
-		c.addPair(argSlots[0], c.cInt)
+		// arg is an fd (int) or a channel — codegen dispatches on its kind. Don't
+		// pin it to int, so close(ch) type-checks.
 		return c.cVoid, nil
 	}
 	if ef, ok := c.externs[ex.Callee]; ok {


### PR DESCRIPTION
Channels could be made and used but never **closed** — so a consumer had no clean "no more data" signal: pools stopped via sentinel values and a stray `range`/receive blocked forever.

## Surface
- `close(ch)` — marks the channel done (wakes every blocked receiver). Dispatches on its argument: a **channel** closes the channel, an **fd** still closes the fd.
- a receive on a closed+drained channel returns the zero value (no block)
- **`for v := range ch`** — receives until the channel is closed and drained, then ends

## How
- `mfl_chan` gains a `closed` flag; `mfl_chan_close` broadcasts; a new `mfl_chan_recv2` (receive-with-ok) is the primitive behind range/close
- typecheck binds the single range var to the channel's element type; codegen emits `while (mfl_chan_recv2(ch, &v)) { ... }`
- `close` codegen dispatches on `KChan`

## Verified live
A streaming fetch pipeline (producer closes `jobs`; workers `for u := range jobs`; a fan-in closes `results`; main `for r := range results`) — terminates cleanly on empty input and on a finite batch, no sentinels. `TestChannelClose` + full suite green. SPEC + CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for closing channels with the `close()` function.
  * Added ability to iterate over channels using `for v := range ch` syntax, which automatically terminates when the channel is closed and fully drained.

* **Documentation**
  * Updated concurrency documentation to reflect new channel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->