### PR TITLE
fix: enforce left-to-right evaluation order (closes #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.21.0
+
+- **Left-to-right evaluation order (fixes #142).** Operands and arguments now
+  evaluate in source order, matching Go — previously machin inherited C's
+  unspecified order, so `f() + g()` could run `g()` first. Codegen hoists
+  side-effecting sub-expressions into sequenced temporaries (a GNU statement-
+  expression) for binary ops, call arguments, slice/struct literals, and
+  multi-return lists; pure expressions are untouched (no overhead). The
+  `eval-order` note in `machin guide` now states the guarantee.
+
 ## v0.20.0
 
 - **`machin guide` completeness pass.** A fresh-eyes audit confirmed the builtin

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.20.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.21.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.20.0
+Version 0.21.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -184,6 +184,10 @@ throughout the function body).
 - **Field access** `x.f` and assignment `x.f = v`.
 - **Calls** `f(args)`; a function value may also be called: `g()(x)`, `fs[i](x)`.
 - **Receive** `<-ch`.
+- **Evaluation order** is **left-to-right** (as in Go): the operands of a binary
+  operator, the arguments of a call, the elements of a slice/struct literal, and
+  the values of a multi-return `return` are evaluated in source order, so their
+  side effects are sequenced predictably.
 
 ---
 

--- a/codegen.go
+++ b/codegen.go
@@ -1405,18 +1405,22 @@ func (g *cgen) stmt(s Stmt, depth int) error {
 			g.emitNamedReturn(g.curFn)
 			return nil
 		}
-		exprs := make([]string, len(st.Vals))
-		for i, v := range st.Vals {
-			e, err := g.expr(v)
+		if len(st.Vals) == 1 {
+			e, err := g.expr(st.Vals[0])
 			if err != nil {
 				return err
 			}
-			exprs[i] = "(" + e + ")"
-		}
-		if len(exprs) == 1 {
-			g.buf.WriteString("return " + exprs[0] + ";\n")
+			g.buf.WriteString("return (" + e + ");\n")
 		} else {
-			fmt.Fprintf(&g.buf, "return (%s_ret){ %s };\n", g.c.CName(g.curFn), strings.Join(exprs, ", "))
+			// multiple return values: sequence them left-to-right (a C aggregate
+			// initializer's elements are otherwise unordered).
+			ret, err := g.seqExprs(st.Vals, func(names []string) (string, error) {
+				return fmt.Sprintf("(%s_ret){ %s }", g.c.CName(g.curFn), strings.Join(names, ", ")), nil
+			})
+			if err != nil {
+				return err
+			}
+			g.buf.WriteString("return " + ret + ";\n")
 		}
 	case *BreakStmt:
 		g.buf.WriteString("break;\n")
@@ -2047,39 +2051,105 @@ func (g *cgen) expr(e Expr) (string, error) {
 	return "", fmt.Errorf("codegen: unknown expression %T", e)
 }
 
+// exprHasSideEffect reports whether evaluating e could have an observable side
+// effect (or observe one) — i.e. it contains a call or a channel receive. Used
+// to decide when operand evaluation order is significant.
+func exprHasSideEffect(e Expr) bool {
+	switch x := e.(type) {
+	case *Call, *CallValue, *Recv:
+		return true
+	case *Unary:
+		return exprHasSideEffect(x.X)
+	case *Binary:
+		return exprHasSideEffect(x.L) || exprHasSideEffect(x.R)
+	case *Index:
+		return exprHasSideEffect(x.X) || exprHasSideEffect(x.Idx)
+	case *FieldAccess:
+		return exprHasSideEffect(x.X)
+	case *SliceLit:
+		for _, el := range x.Elems {
+			if exprHasSideEffect(el) {
+				return true
+			}
+		}
+	case *StructLit:
+		for _, v := range x.Vals {
+			if exprHasSideEffect(v) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// seqExprs evaluates exprs in source order and passes their C strings to build.
+// C leaves operand/argument evaluation order unspecified, but Go (and MFL) fixes
+// it left-to-right; so when any sub-expression has a side effect and there is
+// more than one, the values are hoisted into temporaries inside a GNU statement-
+// expression (whose declarations are sequenced) before being combined.
+func (g *cgen) seqExprs(exprs []Expr, build func([]string) (string, error)) (string, error) {
+	strs := make([]string, len(exprs))
+	impure := false
+	for i, e := range exprs {
+		s, err := g.expr(e)
+		if err != nil {
+			return "", err
+		}
+		strs[i] = s
+		if exprHasSideEffect(e) {
+			impure = true
+		}
+	}
+	if !impure || len(exprs) < 2 {
+		return build(strs)
+	}
+	id := g.tmpID
+	g.tmpID++
+	var decls strings.Builder
+	names := make([]string, len(exprs))
+	for i, e := range exprs {
+		n := fmt.Sprintf("_sq%d_%d", id, i)
+		names[i] = n
+		fmt.Fprintf(&decls, "%s %s = %s; ", g.c.NodeCType(g.curFn, e), n, strs[i])
+	}
+	body, err := build(names)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("({ %s%s; })", decls.String(), body), nil
+}
+
 func (g *cgen) binary(ex *Binary) (string, error) {
-	l, err := g.expr(ex.L)
-	if err != nil {
-		return "", err
-	}
-	r, err := g.expr(ex.R)
-	if err != nil {
-		return "", err
-	}
+	return g.seqExprs([]Expr{ex.L, ex.R}, func(n []string) (string, error) {
+		return g.binaryCombine(ex, n[0], n[1]), nil
+	})
+}
+
+func (g *cgen) binaryCombine(ex *Binary, l, r string) string {
 	if ex.Op == "+" && g.c.NodeKind(g.curFn, ex) == KString {
-		return fmt.Sprintf("mfl_cat(%s, %s)", l, r), nil
+		return fmt.Sprintf("mfl_cat(%s, %s)", l, r)
 	}
 	// Compare strings by value, not by pointer. C's == on char* compares
 	// addresses, so equal-but-distinct strings would wrongly differ.
 	if (ex.Op == "==" || ex.Op == "!=") && g.c.NodeKind(g.curFn, ex.L) == KString {
-		return fmt.Sprintf("(strcmp(%s, %s) %s 0)", l, r, ex.Op), nil
+		return fmt.Sprintf("(strcmp(%s, %s) %s 0)", l, r, ex.Op)
 	}
 	// --safe: checked integer arithmetic (overflow) and division (by zero)
 	if g.safe && g.c.NodeKind(g.curFn, ex) == KInt {
 		switch ex.Op {
 		case "+":
-			return fmt.Sprintf("mfl_iadd(%s, %s)", l, r), nil
+			return fmt.Sprintf("mfl_iadd(%s, %s)", l, r)
 		case "-":
-			return fmt.Sprintf("mfl_isub(%s, %s)", l, r), nil
+			return fmt.Sprintf("mfl_isub(%s, %s)", l, r)
 		case "*":
-			return fmt.Sprintf("mfl_imul(%s, %s)", l, r), nil
+			return fmt.Sprintf("mfl_imul(%s, %s)", l, r)
 		case "/":
-			return fmt.Sprintf("mfl_idiv(%s, %s)", l, r), nil
+			return fmt.Sprintf("mfl_idiv(%s, %s)", l, r)
 		case "%":
-			return fmt.Sprintf("mfl_imod(%s, %s)", l, r), nil
+			return fmt.Sprintf("mfl_imod(%s, %s)", l, r)
 		}
 	}
-	return fmt.Sprintf("(%s %s %s)", l, ex.Op, r), nil
+	return fmt.Sprintf("(%s %s %s)", l, ex.Op, r)
 }
 
 // isBoxed reports whether a variable in the current instance is captured by a
@@ -2124,36 +2194,32 @@ func (g *cgen) sliceLit(ex *SliceLit) (string, error) {
 		// struct / nested-slice elements: build empty + append in source instead
 		return "", fmt.Errorf("non-empty []%s literals are not supported; build with append", ek)
 	}
-	parts := []string{strconv.Itoa(len(ex.Elems))}
-	for _, el := range ex.Elems {
-		e, err := g.expr(el)
-		if err != nil {
-			return "", err
+	return g.seqExprs(ex.Elems, func(names []string) (string, error) {
+		parts := []string{strconv.Itoa(len(ex.Elems))}
+		for _, n := range names {
+			parts = append(parts, fmt.Sprintf("(%s)(%s)", cast, n))
 		}
-		parts = append(parts, fmt.Sprintf("(%s)(%s)", cast, e))
-	}
-	return builder + "(" + strings.Join(parts, ", ") + ")", nil
+		return builder + "(" + strings.Join(parts, ", ") + ")", nil
+	})
 }
 
 // structLit emits a C compound literal: (mfl_Point){ .f_x = (1), .f_y = (2) }
 // for keyed literals, or positional (mfl_Point){ (1), (2) }.
 func (g *cgen) structLit(ex *StructLit) (string, error) {
-	parts := make([]string, len(ex.Vals))
-	for i, v := range ex.Vals {
-		e, err := g.expr(v)
-		if err != nil {
-			return "", err
+	return g.seqExprs(ex.Vals, func(names []string) (string, error) {
+		if len(names) == 0 {
+			return fmt.Sprintf("(mfl_%s){0}", ex.Type), nil
 		}
-		if len(ex.FieldNames) > 0 {
-			parts[i] = fmt.Sprintf(".f_%s = (%s)", ex.FieldNames[i], e)
-		} else {
-			parts[i] = "(" + e + ")"
+		parts := make([]string, len(names))
+		for i, n := range names {
+			if len(ex.FieldNames) > 0 {
+				parts[i] = fmt.Sprintf(".f_%s = (%s)", ex.FieldNames[i], n)
+			} else {
+				parts[i] = "(" + n + ")"
+			}
 		}
-	}
-	if len(parts) == 0 {
-		return fmt.Sprintf("(mfl_%s){0}", ex.Type), nil
-	}
-	return fmt.Sprintf("(mfl_%s){%s}", ex.Type, strings.Join(parts, ", ")), nil
+		return fmt.Sprintf("(mfl_%s){%s}", ex.Type, strings.Join(parts, ", ")), nil
+	})
 }
 
 // mapKeyArgs returns the (int-key, string-key) C arguments for a map op: a
@@ -2438,14 +2504,12 @@ func (g *cgen) jsonParser(typeStr string) (string, error) {
 }
 
 func (g *cgen) call(ex *Call) (string, error) {
-	args := make([]string, len(ex.Args))
-	for i, a := range ex.Args {
-		s, err := g.expr(a)
-		if err != nil {
-			return "", err
-		}
-		args[i] = s
-	}
+	return g.seqExprs(ex.Args, func(args []string) (string, error) {
+		return g.callBody(ex, args)
+	})
+}
+
+func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	switch ex.Callee {
 	case "len":
 		switch g.c.NodeKind(g.curFn, ex.Args[0]) {

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.20.0"
+const machinVersion = "0.21.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -171,7 +171,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"map-comma-ok", "There is no map comma-ok: `v, ok := m[k]` does NOT compile. A read of an absent key returns the value type's zero value; use has(m, k) to test presence. (comma-ok is for channel receives: `v, ok := <-ch`.)"},
 			{"parse-witness", "parse(s, T{}) needs a value of T as a type witness, e.g. `u := parse(body, User{})`. For schemaless extraction use json_get(s, path); json(x) serializes any value."},
 			{"multi-assign-only", "http_get and json_get return multiple values; use `a, b, c := http_get(u)`. Calling them as a single value is a compile error."},
-			{"eval-order", "Operand and argument evaluation order is UNSPECIFIED (it inherits C; often right-to-left), unlike Go's left-to-right. Don't rely on it for side-effecting calls: `f() + g()` may run g() first. Sequence side effects into separate statements."},
+			{"eval-order", "Operands and arguments evaluate left-to-right (as in Go), including side effects: `f() + g()` runs f() before g(). Holds for binary ops, call args, slice/struct literals, and multi-return lists."},
 			{"composite-literal", "T{...} literals need T to be a known struct type at parse time. `machin encode` registers all `type` decls first, so this just works in normal builds."},
 			{"stdout-buffering", "libc fully buffers stdout when it's a pipe; a streaming program must call flush() after a write to appear promptly downstream. A TTY is line-buffered."},
 			{"channels-cross-goroutine", "Values sent over a channel are deep-copied across the goroutine/arena boundary (strings fast; slices/maps/structs via JSON), so they survive the sender goroutine. Channels of closures/funcs are not deep-copied."},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -660,6 +660,22 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+// Operands and arguments evaluate left-to-right (Go semantics), even when they
+// have side effects — `g() + g()` on a counter yields 1 then 2, not 2 then 1.
+func TestEvalOrderLeftToRight(t *testing.T) {
+	mk := `func mk() (f) { n := 0  f = func() { n = n + 1  return n } }`
+	two := `func two(a, b) (s) { s = str(a) + "," + str(b) }`
+	main := `func main() {
+	g := mk()  println(str(g()) + " " + str(g()))
+	h := mk()  println(two(h(), h()))
+	k := mk()  xs := []int{k(), k(), k()}  println(str(xs[0]) + str(xs[1]) + str(xs[2]))
+}`
+	out, _ := buildRun(t, main, mk, two)
+	if out != "1 2\n1,2\n123\n" {
+		t.Fatalf("eval order: got %q, want %q", out, "1 2\n1,2\n123\n")
+	}
+}
+
 // comma-ok receive (v, ok := <-ch) reports false once a channel is closed and
 // drained — both standalone and inside a select case (which fires on close).
 func TestCommaOkReceive(t *testing.T) {


### PR DESCRIPTION
Closes #142.

machin inherited **C's unspecified** operand/argument evaluation order, so `f() + g()` could run `g()` first — diverging from **Go's left-to-right** guarantee (found while reviewing `machin guide`: `str(a(2)) + str(a(3))` printed `5 3`).

## Fix
Codegen hoists side-effecting sub-expressions into **sequenced temporaries** (a GNU statement-expression, whose declarations are evaluated in order) for:
- **binary operators** (`binary` → `seqExprs` + `binaryCombine`)
- **call arguments** (`call` → `seqExprs` + `callBody`)
- **slice & struct literals**
- **multi-return `return e1, e2`** lists

`print` statements and parallel assignment already evaluated in source order.

## No overhead for pure code
A new `exprHasSideEffect` gates the rewrite: an expression with no call/receive is emitted unchanged. Verified `1 + 2 * 3` produces **zero** statement-expressions.

## Verified
`g() + g()` on a counter → `1 2` (was `2 1`); `two(g(), g())` → `1,2`; `[]int{g(),g(),g()}` → `1,2,3`; `Pair{a: h(), b: h()}` → `a=1 b=2`; `return g(), g()` → `1 2`. `TestEvalOrderLeftToRight` + full suite green. SPEC §6 + the guide note document the guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)