### PR TITLE
release: v0.16.0 (channel slice/map deep-copy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.16.0
 
 - **Channels deep-copy slices and maps too.** v0.15.0 made channels safe for
   strings; now slices, maps, and structs containing them (nested arbitrarily)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.15.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.16.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.15.0
+Version 0.16.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.16.0**, capturing the channel slice/map deep-copy (#132) already on `main`:

- slices, maps, and structs containing them now survive the sender goroutine across a channel (deep-copied via a JSON round-trip); strings keep the fast offset-copy path.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.16.0). Full suite green. On merge I'll tag `v0.16.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)