### PR TITLE
feat: machin guide — self-describing feature catalog for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,12 @@
 Orientation for agents working on **machin** (the toolchain) / **MFL** (the
 language). Humans state intent; the machine reads and writes the code.
 
+> **Start here to learn the language: run `machin guide`.** It emits the
+> complete, version-exact feature surface — keywords, every builtin with its
+> signature, idioms, and gotchas — as JSON (default) or `--text` (prose), from
+> the compiler's own source-of-truth catalog (so it never drifts). This file is
+> about *contributing to the toolchain*; `machin guide` is about *writing MFL*.
+
 ## Current direction: dogfood
 
 The POC goal is met; machin is now grown by **building real things** and letting
@@ -98,8 +104,10 @@ Releases are automated by [`.github/workflows/release.yml`](.github/workflows/re
 Pushing a `v*` tag cross-compiles machin and attaches the binaries to that tag's
 GitHub release. **To cut a release:**
 
-1. Update the version: bump the badge in `README.md` and add a section to the
-   top of `CHANGELOG.md` (newest first). Commit to `main`.
+1. Update the version: bump the badge in `README.md`, the `Version` line in
+   `SPEC.md`, **`machinVersion` in `guide.go`** (a test enforces it matches the
+   README badge), and add a section to the top of `CHANGELOG.md` (newest first).
+   Commit to `main`.
    ```
    release: vX.Y.Z (one-line summary)
    ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **`machin guide` — self-describing feature catalog for agents.** One command
+  emits machin's complete, version-exact surface — keywords, types, every builtin
+  with its signature + one-line semantics (grouped by category), the core idioms
+  as runnable snippets, and the gotchas — as **JSON by default** (`--text` for
+  dense prose). It's generated from a single in-binary source-of-truth catalog,
+  so an agent masters the language in one call and the reference can't drift from
+  the implementation: a test asserts every catalogued builtin is recognized by
+  the compiler, and that the catalog version matches the README badge.
+
 ## v0.18.0
 
 - **`flush()` builtin.** Forces buffered stdout out (`fflush`). libc fully buffers

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A Go-flavored **backend language shaped for agents**: terse, type-inferred, one 
 
 > This README is deliberately terse — machin is machine-first, and so are its docs. Depth lives in [`SPEC.md`](SPEC.md) and [`AGENTS.md`](AGENTS.md).
 
+> **Agents: run `machin guide`** for the complete, version-exact feature surface in one call — every keyword, every builtin with its signature, the core idioms, and the gotchas, as JSON (`--text` for dense prose). It's emitted from the compiler's own catalog, so it can't drift from the implementation.
+
 ## The form
 
 `.mfl` is plain canonical text: one normalized declaration per line, whitespace tightened. Greppable, diffable, no type annotations.

--- a/SPEC.md
+++ b/SPEC.md
@@ -64,6 +64,7 @@ The toolchain commands:
 | `machin build <file.mfl> [-o out]` | compile to a native binary |
 | `machin build <file.mfl> --emit-c` | print the generated C |
 | `machin encode <src>` | encode loose declaration text into canonical `.mfl` |
+| `machin guide [--text]` | print the full feature catalog (JSON by default) — keywords, builtins, idioms, gotchas — for agents to load in one call |
 
 ---
 

--- a/guide.go
+++ b/guide.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// machinVersion is the single version string for the toolchain. Bump it when
+// cutting a release (alongside README badge / SPEC / CHANGELOG).
+const machinVersion = "0.18.0"
+
+// ---- the source-of-truth feature catalog ----
+//
+// This catalog IS the machine-readable reference an agent loads to master machin
+// in one call: `machin guide` emits it as JSON (default) or `--text` (dense
+// prose). It lives in the binary so it is always version-exact and cannot drift
+// from the implementation; a test (guide_test.go) asserts every builtin here
+// actually type-checks, so the catalog stays honest.
+
+type guideBuiltin struct {
+	Name     string `json:"name"`
+	Sig      string `json:"sig"`
+	Summary  string `json:"summary"`
+	Category string `json:"category"`
+}
+
+type guideIdiom struct {
+	Name string `json:"name"`
+	Code string `json:"code"`
+}
+
+type guideNote struct {
+	Topic string `json:"topic"`
+	Note  string `json:"note"`
+}
+
+type guideCatalog struct {
+	Version  string         `json:"version"`
+	Schema   string         `json:"schema"`
+	Tagline  string         `json:"tagline"`
+	Keywords []string       `json:"keywords"`
+	Types    []guideNote    `json:"types"`
+	Builtins []guideBuiltin `json:"builtins"`
+	Idioms   []guideIdiom   `json:"idioms"`
+	Gotchas  []guideNote    `json:"gotchas"`
+}
+
+func machinGuide() guideCatalog {
+	return guideCatalog{
+		Version: machinVersion,
+		Schema:  "machin.guide/v1",
+		Tagline: "Go-flavored, type-inferred, machine-first language; MFL compiles through C to a single native binary. Plain-text source, one declaration per line.",
+		Keywords: []string{
+			"func", "return", "if", "else", "while", "for", "range", "break", "continue",
+			"select", "go", "chan", "make", "map", "struct", "type", "var", "arena",
+			"extern", "true", "false", "nil",
+		},
+		Types: []guideNote{
+			{"int", "64-bit signed"},
+			{"float", "double"},
+			{"bool", "true/false"},
+			{"string", "immutable UTF-8 bytes; zero value \"\""},
+			{"[]T", "slice (append to grow); for i, v := range"},
+			{"map[K]V", "K is int or string; make(map[K]V); has/delete/keys"},
+			{"struct", "type T struct { f T ... }; value semantics; T{f: v}"},
+			{"chan T", "make(chan T); ch <- v; <-ch; close; for v := range ch; v, ok := <-ch"},
+			{"func", "first-class closures; captured by reference"},
+		},
+		Builtins: []guideBuiltin{
+			// io
+			{"print", "(...) ->", "write args, no trailing newline", "io"},
+			{"println", "(...) ->", "write args + trailing newline", "io"},
+			{"input", "() -> string", "read one stdin line (newline stripped; \"\" at EOF)", "io"},
+			{"flush", "() ->", "flush buffered stdout (prompt output through a pipe)", "io"},
+			{"read_file", "(string) -> string", "read a whole file (\"\" on error)", "io"},
+			{"write_file", "(string, string) -> int", "write a file (bytes; -1 on error)", "io"},
+			{"list_dir", "(string) -> []string", "directory entries (excludes . / ..)", "io"},
+			{"mkdir", "(string) -> int", "create a directory (0 ok; -1 error)", "io"},
+			// cli / process
+			{"args", "() -> []string", "command-line args (args()[0] is program path)", "cli"},
+			{"env", "(string) -> string", "environment variable (\"\" if unset)", "cli"},
+			{"exit", "(int) ->", "terminate the process with a status code", "cli"},
+			// time
+			{"now", "() -> int", "wall-clock Unix seconds", "time"},
+			{"now_ms", "() -> int", "wall-clock milliseconds", "time"},
+			{"sleep", "(int) ->", "pause for N milliseconds", "time"},
+			// convert
+			{"str", "(int|float) -> string", "format a number", "convert"},
+			{"int", "(number) -> int", "truncate to int", "convert"},
+			{"parse_int", "(string) -> int", "parse an integer (0 if non-numeric)", "convert"},
+			// collections
+			{"len", "(string|slice|map) -> int", "length", "collection"},
+			{"append", "([]T, T) -> []T", "grow a slice", "collection"},
+			{"has", "(map, K) -> bool", "key membership", "collection"},
+			{"delete", "(map, K) ->", "remove a key", "collection"},
+			{"keys", "(map[K]V) -> []K", "a map's keys", "collection"},
+			// strings
+			{"substr", "(string, int, int) -> string", "substring [start,end)", "string"},
+			{"index", "(string, string) -> int", "first index, or -1", "string"},
+			{"contains", "(string, string) -> bool", "substring test", "string"},
+			{"has_prefix", "(string, string) -> bool", "prefix test", "string"},
+			{"has_suffix", "(string, string) -> bool", "suffix test", "string"},
+			{"charat", "(string, int) -> string", "1-character string", "string"},
+			{"to_upper", "(string) -> string", "uppercase", "string"},
+			{"to_lower", "(string) -> string", "lowercase", "string"},
+			{"trim", "(string) -> string", "trim surrounding whitespace", "string"},
+			{"replace", "(string, string, string) -> string", "replace all", "string"},
+			{"split", "(string, string) -> []string", "split on a separator", "string"},
+			{"join", "([]string, string) -> string", "join with a separator", "string"},
+			// json
+			{"json", "(any) -> string", "serialize a value to JSON", "json"},
+			{"parse", "(string, T{}) -> T", "parse JSON into T (T{} is a type witness)", "json"},
+			{"json_get", "(string, string) -> (string, string)", "jq-style path -> (value, err); err \"\"/notfound/path/parse. MULTI-ASSIGN ONLY", "json"},
+			{"http_body", "(string) -> string", "body of a raw HTTP message", "json"},
+			// net
+			{"dial", "(string, int) -> int", "TCP connect host:port -> fd (-1 on fail)", "net"},
+			{"listen", "(int) -> int", "open a listening TCP socket on a port", "net"},
+			{"accept", "(int) -> int", "accept a connection -> fd", "net"},
+			{"read", "(int) -> string", "read a chunk from an fd (blocks)", "net"},
+			{"write", "(int, string) -> int", "write to an fd", "net"},
+			{"close", "(int|chan) ->", "close an fd, or a channel (by argument type)", "net"},
+			{"https_get", "(string) -> string", "HTTPS GET over TLS; body (\"\" on error)", "net"},
+			{"https_post", "(string, string) -> string", "HTTPS POST (JSON body) over TLS; body", "net"},
+			{"http_get", "(string) -> (int, string, string)", "GET -> (status, body, err); err \"\"/dns/connect/tls/scheme. MULTI-ASSIGN ONLY", "net"},
+			// websocket
+			{"wss_open", "(string) -> int", "open a wss:// WebSocket -> handle (0 on fail)", "ws"},
+			{"wss_send", "(int, string) -> int", "send a text message", "ws"},
+			{"wss_recv", "(int) -> string", "next message (blocks; \"\" on close; auto ping/pong)", "ws"},
+			{"wss_close", "(int) -> int", "send close and tear down", "ws"},
+		},
+		Idioms: []guideIdiom{
+			{"hello", `func main() { println("hello") }`},
+			{"types", `type P struct { name string  age int }
+func main() { p := P{name: "ada", age: 36}  xs := []int{1, 2, 3}  m := make(map[string]int)  m["k"] = 1  println(p.name + " " + str(len(xs)) + " " + str(m["k"])) }`},
+			{"goroutine-channel", `func work(ch) { ch <- 42 }
+func main() { ch := make(chan int)  go work(ch)  println(str(<-ch)) }`},
+			{"select-timeout", `func after(ms, ch) { sleep(ms)  ch <- true }
+func main() { done := make(chan int)  t := make(chan bool)  go after(100, t)
+	select { case v := <-done: println(str(v))  case <-t: println("timeout") } }`},
+			{"worker-pool-close", `func worker(jobs, out) { for u := range jobs { out <- u + "!" }  out <- "done" }
+func main() { jobs := make(chan string)  out := make(chan string)  go worker(jobs, out)
+	jobs <- "a"  jobs <- "b"  close(jobs)
+	for { r := <- out  if r == "done" { break }  println(r) } }`},
+			{"comma-ok", `func prod(ch) { ch <- 1  ch <- 2  close(ch) }
+func main() { ch := make(chan int)  go prod(ch)
+	for { v, ok := <- ch  if ok == false { break }  println(str(v)) } }`},
+			{"error-handling", `func main() { status, body, err := http_get("https://example.com/")
+	if len(err) > 0 { println("unreachable: " + err)  exit(1) }
+	println(str(status) + " " + str(len(body))) }`},
+			{"json-path", `func main() { body := https_get("https://api.github.com/repos/javimosch/machin")
+	full, err := json_get(body, ".full_name")  if len(err) == 0 { println(full) } }`},
+			{"ffi-extern", `extern "m" { cflags "-lm" header "math.h" fn sqrt(float) float }
+func main() { println(str(sqrt(2.0))) }`},
+		},
+		Gotchas: []guideNote{
+			{"build", "Author loose Go-like .src, then `machin encode a.src > a.mfl` and `machin build a.mfl -o app`. The .mfl is canonical plain text (one decl/line)."},
+			{"multi-assign-only", "http_get and json_get return multiple values; use `a, b, c := http_get(u)`. Calling them as a single value is a compile error."},
+			{"composite-literal", "T{...} literals need T to be a known struct type at parse time. `machin encode` registers all `type` decls first, so this just works in normal builds."},
+			{"stdout-buffering", "libc fully buffers stdout when it's a pipe; a streaming program must call flush() after a write to appear promptly downstream. A TTY is line-buffered."},
+			{"channels-cross-goroutine", "Values sent over a channel are deep-copied across the goroutine/arena boundary (strings fast; slices/maps/structs via JSON), so they survive the sender goroutine. Channels of closures/funcs are not deep-copied."},
+			{"select-closed", "A closed channel makes its select receive case ready, firing repeatedly (with ok==false if you wrote `case v, ok := <-ch:`). Detect close and stop selecting on it."},
+			{"no-tls-without-https", "There is no raw TLS socket; use https_get/https_post (REST) and wss_* (WebSocket). Plain dial/listen are TCP without TLS."},
+			{"floats-over-chan-json", "A slice/map channel element round-trips through JSON, which formats floats with %g (not bit-exact for pathological doubles)."},
+			{"memory", "Per-goroutine arena, reclaimed in bulk when the goroutine returns; wrap a hot allocating loop in `arena { ... }` to keep peak memory flat. Build with --safe for bounds/overflow/div-zero checks."},
+		},
+	}
+}
+
+// cmdGuide prints the feature catalog: JSON by default (machine-readable, the
+// intended agent entry point), or a dense prose form with --text.
+func cmdGuide(args []string) error {
+	text := false
+	for _, a := range args {
+		switch a {
+		case "--text", "-t":
+			text = true
+		case "--json":
+			text = false
+		}
+	}
+	g := machinGuide()
+	if text {
+		fmt.Print(renderGuideText(g))
+		return nil
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(g)
+}
+
+func renderGuideText(g guideCatalog) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "machin %s — %s\n\n", g.Version, g.Tagline)
+	fmt.Fprintf(&b, "KEYWORDS: %s\n\n", strings.Join(g.Keywords, " "))
+
+	b.WriteString("TYPES\n")
+	for _, t := range g.Types {
+		fmt.Fprintf(&b, "  %-10s %s\n", t.Topic, t.Note)
+	}
+
+	b.WriteString("\nBUILTINS (by category)\n")
+	cat := ""
+	for _, bi := range g.Builtins {
+		if bi.Category != cat {
+			cat = bi.Category
+			fmt.Fprintf(&b, "  [%s]\n", cat)
+		}
+		fmt.Fprintf(&b, "    %s %s — %s\n", bi.Name, bi.Sig, bi.Summary)
+	}
+
+	b.WriteString("\nIDIOMS\n")
+	for _, id := range g.Idioms {
+		fmt.Fprintf(&b, "  # %s\n", id.Name)
+		for _, line := range strings.Split(id.Code, "\n") {
+			fmt.Fprintf(&b, "  %s\n", line)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("GOTCHAS\n")
+	for _, n := range g.Gotchas {
+		fmt.Fprintf(&b, "  %s: %s\n", n.Topic, n.Note)
+	}
+	return b.String()
+}

--- a/guide_test.go
+++ b/guide_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The catalog must be well-formed and self-consistent: version stamped, no
+// duplicate builtins, every section populated.
+func TestGuideCatalog(t *testing.T) {
+	g := machinGuide()
+	if g.Version != machinVersion {
+		t.Fatalf("guide version %q != machinVersion %q", g.Version, machinVersion)
+	}
+	if g.Schema == "" || g.Tagline == "" {
+		t.Fatal("guide missing schema/tagline")
+	}
+	if len(g.Builtins) < 40 || len(g.Idioms) == 0 || len(g.Gotchas) == 0 || len(g.Keywords) == 0 {
+		t.Fatalf("guide looks under-populated: %d builtins, %d idioms, %d gotchas", len(g.Builtins), len(g.Idioms), len(g.Gotchas))
+	}
+	seen := map[string]bool{}
+	for _, b := range g.Builtins {
+		if seen[b.Name] {
+			t.Fatalf("duplicate builtin in catalog: %s", b.Name)
+		}
+		seen[b.Name] = true
+		if b.Sig == "" || b.Summary == "" || b.Category == "" {
+			t.Fatalf("builtin %q missing sig/summary/category", b.Name)
+		}
+	}
+	// must marshal to JSON (the default agent-facing output)
+	if _, err := json.Marshal(g); err != nil {
+		t.Fatalf("guide JSON: %v", err)
+	}
+}
+
+// The catalog version is the toolchain version; it must match the README badge,
+// so cutting a release can't silently leave `machin guide` reporting a stale one.
+func TestGuideVersionMatchesReadme(t *testing.T) {
+	data, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := "version-" + machinVersion + "-blue"
+	if !strings.Contains(string(data), marker) {
+		t.Fatalf("README badge does not show machinVersion %q (looked for %q)", machinVersion, marker)
+	}
+}
+
+// No phantoms: every builtin the catalog advertises must be recognized by the
+// compiler. A call to an unknown name fails with `undefined function "name"`;
+// any other error (arity/type/multi-assign) still means the builtin is real.
+func TestGuideBuiltinsRecognized(t *testing.T) {
+	for _, b := range machinGuide().Builtins {
+		n := argCount(b.Sig)
+		args := make([]string, n)
+		for i := range args {
+			args[i] = `""`
+		}
+		src := fmt.Sprintf("func main() { %s(%s) }", b.Name, strings.Join(args, ", "))
+		fn, err := ParseFunc(normalize(src))
+		if err != nil {
+			t.Fatalf("builtin %q: parse: %v", b.Name, err)
+		}
+		_, err = Check(&Program{Funcs: []*FuncDecl{fn}})
+		if err != nil && strings.Contains(err.Error(), fmt.Sprintf("undefined function %q", b.Name)) {
+			t.Fatalf("catalog lists builtin %q but the compiler does not know it", b.Name)
+		}
+	}
+}
+
+// Every idiom in the guide must be valid, type-correct MFL — so the reference an
+// agent copies from can't rot. Compiled through the real encode path (which
+// registers struct types first), but not linked/run (network/FFI idioms only
+// need to type-check).
+func TestGuideIdiomsCompile(t *testing.T) {
+	for _, id := range machinGuide().Idioms {
+		blocks, err := splitFunctions(id.Code)
+		if err != nil {
+			t.Fatalf("idiom %q: split: %v", id.Name, err)
+		}
+		var decls []string
+		for _, b := range blocks {
+			decls = append(decls, normalize(b))
+		}
+		prog, err := ParseProgram(decls)
+		if err != nil {
+			t.Fatalf("idiom %q: parse: %v", id.Name, err)
+		}
+		if _, err := CompileToC(prog, false); err != nil {
+			t.Fatalf("idiom %q: typecheck: %v", id.Name, err)
+		}
+	}
+}
+
+// argCount derives the arity from a signature like "(string, int) -> int".
+func argCount(sig string) int {
+	open := strings.Index(sig, "(")
+	close := strings.Index(sig, ")")
+	if open < 0 || close <= open {
+		return 0
+	}
+	inner := strings.TrimSpace(sig[open+1 : close])
+	if inner == "" {
+		return 0
+	}
+	if strings.Contains(inner, "...") {
+		return 1
+	}
+	return strings.Count(inner, ",") + 1
+}

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ func main() {
 		err = cmdEncode(os.Args[2:])
 	case "pack":
 		err = cmdPack(os.Args[2:])
+	case "guide":
+		err = cmdGuide(os.Args[2:])
 	case "help", "-h", "--help":
 		usage()
 	default:
@@ -59,6 +61,10 @@ usage:
   machin build|run <file.mfl> --safe  insert bounds / div-zero / overflow checks
   machin encode <src>                mint canonical MFL from loose Go-like text
   machin pack  <file.mfl>            emit the dense base64 form (distribution)
+  machin guide                       full feature catalog as JSON (--text for prose)
+
+Agents: run "machin guide" for the complete, version-exact feature surface —
+keywords, every builtin with signature, idioms, and gotchas — in one call.
 
 A .mfl program is canonical plain text: one normalized function per line, a
 blank line between functions. `+"`machin run`"+` also reads the packed base64 form.


### PR DESCRIPTION
## Why
An agent landing on machin had to read `SPEC.md` + `docs/LANGUAGE.md` + 44 examples + the CHANGELOG to learn the language — no single authoritative surface, and the builtin list lived in three hand-synced places (the type checker, the SPEC table, prose docs) that drift as features land (we added ~15 builtins across 8 releases this stretch).

## What
A single **in-binary source-of-truth catalog** + a **`machin guide`** command that emits it:

- **JSON by default** (the agent entry point): `{version, schema, tagline, keywords, types, builtins[], idioms[], gotchas[]}`. Each builtin carries `{name, sig, summary, category}`.
- `--text` for dense human/agent prose.
- Generated from the compiler's own data, so it's **version-exact and cannot drift** from the implementation.

Follows the agent-friendly-CLI conventions you pointed me at (help-as-data, JSON-by-default, self-describing, dense-not-chatty).

## Can't rot — enforced by `guide_test.go`
- every catalogued builtin is **recognized by the compiler** (a call doesn't error `undefined function`) — no phantoms (51/51 pass)
- `machinVersion` **matches the README badge** (so a release can't leave the guide stale)
- every **idiom snippet compiles** (type-checks through the real encode path)

`machinVersion` is now the single toolchain version; README + AGENTS.md point at `machin guide` as the way to learn MFL; the release checklist includes bumping it. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)