### PR TITLE
release: v0.17.0 (comma-ok receive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.17.0
 
 - **Comma-ok receive — `v, ok := <-ch`.** A receive now optionally reports
   whether the channel is still open: `ok` is `false` once it's closed and

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.16.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.17.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.16.0
+Version 0.17.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.17.0**, capturing comma-ok receive (#134) already on `main`:

- **`v, ok := <-ch`** standalone and as a `select` case; `select` now fires on a closed channel.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.17.0). Full suite green. On merge I'll tag `v0.17.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)