### PR TITLE
feat: comma-ok receive — v, ok := <-ch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **Comma-ok receive — `v, ok := <-ch`.** A receive now optionally reports
+  whether the channel is still open: `ok` is `false` once it's closed and
+  drained (and `v` is the zero value). Works standalone and as a `select` case
+  (`case v, ok := <-ch:`). Relatedly, **`select` now treats a closed channel as
+  ready** — its receive case fires (with `ok == false` if bound) instead of
+  spinning — so a `select` loop can detect a source closing. Built on the
+  existing `mfl_chan_recv2` plus a new `mfl_chan_tryrecv2`. Surfaced building a
+  stream batcher that flushes on size, on a timer, or when the input ends.
+
 ## v0.16.0
 
 - **Channels deep-copy slices and maps too.** v0.15.0 made channels safe for

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 
 - **Types** (all inferred, unboxed): `int` `float` `bool` `string`, slices `[]T`, maps `map[K]V`, structs, `func` values
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
-- **Concurrency**: goroutines (`go`), channels (`close` + `for v := range ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
+- **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
 - **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`, string ops
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)

--- a/SPEC.md
+++ b/SPEC.md
@@ -198,6 +198,10 @@ throughout the function body).
     value), or string (index, 1-char). Either variable may be `_`.
   - `for v := range ch { ... }` over a channel: receives each value until the
     channel is closed and drained, then ends. One variable (the element).
+  - `v, ok := <-ch` (comma-ok receive): `ok` is `false` once the channel is
+    closed and drained (`v` is then the zero value). Works standalone and as a
+    `select` case (`case v, ok := <-ch:`); a closed channel makes its select case
+    ready, firing with `ok == false`.
   - `break` exits the innermost loop; `continue` skips to its next iteration.
 - `return`, `return e`, `return e1, e2`.
 - `x[i] = v`, `x.f = v`.
@@ -409,7 +413,7 @@ Return      = "return" [ exprList ] .
 Send        = Expr "<-" Expr .
 Go          = "go" Call .
 Select      = "select" "{" { "case" Comm ":" { Stmt } } [ "default" ":" { Stmt } ] "}" .
-Comm        = ident ":=" "<-" Expr | "<-" Expr | Expr "<-" Expr .
+Comm        = ident [ "," ident ] ":=" "<-" Expr | "<-" Expr | Expr "<-" Expr .
 Expr        = ... operators, calls, indexing, field access, literals,
               FuncLit, make, "<-" Expr ... .
 FuncLit     = "func" "(" [ identList ] ")" Block .

--- a/ast.go
+++ b/ast.go
@@ -246,9 +246,11 @@ type GoStmt struct{ Call *Call }
 //   }
 // The first ready case runs; with no default and nothing ready, it blocks.
 type SelectCase struct {
-	// receive case: RecvCh set; Name is the binding ("" / "_" to discard)
+	// receive case: RecvCh set; Name is the binding ("" / "_" to discard);
+	// OkName is the optional comma-ok variable (case v, ok := <-ch)
 	RecvCh Expr
 	Name   string
+	OkName string
 	// send case: SendCh + SendVal set (RecvCh nil)
 	SendCh  Expr
 	SendVal Expr

--- a/codegen.go
+++ b/codegen.go
@@ -266,16 +266,18 @@ static int mfl_chan_recv2(mfl_chan* c, void* out) {
 static void mfl_chan_recv(mfl_chan* c, void* out) {
     if (!mfl_chan_recv2(c, out)) memset(out, 0, c->es);
 }
-/* non-blocking receive: 1 and fills out if an element was ready, else 0. The
-   primitive behind select's poll over multiple channels. */
-static int mfl_chan_tryrecv(mfl_chan* c, void* out) {
+/* non-blocking receive for select: returns 1 if the case is ready — either a
+   value arrived (*ok = 1, out filled) or the channel is closed and drained
+   (*ok = 0, out zeroed). Returns 0 if not ready (open and empty). */
+static int mfl_chan_tryrecv2(mfl_chan* c, void* out, int* ok) {
     pthread_mutex_lock(&c->mu);
     mfl_cnode* n = c->head;
     if (n) { c->head = n->next; if (!c->head) c->tail = NULL; }
+    int closed = c->closed;
     pthread_mutex_unlock(&c->mu);
-    if (!n) return 0;
-    mfl_chan_deliver(c, n, out);
-    return 1;
+    if (n) { mfl_chan_deliver(c, n, out); *ok = 1; return 1; }
+    if (closed) { memset(out, 0, c->es); *ok = 0; return 1; }
+    return 0;
 }
 
 /* maps: a chained hash table keyed by int64 or string, fixed-size values */
@@ -1556,7 +1558,7 @@ func (g *cgen) selectStmt(st *SelectStmt, depth int) error {
 				return err
 			}
 			et := g.c.ElemCType(g.curFn, sc.RecvCh)
-			fmt.Fprintf(&g.buf, "mfl_chan* _sc%d_%d = %s; %s _sv%d_%d;\n", id, i, ch, et, id, i)
+			fmt.Fprintf(&g.buf, "mfl_chan* _sc%d_%d = %s; %s _sv%d_%d; int _sok%d_%d = 0;\n", id, i, ch, et, id, i, id, i)
 		} else {
 			ch, err := g.expr(sc.SendCh)
 			if err != nil {
@@ -1578,7 +1580,7 @@ func (g *cgen) selectStmt(st *SelectStmt, depth int) error {
 		sc := &st.Cases[i]
 		indentC(&g.buf, depth+2)
 		if sc.RecvCh != nil {
-			fmt.Fprintf(&g.buf, "if (mfl_chan_tryrecv(_sc%d_%d, &_sv%d_%d)) { _sel%d = %d; break; }\n", id, i, id, i, id, i)
+			fmt.Fprintf(&g.buf, "if (mfl_chan_tryrecv2(_sc%d_%d, &_sv%d_%d, &_sok%d_%d)) { _sel%d = %d; break; }\n", id, i, id, i, id, i, id, i)
 		} else {
 			fmt.Fprintf(&g.buf, "{ mfl_chan_send(_sc%d_%d, &_sv%d_%d); _sel%d = %d; break; }\n", id, i, id, i, id, i)
 		}
@@ -1598,6 +1600,10 @@ func (g *cgen) selectStmt(st *SelectStmt, depth int) error {
 		if sc.RecvCh != nil && sc.Name != "" && sc.Name != "_" {
 			indentC(&g.buf, depth+2)
 			fmt.Fprintf(&g.buf, "%s = _sv%d_%d;\n", g.varRef(sc.Name), id, i)
+		}
+		if sc.RecvCh != nil && sc.OkName != "" && sc.OkName != "_" {
+			indentC(&g.buf, depth+2)
+			fmt.Fprintf(&g.buf, "%s = _sok%d_%d;\n", g.varRef(sc.OkName), id, i)
 		}
 		for _, s := range sc.Body {
 			if err := g.stmt(s, depth+2); err != nil {
@@ -1633,6 +1639,26 @@ func (g *cgen) multiAssign(st *MultiAssign, depth int) error {
 	}
 
 	if len(st.Rhs) == 1 {
+		// comma-ok receive: v, ok := <-ch  (ok is false when closed and drained)
+		if recv, isRecv := st.Rhs[0].(*Recv); isRecv {
+			ch, err := g.expr(recv.Ch)
+			if err != nil {
+				return err
+			}
+			et := g.c.ElemCType(g.curFn, recv.Ch)
+			id := g.tmpID
+			g.tmpID++
+			g.buf.WriteString("{\n")
+			indentC(&g.buf, depth+1)
+			fmt.Fprintf(&g.buf, "%s _rv%d; int _rok%d = mfl_chan_recv2(%s, &_rv%d);\n", et, id, id, ch, id)
+			indentC(&g.buf, depth+1)
+			fmt.Fprintf(&g.buf, "if (!_rok%d) memset(&_rv%d, 0, sizeof(_rv%d));\n", id, id, id)
+			assign(st.Names[0], fmt.Sprintf("_rv%d", id))
+			assign(st.Names[1], fmt.Sprintf("_rok%d", id))
+			indentC(&g.buf, depth)
+			g.buf.WriteString("}\n")
+			return nil
+		}
 		// multi-return builtin (the `v, err :=` idiom): emit the result struct
 		// and destructure its fields across the assigned names.
 		if call, isCall := st.Rhs[0].(*Call); isCall {

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -643,6 +643,24 @@ func TestChannelClose(t *testing.T) {
 	}
 }
 
+// comma-ok receive (v, ok := <-ch) reports false once a channel is closed and
+// drained — both standalone and inside a select case (which fires on close).
+func TestCommaOkReceive(t *testing.T) {
+	prod := `func prod(ch) { i := 0 for i < 3 { ch <- i * 2 i = i + 1 } close(ch) }`
+	// standalone comma-ok loop
+	standalone := `func main() { ch := make(chan int) go prod(ch) sleep(30) sum := 0 for { v, ok := <- ch if ok == false { break } sum = sum + v } println(str(sum)) }`
+	out, _ := buildRun(t, standalone, prod)
+	if out != "6\n" {
+		t.Fatalf("standalone comma-ok: got %q, want %q", out, "6\n")
+	}
+	// comma-ok inside select: fires on close with ok == false
+	sel := `func main() { ch := make(chan int) go prod(ch) sleep(30) sum := 0 done := false for done == false { select { case v, ok := <- ch: if ok == false { done = true } if ok { sum = sum + v } } } println(str(sum)) }`
+	out2, _ := buildRun(t, sel, prod)
+	if out2 != "6\n" {
+		t.Fatalf("select comma-ok: got %q, want %q", out2, "6\n")
+	}
+}
+
 // select waits on multiple channels: it takes a ready receive, falls to default
 // when nothing is ready, and supports the timer/result timeout pattern.
 func TestSelect(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -605,10 +605,21 @@ func (p *Parser) parseSelect() (Stmt, error) {
 			}
 			sc.RecvCh = ch
 			sc.Name = "_"
-		} else if p.peek().Kind == TIdent && p.toks[p.pos+1].Val == ":=" {
-			// case v := <-ch:
+		} else if p.peek().Kind == TIdent && (p.toks[p.pos+1].Val == ":=" || p.toks[p.pos+1].Val == ",") {
+			// case v := <-ch:   or   case v, ok := <-ch:
 			name := p.next().Val
-			p.next() // :=
+			okName := ""
+			if p.peek().Val == "," {
+				p.next() // ,
+				ok2, e := p.expect(TIdent, "")
+				if e != nil {
+					return nil, e
+				}
+				okName = ok2.Val
+			}
+			if _, err := p.expect(TOp, ":="); err != nil {
+				return nil, err
+			}
 			if _, err := p.expect(TOp, "<-"); err != nil {
 				return nil, err
 			}
@@ -618,6 +629,7 @@ func (p *Parser) parseSelect() (Stmt, error) {
 			}
 			sc.RecvCh = ch
 			sc.Name = name
+			sc.OkName = okName
 		} else {
 			// case ch <- v:  (send)
 			ch, err := p.parseExpr()

--- a/types.go
+++ b/types.go
@@ -1097,6 +1097,15 @@ func (c *Checker) genStmt(fn *FuncDecl, s Stmt) error {
 					}
 					c.addPair(slot, eslot)
 				}
+				if sc.OkName != "" && sc.OkName != "_" {
+					slot, ok := env[sc.OkName]
+					if !ok {
+						slot = newSlot(c, KVar)
+						env[sc.OkName] = slot
+						c.localOrder[fn.Name] = append(c.localOrder[fn.Name], sc.OkName)
+					}
+					c.addPair(slot, c.cBool)
+				}
 			} else {
 				cs, err := c.genExpr(fn, sc.SendCh)
 				if err != nil {
@@ -1390,6 +1399,23 @@ func (c *Checker) genMultiAssign(fn *FuncDecl, st *MultiAssign) error {
 	}
 
 	if len(st.Rhs) == 1 {
+		// comma-ok receive: v, ok := <-ch
+		if recv, ok := st.Rhs[0].(*Recv); ok {
+			if len(st.Names) != 2 {
+				return fmt.Errorf("comma-ok receive needs exactly 2 variables: v, ok := <-ch")
+			}
+			cs, err := c.genExpr(fn, recv.Ch)
+			if err != nil {
+				return err
+			}
+			eslot, err := c.chanElem(cs)
+			if err != nil {
+				return err
+			}
+			c.addPair(nameSlots[0], eslot)
+			c.addPair(nameSlots[1], c.cBool)
+			return nil
+		}
 		// a multi-return builtin (e.g. http_get -> status, body, err)
 		if call, ok := st.Rhs[0].(*Call); ok {
 			if aks, rks, isMRB := c.multiRetBuiltin(call.Callee); isMRB {


### PR DESCRIPTION
A receive can now report whether the channel is still open: `ok` is `false` once it's **closed and drained** (and `v` is the zero value). Works standalone and as a `select` case.

## Surface
- `v, ok := <-ch` — standalone comma-ok receive.
- `case v, ok := <-ch:` — comma-ok in a `select` case.
- Relatedly, **`select` now treats a closed channel as ready**: its receive case fires (with `ok == false` if bound) instead of spinning — so a `select` loop can detect a source closing and stop.

## How
- parser: `SelectCase.OkName`; parse `v, ok :=` in a case and in a standalone multi-assign (`*Recv` RHS)
- typecheck: bind `ok` to `bool` (select case + a `genMultiAssign` Recv branch)
- codegen: standalone uses the existing blocking `mfl_chan_recv2`; select uses a new non-blocking **`mfl_chan_tryrecv2`** that returns ready on value-*or*-closed and reports which (zeroing `out` on close)

## Verified live
A stream batcher whose `select` watches the input channel and a ticker at once, doing a final flush when `ok == false` — batches by size and by time, both correct. `TestCommaOkReceive` (standalone + select) + full suite green; existing `TestSelect`/`TestChannel*` unaffected. SPEC + CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)