### PR TITLE
release: v0.18.0 (flush)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.18.0
 
 - **`flush()` builtin.** Forces buffered stdout out (`fflush`). libc fully buffers
   stdout when it's a pipe, so a streaming program's output otherwise only appears

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.17.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.18.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.17.0
+Version 0.18.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts **v0.18.0**, capturing the `flush()` builtin (#136) already on `main`:

- **`flush()`** — flush buffered stdout for prompt output through a pipe.

Version bumps: README badge, `SPEC.md`, `CHANGELOG.md` (Unreleased → v0.18.0). Full suite green. On merge I'll tag `v0.18.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers to 0.18.0 across documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->