### PR TITLE
release: v0.14.0 (channel close)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.14.0
 
 - **Channel `close` + range-over-channel.** Channels could be made and used but
   never closed, so a consumer had no clean "no more data" signal — pools stopped

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.13.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.14.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.13.0
+Version 0.14.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.14.0**, capturing channel close (#128) already on `main`:

- **`close(ch)`** + **`for v := range ch`** — clean termination of channel pipelines; `close` dispatches on its argument (channel vs fd).

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.14.0). Full suite green. On merge I'll tag `v0.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)