### PR TITLE
feat: flush() builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **`flush()` builtin.** Forces buffered stdout out (`fflush`). libc fully buffers
+  stdout when it's a pipe, so a streaming program's output otherwise only appears
+  when the buffer fills or the process exits; calling `flush()` after a write
+  makes it visible immediately downstream. Surfaced by the streaming batcher,
+  whose whole point is timely emission.
+
 ## v0.17.0
 
 - **Comma-ok receive — `v, ok := <-ch`.** A receive now optionally reports

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`, string ops
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -227,6 +227,7 @@ throughout the function body).
 | `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
 | `exit` | `(int) -> ` | terminate the process with a status code |
+| `flush` | `() -> ` | flush buffered stdout (for prompt output through a pipe) |
 | `read_file` | `(string) -> string` | read a whole file ("" on error) |
 | `write_file` | `(string, string) -> int` | write a file (bytes written; -1 on error) |
 | `list_dir` | `(string) -> []string` | directory entries (excludes `.`/`..`) |

--- a/codegen.go
+++ b/codegen.go
@@ -160,6 +160,7 @@ static mfl_slice mfl_lit_str(int64_t n, ...) {
     va_end(ap); return s;
 }
 static int64_t mfl_exit(int64_t code) { exit((int)code); return 0; }
+static int64_t mfl_flush(void) { fflush(stdout); return 0; }
 static void mfl_sleep(int64_t ms) {
     struct timespec ts = { ms / 1000, (ms % 1000) * 1000000L };
     nanosleep(&ts, NULL);
@@ -2510,6 +2511,8 @@ func (g *cgen) call(ex *Call) (string, error) {
 		return fmt.Sprintf("mfl_sleep(%s)", args[0]), nil
 	case "exit":
 		return fmt.Sprintf("mfl_exit(%s)", args[0]), nil
+	case "flush":
+		return "mfl_flush()", nil
 	case "str":
 		if g.c.NodeKind(g.curFn, ex.Args[0]) == KFloat {
 			return fmt.Sprintf("mfl_str_d(%s)", args[0]), nil

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -643,6 +643,23 @@ func TestChannelClose(t *testing.T) {
 	}
 }
 
+// flush() forces buffered stdout out; it compiles to fflush and is a no-op on
+// captured output (which sees everything anyway), so just assert it runs.
+func TestFlush(t *testing.T) {
+	prog := &Program{Funcs: parseFuncs(t, `func main() { print("a") flush() print("b") flush() }`)}
+	c, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_flush()") {
+		t.Fatal("flush() must compile to mfl_flush()")
+	}
+	out, _ := buildRun(t, `func main() { print("a") flush() print("b") flush() }`)
+	if out != "ab" {
+		t.Fatalf("flush: got %q, want %q", out, "ab")
+	}
+}
+
 // comma-ok receive (v, ok := <-ch) reports false once a channel is closed and
 // drained — both standalone and inside a select case (which fires on close).
 func TestCommaOkReceive(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -1800,6 +1800,11 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return c.cInt, nil
+	case "flush":
+		if len(argSlots) != 0 {
+			return 0, fmt.Errorf("flush: no args")
+		}
+		return c.cInt, nil
 	case "http_get":
 		return 0, fmt.Errorf("http_get returns 3 values; use: status, body, err := http_get(url)")
 	case "json_get":


### PR DESCRIPTION
Adds **`flush()`** — flush buffered stdout (`fflush(stdout)`).

libc fully buffers stdout when it's a pipe, so a streaming program's output otherwise only appears when the buffer fills or the process exits. `flush()` after a write makes it visible immediately downstream — verified through a pipe (a line printed + flushed appears ~2s before a later line behind a `sleep`, instead of both at exit).

Surfaced by machin-batch, whose whole point is timely emission (it'll call `flush()` after each batch, retiring the `stdbuf -oL` workaround). `TestFlush` + full suite green; SPEC + CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)