### PR TITLE
feat: deep-copy slices and maps sent over channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **Channels deep-copy slices and maps too.** v0.15.0 made channels safe for
+  strings; now slices, maps, and structs containing them (nested arbitrarily)
+  are deep-copied across the goroutine boundary as well, so a `chan []string`,
+  `chan map[string]int`, or `chan SomeStruct{…[]T…}` value sent from a short-
+  lived goroutine survives that goroutine's arena being reclaimed. Plain strings
+  keep the fast offset-copy path; elements containing a slice or map round-trip
+  through the per-type JSON serializer/parser (a general deep copy reused from
+  `json`/`parse`). Scalars are still a plain memcpy.
+
 ## v0.15.0
 
 - **Fix: strings sent over a channel survive the sender goroutine.** A channel

--- a/SPEC.md
+++ b/SPEC.md
@@ -341,12 +341,12 @@ id(42); id("hi"); id(3.14)   // → three native functions
   goroutine's arena lives for the whole program. This bounds the memory of a
   long-running concurrent server — each request handler runs in its own
   goroutine and frees everything it allocated on return.
-  - **Channels deep-copy strings across this boundary:** a `string` (or a
-    struct's string fields, recursively) sent over a channel is copied out of the
-    sender's arena on send and adopted into the receiver's arena on receive, so it
-    stays valid even after the sender goroutine finishes. (Slice/map backings
-    inside a channel element are *not* deep-copied — keep those in a scope that
-    outlives the receiver.)
+  - **Channels deep-copy heap data across this boundary:** a value sent over a
+    channel — a `string`, a slice, a map, or a struct containing any of these,
+    nested arbitrarily — is copied out of the sender's arena on send and rebuilt
+    in the receiver's arena on receive, so it stays valid even after the sender
+    goroutine finishes. (Strings take a fast offset-copy path; elements containing
+    a slice or map go through a JSON round-trip.)
   - *Caveat:* a value allocated in one goroutine and shared with another by other
     means (stored in a map outliving the sender, captured by a closure) may be
     reclaimed while still referenced. Keep such values in the receiver's scope.

--- a/codegen.go
+++ b/codegen.go
@@ -15,7 +15,7 @@ func CompileToC(p *Program, safe bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	g := &cgen{c: c, safe: safe, jsonMemo: map[string]string{}, parseMemo: map[string]string{}}
+	g := &cgen{c: c, safe: safe, jsonMemo: map[string]string{}, parseMemo: map[string]string{}, chanJSONMemo: map[string][2]string{}}
 	return g.program(p)
 }
 
@@ -54,6 +54,7 @@ type cgen struct {
 	jsonFns   strings.Builder   // generated per-type JSON serializers + parsers
 	jsonMemo  map[string]string // type string -> serializer function name
 	parseMemo map[string]string // type string -> parser function name
+	chanJSONMemo map[string][2]string // type string -> {serWrapper, desWrapper}
 	jsonID    int
 	rangeID   int    // unique temp names for for-range loops
 	tmpID     int    // unique temp names for multi-assignment
@@ -164,23 +165,30 @@ static void mfl_sleep(int64_t ms) {
     nanosleep(&ts, NULL);
 }
 
-/* channels: a mutex + condvar FIFO carrying fixed-size elements.
-   stroff[] holds the byte offsets of every string (char*) inside an element, so
-   a sent value's strings can be deep-copied out of the (possibly short-lived)
-   sender arena on send and adopted into the receiver arena on receive. Without
-   this, the channel copies only the char*, dangling once the sender's goroutine
-   arena is reclaimed. */
+/* channels: a mutex + condvar FIFO. An element's heap data lives in the sending
+   goroutine's arena, which is reclaimed when that goroutine finishes — so the
+   channel must copy it somewhere stable on send and into the receiver's arena on
+   receive. Two marshaling modes (chosen by codegen from the element type):
+     - string mode (stroff[]): byte offsets of every string (char*) reachable by
+       value in the element; send deep-copies them, receive adopts them.
+     - json mode (ser/des): for elements containing a slice or map, the whole
+       value is serialized to JSON on send and parsed back on receive — a general
+       deep copy that handles arbitrary nesting (slices, maps, structs).
+   Scalar elements need neither and are a plain memcpy. */
 static char* mfl_dup_arena(const char* s, size_t n); /* defined later in the runtime */
 typedef struct mfl_cnode { struct mfl_cnode* next; void* data; } mfl_cnode;
 typedef struct {
     pthread_mutex_t mu; pthread_cond_t cnd;
     mfl_cnode *head, *tail; int64_t es; int closed;
     int nstr; int* stroff;
+    char* (*ser)(const void*);          /* json mode: element -> arena JSON */
+    void (*des)(const char*, void*);    /* json mode: JSON -> *out (arena) */
 } mfl_chan;
-static mfl_chan* mfl_make_chan(int64_t es, int nstr, ...) {
+static mfl_chan* mfl_make_chan(int64_t es, char* (*ser)(const void*), void (*des)(const char*, void*), int nstr, ...) {
     mfl_chan* c = malloc(sizeof(mfl_chan));
     pthread_mutex_init(&c->mu, NULL); pthread_cond_init(&c->cnd, NULL);
     c->head = c->tail = NULL; c->es = es; c->closed = 0;
+    c->ser = ser; c->des = des;
     c->nstr = nstr; c->stroff = NULL;
     if (nstr > 0) {
         c->stroff = (int*)malloc((size_t)nstr * sizeof(int));
@@ -216,14 +224,30 @@ static void mfl_chan_close(mfl_chan* c) {
 }
 static void mfl_chan_send(mfl_chan* c, const void* v) {
     mfl_cnode* n = malloc(sizeof(mfl_cnode));
-    n->data = malloc(c->es); memcpy(n->data, v, c->es);
-    mfl_chan_freeze(c, n->data);
+    if (c->ser) {
+        char* j = c->ser(v);                 /* arena JSON of the whole value */
+        size_t L = strlen(j);
+        n->data = malloc(L + 1); memcpy(n->data, j, L + 1);
+    } else {
+        n->data = malloc(c->es); memcpy(n->data, v, c->es);
+        mfl_chan_freeze(c, n->data);
+    }
     n->next = NULL;
     pthread_mutex_lock(&c->mu);
     if (c->tail) c->tail->next = n; else c->head = n;
     c->tail = n;
     pthread_cond_signal(&c->cnd);
     pthread_mutex_unlock(&c->mu);
+}
+/* deliver node n's payload into out (receiver arena), then free the node. */
+static void mfl_chan_deliver(mfl_chan* c, mfl_cnode* n, void* out) {
+    if (c->des) {
+        c->des((const char*)n->data, out);
+    } else {
+        memcpy(out, n->data, c->es);
+        mfl_chan_thaw(c, out);
+    }
+    free(n->data); free(n);
 }
 /* blocking receive with ok: 1 and fills out if a value arrived; 0 if the channel
    is closed and drained (out left untouched). The primitive behind range-over-
@@ -236,9 +260,7 @@ static int mfl_chan_recv2(mfl_chan* c, void* out) {
     c->head = n->next;
     if (!c->head) c->tail = NULL;
     pthread_mutex_unlock(&c->mu);
-    memcpy(out, n->data, c->es);
-    mfl_chan_thaw(c, out);
-    free(n->data); free(n);
+    mfl_chan_deliver(c, n, out);
     return 1;
 }
 static void mfl_chan_recv(mfl_chan* c, void* out) {
@@ -252,9 +274,7 @@ static int mfl_chan_tryrecv(mfl_chan* c, void* out) {
     if (n) { c->head = n->next; if (!c->head) c->tail = NULL; }
     pthread_mutex_unlock(&c->mu);
     if (!n) return 0;
-    memcpy(out, n->data, c->es);
-    mfl_chan_thaw(c, out);
-    free(n->data); free(n);
+    mfl_chan_deliver(c, n, out);
     return 1;
 }
 
@@ -1964,15 +1984,25 @@ func (g *cgen) expr(e Expr) (string, error) {
 		return g.closureCall(clos, params, ret, args), nil
 	case *MakeChan:
 		ect := g.c.ElemCType(g.curFn, ex)
-		offs := g.chanStrOffsets(g.c.ElemTypeString(g.curFn, ex), "")
+		et := g.c.ElemTypeString(g.curFn, ex)
+		// elements with a slice or map are deep-copied via JSON round-trip; plain
+		// strings via the fast offset path; scalars need nothing.
+		if g.chanNeedsJSON(et) {
+			ser, des, err := g.chanJSONFns(et)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("mfl_make_chan(sizeof(%s), %s, %s, 0)", ect, ser, des), nil
+		}
+		offs := g.chanStrOffsets(et, "")
 		if len(offs) == 0 {
-			return fmt.Sprintf("mfl_make_chan(sizeof(%s), 0)", ect), nil
+			return fmt.Sprintf("mfl_make_chan(sizeof(%s), 0, 0, 0)", ect), nil
 		}
 		casted := make([]string, len(offs))
 		for i, o := range offs {
 			casted[i] = "(int)(" + o + ")"
 		}
-		return fmt.Sprintf("mfl_make_chan(sizeof(%s), %d, %s)", ect, len(offs), strings.Join(casted, ", ")), nil
+		return fmt.Sprintf("mfl_make_chan(sizeof(%s), 0, 0, %d, %s)", ect, len(offs), strings.Join(casted, ", ")), nil
 	case *MakeMap:
 		keyIsStr := 0
 		if g.c.MapKeyKind(g.curFn, ex) == KString {
@@ -2131,6 +2161,49 @@ func (g *cgen) chanStrOffsets(typeStr, base string) []string {
 		}
 	}
 	return offs
+}
+
+// chanNeedsJSON reports whether a channel element of this type contains a slice
+// or map (reachable by value), which the flat string-offset path can't deep-copy
+// — those elements go through a JSON serialize/parse round-trip instead.
+func (g *cgen) chanNeedsJSON(typeStr string) bool {
+	if strings.HasPrefix(typeStr, "[]") || strings.HasPrefix(typeStr, "map[") {
+		return true
+	}
+	if td, ok := g.c.StructTypes()[typeStr]; ok {
+		for _, f := range td.Fields {
+			if g.chanNeedsJSON(f.Type) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// chanJSONFns emits (once per type) the serialize/parse wrappers a JSON-mode
+// channel calls, returning their names. The wrappers adapt the generated
+// per-type JSON serializer/parser to the channel's void* calling convention.
+func (g *cgen) chanJSONFns(typeStr string) (string, string, error) {
+	if n, ok := g.chanJSONMemo[typeStr]; ok {
+		return n[0], n[1], nil
+	}
+	ser, err := g.jsonSerializer(typeStr)
+	if err != nil {
+		return "", "", err
+	}
+	des, err := g.jsonParser(typeStr)
+	if err != nil {
+		return "", "", err
+	}
+	ct := cTypeName(typeStr)
+	id := g.jsonID
+	g.jsonID++
+	sName := fmt.Sprintf("mfl_chanser_%d", id)
+	dName := fmt.Sprintf("mfl_chandes_%d", id)
+	fmt.Fprintf(&g.jsonFns, "static char* %s(const void* _e) { return %s(*(const %s*)_e); }\n", sName, ser, ct)
+	fmt.Fprintf(&g.jsonFns, "static void %s(const char* _j, void* _o) { const char* _p = _j; *(%s*)_o = %s(&_p); }\n", dName, ct, des)
+	g.chanJSONMemo[typeStr] = [2]string{sName, dName}
+	return sName, dName, nil
 }
 
 // jsonSerializer ensures a C function exists that serializes a value of the

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -598,6 +598,29 @@ func TestChannelStringArena(t *testing.T) {
 	}
 }
 
+// Slices and maps sent over a channel from a short-lived goroutine are deep-
+// copied (via a JSON round-trip), so their backings survive the sender's arena.
+func TestChannelSliceMap(t *testing.T) {
+	prodS := `func prodS(jobs) { i := 0 for i < 3 { jobs <- []string{"a" + str(i), "b" + str(i)} i = i + 1 } close(jobs) }`
+	prodM := `func prodM(jobs) { i := 0 for i < 2 { m := make(map[string]int) m["k"] = i * 7 jobs <- m i = i + 1 } close(jobs) }`
+	main := `func main() {
+	sj := make(chan []string)
+	go prodS(sj)
+	acc := ""
+	for s := range sj { for _, e := range s { acc = acc + e } acc = acc + " " }
+	println(acc)
+	mj := make(chan map[string]int)
+	go prodM(mj)
+	macc := ""
+	for m := range mj { macc = macc + str(m["k"]) + " " }
+	println(macc)
+}`
+	out, _ := buildRun(t, main, prodS, prodM)
+	if out != "a0b0 a1b1 a2b2 \n0 7 \n" {
+		t.Fatalf("channel slice/map: got %q", out)
+	}
+}
+
 // close(ch) ends a range-over-channel: workers draining a closed jobs channel
 // stop cleanly, and a closed buffered channel is drained before the range ends.
 func TestChannelClose(t *testing.T) {


### PR DESCRIPTION
v0.15.0 made channels safe for **strings**; this extends the same guarantee to **slices, maps, and structs containing them** (nested arbitrarily). A `chan []string`, `chan map[string]int`, or `chan SomeStruct{…[]T…}` value sent from a short-lived goroutine now survives that goroutine's arena being reclaimed.

## How
- Channels gain a **JSON marshaling mode**: an element whose type contains a slice or map is serialized to JSON on send (copied to stable storage) and parsed back into the receiver's arena on receive — a general deep copy that handles arbitrary nesting, **reusing the per-type `json` serializer + `parse` parser** (thin `chanser`/`chandes` wrappers).
- `make(chan T)` picks the mode from the element type: **JSON** for slice/map-bearing, the fast **string offset-copy** for string-bearing, plain **memcpy** for scalars.
- `mfl_make_chan` now takes `ser`/`des` function pointers; `mfl_chan_deliver` routes receive through parse-or-thaw.

## Verified
`chan []string`, `chan map[string]int`, and `chan Doc{title string; tags []string; views int}` all sent from short-lived producer goroutines read correctly on the far side. String fast-path unchanged (`TestChannelStringArena` green); `TestChannelSliceMap` added; full suite green. SPEC caveat + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channels now deep-copy slices, maps, and nested structs across goroutine boundaries, ensuring all heap data remains valid after the sender goroutine completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->