### PR TITLE
feat: regex builtins (POSIX ERE) — regex_match/find/groups/replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.22.0
+
+- **Regex builtins — `regex_match`, `regex_find`, `regex_groups`, `regex_replace`.**
+  POSIX extended-regex (ERE) over the subject string: test a match, extract the
+  first match, pull capture groups (`[0]` whole, `[1..]` subgroups), or replace
+  all matches. Backed by libc's `<regex.h>`, emitted only when a program uses
+  `regex_*` (so others stay portable). Surfaced building a grep.
+
 ## v0.21.0
 
 - **Left-to-right evaluation order (fixes #142).** Operands and arguments now

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.21.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.22.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops + regex (`regex_match`/`find`/`groups`/`replace`)
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.21.0
+Version 0.22.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -255,6 +255,10 @@ throughout the function body).
 | `replace` | `(string, string, string) -> string` | replace all |
 | `split` | `(string, string) -> []string` | split |
 | `join` | `([]string, string) -> string` | join |
+| `regex_match` | `(string, string) -> bool` | does a POSIX ERE pattern match anywhere in s |
+| `regex_find` | `(string, string) -> string` | first ERE match in s (`""` if none) |
+| `regex_groups` | `(string, string) -> []string` | first match's groups: `[0]` whole, `[1..]` captures (`[]` if none) |
+| `regex_replace` | `(string, string, string) -> string` | replace all ERE matches in s with repl |
 | `sleep` | `(int) -> ` | pause (milliseconds) |
 | `dial` | `(string, int) -> int` | connect to host:port; an fd, or -1 on failure |
 | `listen`, `accept` | `(int) -> int` | open / accept on a TCP socket |

--- a/codegen.go
+++ b/codegen.go
@@ -63,6 +63,7 @@ type cgen struct {
 	safe      bool   // emit runtime bounds / div-by-zero / overflow checks
 	usesTLS   bool   // program calls https_get/https_post -> emit + link OpenSSL
 	usesWSS   bool   // program calls wss_* -> emit WebSocket runtime + link OpenSSL
+	usesRegex bool   // program calls regex_* -> emit POSIX regex runtime
 }
 
 const cRuntime = `#define _GNU_SOURCE
@@ -1050,6 +1051,83 @@ static int64_t mfl_wss_close(int64_t h) {
 }
 `
 
+// regexRuntime is POSIX extended-regex (ERE) support via libc's <regex.h>,
+// emitted only when a program calls regex_*. match/find/groups/replace operate
+// on the subject first (like the other string builtins). A bad pattern fails
+// safe: match=false, find/replace return the input/empty, groups returns [].
+const regexRuntime = `#include <regex.h>
+
+static int mfl_regex_match(const char* s, const char* pat) {
+    regex_t re;
+    if (regcomp(&re, pat, REG_EXTENDED | REG_NOSUB) != 0) return 0;
+    int r = regexec(&re, s, 0, NULL, 0);
+    regfree(&re);
+    return r == 0 ? 1 : 0;
+}
+static char* mfl_regex_find(const char* s, const char* pat) {
+    regex_t re;
+    if (regcomp(&re, pat, REG_EXTENDED) != 0) return mfl_dup_arena("", 0);
+    regmatch_t m[1];
+    char* out = mfl_dup_arena("", 0);
+    if (regexec(&re, s, 1, m, 0) == 0 && m[0].rm_so >= 0) {
+        out = mfl_dup_arena(s + m[0].rm_so, (size_t)(m[0].rm_eo - m[0].rm_so));
+    }
+    regfree(&re);
+    return out;
+}
+/* groups: []string of the first match — index 0 is the whole match, 1..n the
+   captured subgroups (an unmatched optional group is ""). Empty if no match. */
+static mfl_slice mfl_regex_groups(const char* s, const char* pat) {
+    mfl_slice out = {0};
+    regex_t re;
+    if (regcomp(&re, pat, REG_EXTENDED) != 0) return out;
+    size_t ng = re.re_nsub + 1;
+    regmatch_t* m = (regmatch_t*)malloc(ng * sizeof(regmatch_t));
+    if (regexec(&re, s, ng, m, 0) == 0) {
+        for (size_t i = 0; i < ng; i++) {
+            char* g;
+            if (m[i].rm_so >= 0) g = mfl_dup_arena(s + m[i].rm_so, (size_t)(m[i].rm_eo - m[i].rm_so));
+            else g = mfl_dup_arena("", 0);
+            out = mfl_append(out, &g, sizeof(char*));
+        }
+    }
+    free(m);
+    regfree(&re);
+    return out;
+}
+static char* mfl_regex_replace(const char* s, const char* pat, const char* repl) {
+    regex_t re;
+    if (regcomp(&re, pat, REG_EXTENDED) != 0) return mfl_dup_arena(s, strlen(s));
+    size_t cap = strlen(s) + 64, len = 0, rl = strlen(repl);
+    char* out = (char*)malloc(cap);
+    const char* p = s;
+    regmatch_t m[1];
+    int eflags = 0;
+    while (regexec(&re, p, 1, m, eflags) == 0) {
+        size_t so = (size_t)m[0].rm_so, eo = (size_t)m[0].rm_eo;
+        while (len + so + rl + 2 >= cap) { cap *= 2; out = (char*)realloc(out, cap); }
+        memcpy(out + len, p, so); len += so;
+        memcpy(out + len, repl, rl); len += rl;
+        if (eo == so) { /* empty match: emit one char to make progress */
+            if (p[eo] == 0) { p += eo; break; }
+            out[len++] = p[eo];
+            p += eo + 1;
+        } else {
+            p += eo;
+        }
+        eflags = REG_NOTBOL;
+    }
+    size_t rest = strlen(p);
+    while (len + rest + 1 >= cap) { cap *= 2; out = (char*)realloc(out, cap); }
+    memcpy(out + len, p, rest); len += rest;
+    out[len] = 0;
+    regfree(&re);
+    char* r = mfl_dup_arena(out, len);
+    free(out);
+    return r;
+}
+`
+
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
 func isFFIScalar(t string) bool {
 	switch t {
@@ -1188,6 +1266,12 @@ func (g *cgen) program(p *Program) (string, error) {
 	}
 	if g.usesWSS {
 		out.WriteString(wssRuntime)
+		out.WriteByte('\n')
+	}
+	if g.usesRegex {
+		// POSIX regex (libc) — emitted only when a program calls regex_*, so other
+		// programs don't pull in <regex.h> (keeps them portable to libcs without it).
+		out.WriteString(regexRuntime)
 		out.WriteByte('\n')
 	}
 	// foreign (extern) declarations. With a header, its prototypes + C structs are
@@ -2577,6 +2661,18 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_exit(%s)", args[0]), nil
 	case "flush":
 		return "mfl_flush()", nil
+	case "regex_match":
+		g.usesRegex = true
+		return fmt.Sprintf("mfl_regex_match(%s, %s)", args[0], args[1]), nil
+	case "regex_find":
+		g.usesRegex = true
+		return fmt.Sprintf("mfl_regex_find(%s, %s)", args[0], args[1]), nil
+	case "regex_replace":
+		g.usesRegex = true
+		return fmt.Sprintf("mfl_regex_replace(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "regex_groups":
+		g.usesRegex = true
+		return fmt.Sprintf("mfl_regex_groups(%s, %s)", args[0], args[1]), nil
 	case "str":
 		if g.c.NodeKind(g.curFn, ex.Args[0]) == KFloat {
 			return fmt.Sprintf("mfl_str_d(%s)", args[0]), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.21.0"
+const machinVersion = "0.22.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -109,6 +109,11 @@ func machinGuide() guideCatalog {
 			{"replace", "(string, string, string) -> string", "replace all", "string"},
 			{"split", "(string, string) -> []string", "split on a separator", "string"},
 			{"join", "([]string, string) -> string", "join with a separator", "string"},
+			// regex (POSIX extended)
+			{"regex_match", "(string, string) -> bool", "does the ERE pattern match anywhere in s", "regex"},
+			{"regex_find", "(string, string) -> string", "first ERE match in s (\"\" if none)", "regex"},
+			{"regex_groups", "(string, string) -> []string", "first match's groups: [0]=whole, [1..]=captures ([] if none)", "regex"},
+			{"regex_replace", "(string, string, string) -> string", "replace all ERE matches in s with repl", "regex"},
 			// json
 			{"json", "(any) -> string", "serialize a value to JSON", "json"},
 			{"parse", "(string, T{}) -> T", "parse JSON into T (T{} is a type witness)", "json"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -660,6 +660,20 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+// POSIX regex builtins: match, find, capture groups, and replace-all.
+func TestRegex(t *testing.T) {
+	main := `func main() {
+	ok := "false"  if regex_match("a@b.co", "^[a-z]+@[a-z]+\.[a-z]+$") { ok = "true" }
+	g := regex_groups("2026-06-22", "([0-9]+)-([0-9]+)-([0-9]+)")
+	gs := ""  if len(g) == 4 { gs = g[1] + "/" + g[2] + "/" + g[3] }
+	println(ok + "|" + regex_find("id 4821 x", "[0-9]+") + "|" + gs + "|" + regex_replace("5-9", "[0-9]+", "#"))
+}`
+	out, _ := buildRun(t, main)
+	if out != "true|4821|2026/06/22|#-#\n" {
+		t.Fatalf("regex: got %q", out)
+	}
+}
+
 // Operands and arguments evaluate left-to-right (Go semantics), even when they
 // have side effects — `g() + g()` on a counter yields 1 then 2, not 2 then 1.
 func TestEvalOrderLeftToRight(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -1805,6 +1805,35 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("flush: no args")
 		}
 		return c.cInt, nil
+	case "regex_match":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("regex_match: 2 args (s, pattern)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
+		return c.cBool, nil
+	case "regex_find":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("regex_find: 2 args (s, pattern)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
+		return c.cString, nil
+	case "regex_replace":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("regex_replace: 3 args (s, pattern, repl)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
+		c.addPair(argSlots[2], c.cString)
+		return c.cString, nil
+	case "regex_groups":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("regex_groups: 2 args (s, pattern)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
+		return newSliceSlot(c, c.cString), nil
 	case "http_get":
 		return 0, fmt.Errorf("http_get returns 3 values; use: status, body, err := http_get(url)")
 	case "json_get":


### PR DESCRIPTION
machin had plenty of string ops but no **regex**. This adds POSIX extended-regex builtins (subject-first, matching `contains`/`index`/`replace`):

- `regex_match(s, pat) -> bool` — match anywhere
- `regex_find(s, pat) -> string` — first match (`""` if none)
- `regex_groups(s, pat) -> []string` — `[0]` whole match, `[1..]` captures
- `regex_replace(s, pat, repl) -> string` — replace all matches

## Backing + gating
Implemented over libc's `<regex.h>` (regcomp/regexec) — no extra link. The regex runtime is emitted **only when a program calls `regex_*`** (verified: a `println` program includes no `<regex.h>`), so other programs stay portable to libcs without it. A malformed pattern fails safe (match=false, find/replace return input/empty, groups returns `[]`).

## Verified
match (email/digits), find, capture groups (`2026-06-22` → `2026/06/22`), replace-all (`5-9` with `[0-9]+`→`#` → `#-#`). `TestRegex` + full suite green. Added to the `machin guide` catalog (new `regex` category) and SPEC §8. Drove **machin-grep**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)