### PR TITLE
release: v0.20.0 (guide completeness + flags module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Changelog
 
-## Unreleased
+## v0.20.0
 
+- **`machin guide` completeness pass.** A fresh-eyes audit confirmed the builtin
+  (51) and keyword catalogs match the compiler exactly, and filled the gaps: new
+  idioms for the *functions* surface (`variadic`, `named-returns`, `closure`,
+  `generic`, `scoped-arena`) and new gotchas — struct **value semantics** (copied
+  on pass; use a map for shared mutable state), **no map comma-ok** (`v, ok :=
+  m[k]` doesn't compile), the `parse(s, T{})` **witness**, and **unspecified
+  evaluation order** (the review found `f() + g()` runs right-to-left, unlike Go;
+  tracked in #142). Now 14 idioms, 13 gotchas, all compiled by a test.
 - **`framework/flags.src` — a CLI flag parser (MFL module).** Every machin tool
   hand-rolled its argument parsing; this is a reusable parser composed like
   `machweb` (`machin encode framework/flags.src yourtool.src`). Short/long flags,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.19.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.20.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.19.0
+Version 0.20.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.19.0"
+const machinVersion = "0.20.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Cuts **v0.20.0**:

- `machin guide` completeness pass (#143) — function idioms + value-semantics/map-comma-ok/eval-order gotchas.
- `framework/flags.src` CLI flag parser (#141).

Version bumps: README badge, `SPEC.md`, `machinVersion`, `CHANGELOG.md`. Full suite green. On merge I'll tag `v0.20.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)