### PR TITLE
release: v0.15.0 (channel string arena fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.15.0
 
 - **Fix: strings sent over a channel survive the sender goroutine.** A channel
   copied only the element bytes — for a string, just the `char*` — so a string

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.14.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.15.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.14.0
+Version 0.15.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.15.0**, capturing the channel string-arena fix (#130) already on `main`:

- strings (and a struct's string fields) sent over a channel now survive the sender goroutine — deep-copied on send, adopted into the receiver's arena on receive.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.15.0). Full suite green. On merge I'll tag `v0.15.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)