### PR TITLE
release: v0.19.0 (machin guide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.19.0
 
 - **`machin guide` — self-describing feature catalog for agents.** One command
   emits machin's complete, version-exact surface — keywords, types, every builtin

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.18.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.19.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.18.0
+Version 0.19.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.18.0"
+const machinVersion = "0.19.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Cuts **v0.19.0**, capturing `machin guide` (#139) already on `main`:

- **`machin guide`** — self-describing feature catalog (JSON by default, `--text` prose) so agents master the language in one call.

Version bumps: README badge, `SPEC.md`, `machinVersion` in `guide.go`, `CHANGELOG.md`. Full suite green. On merge I'll tag `v0.19.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)