### PR TITLE
feat: base64 builtins — base64_encode / base64_decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.23.0
+
+- **Base64 builtins — `base64_encode`, `base64_decode`.** `base64_encode` emits
+  standard padded base64; `base64_decode` is lenient — it accepts the standard
+  and url-safe alphabets (`-`/`_`) and ignores padding/whitespace, so it also
+  decodes JWT segments. Pure C (no dependency), in the always-on runtime.
+  Surfaced building a JWT decoder.
+
 ## v0.22.0
 
 - **Regex builtins — `regex_match`, `regex_find`, `regex_groups`, `regex_replace`.**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.22.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.23.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops + regex (`regex_match`/`find`/`groups`/`replace`)
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops, regex, base64
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.22.0
+Version 0.23.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -255,6 +255,8 @@ throughout the function body).
 | `replace` | `(string, string, string) -> string` | replace all |
 | `split` | `(string, string) -> []string` | split |
 | `join` | `([]string, string) -> string` | join |
+| `base64_encode` | `(string) -> string` | base64-encode text (standard, padded) |
+| `base64_decode` | `(string) -> string` | base64-decode (lenient: standard + url-safe; ignores padding) |
 | `regex_match` | `(string, string) -> bool` | does a POSIX ERE pattern match anywhere in s |
 | `regex_find` | `(string, string) -> string` | first ERE match in s (`""` if none) |
 | `regex_groups` | `(string, string) -> []string` | first match's groups: `[0]` whole, `[1..]` captures (`[]` if none) |

--- a/codegen.go
+++ b/codegen.go
@@ -338,6 +338,51 @@ static char* mfl_cat(const char* a, const char* b) {
 static char* mfl_str_i(int64_t v) { char* b = mfl_alloc(24); snprintf(b, 24, "%lld", (long long)v); return b; }
 static char* mfl_str_d(double v)  { char* b = mfl_alloc(32); snprintf(b, 32, "%g", v); return b; }
 static char* mfl_dup(const char* s) { size_t n = strlen(s); char* r = mfl_alloc(n+1); memcpy(r, s, n+1); return r; }
+/* base64 (standard alphabet, padded) over text. */
+static char* mfl_base64_encode(const char* s) {
+    static const char t[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    size_t n = strlen(s), j = 0, i = 0;
+    char* out = (char*)mfl_alloc(4 * ((n + 2) / 3) + 1);
+    for (; i + 3 <= n; i += 3) {
+        uint32_t v = ((uint32_t)(unsigned char)s[i] << 16) | ((uint32_t)(unsigned char)s[i+1] << 8) | (unsigned char)s[i+2];
+        out[j++] = t[(v >> 18) & 63]; out[j++] = t[(v >> 12) & 63];
+        out[j++] = t[(v >> 6) & 63];  out[j++] = t[v & 63];
+    }
+    if (n - i == 1) {
+        uint32_t v = (uint32_t)(unsigned char)s[i] << 16;
+        out[j++] = t[(v >> 18) & 63]; out[j++] = t[(v >> 12) & 63];
+        out[j++] = '='; out[j++] = '=';
+    } else if (n - i == 2) {
+        uint32_t v = ((uint32_t)(unsigned char)s[i] << 16) | ((uint32_t)(unsigned char)s[i+1] << 8);
+        out[j++] = t[(v >> 18) & 63]; out[j++] = t[(v >> 12) & 63];
+        out[j++] = t[(v >> 6) & 63];  out[j++] = '=';
+    }
+    out[j] = 0;
+    return out;
+}
+/* lenient base64 decode: accepts standard and url-safe ('-' '_'), ignores
+   padding/whitespace, so it also decodes JWT segments. "" for empty input. */
+static int mfl_b64val(int c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+' || c == '-') return 62;
+    if (c == '/' || c == '_') return 63;
+    return -1;
+}
+static char* mfl_base64_decode(const char* s) {
+    size_t n = strlen(s), j = 0;
+    char* out = (char*)mfl_alloc(n + 1);
+    int buf = 0, bits = 0;
+    for (size_t i = 0; i < n; i++) {
+        int v = mfl_b64val((unsigned char)s[i]);
+        if (v < 0) continue;
+        buf = (buf << 6) | v; bits += 6;
+        if (bits >= 8) { bits -= 8; out[j++] = (char)((buf >> bits) & 0xFF); }
+    }
+    out[j] = 0;
+    return out;
+}
 static char* mfl_json_str(const char* s) { /* quote + escape a string */
     if (!s) s = "";
     size_t n = strlen(s), j = 0;
@@ -2661,6 +2706,10 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_exit(%s)", args[0]), nil
 	case "flush":
 		return "mfl_flush()", nil
+	case "base64_encode":
+		return fmt.Sprintf("mfl_base64_encode(%s)", args[0]), nil
+	case "base64_decode":
+		return fmt.Sprintf("mfl_base64_decode(%s)", args[0]), nil
 	case "regex_match":
 		g.usesRegex = true
 		return fmt.Sprintf("mfl_regex_match(%s, %s)", args[0], args[1]), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.22.0"
+const machinVersion = "0.23.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -109,6 +109,8 @@ func machinGuide() guideCatalog {
 			{"replace", "(string, string, string) -> string", "replace all", "string"},
 			{"split", "(string, string) -> []string", "split on a separator", "string"},
 			{"join", "([]string, string) -> string", "join with a separator", "string"},
+			{"base64_encode", "(string) -> string", "base64-encode text (standard, padded)", "string"},
+			{"base64_decode", "(string) -> string", "base64-decode (lenient: standard + url-safe; ignores padding)", "string"},
 			// regex (POSIX extended)
 			{"regex_match", "(string, string) -> bool", "does the ERE pattern match anywhere in s", "regex"},
 			{"regex_find", "(string, string) -> string", "first ERE match in s (\"\" if none)", "regex"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -660,6 +660,20 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+// base64 encode/decode, round-trip, and lenient url-safe (JWT) decoding.
+func TestBase64(t *testing.T) {
+	main := `func main() {
+	e := base64_encode("hi machin")
+	rt := "no"  if base64_decode(e) == "hi machin" { rt = "yes" }
+	jwt := base64_decode("eyJhbGciOiJIUzI1NiJ9")
+	println(e + "|" + rt + "|" + jwt)
+}`
+	out, _ := buildRun(t, main)
+	if out != "aGkgbWFjaGlu|yes|{\"alg\":\"HS256\"}\n" {
+		t.Fatalf("base64: got %q", out)
+	}
+}
+
 // POSIX regex builtins: match, find, capture groups, and replace-all.
 func TestRegex(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -1805,6 +1805,12 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("flush: no args")
 		}
 		return c.cInt, nil
+	case "base64_encode", "base64_decode":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("%s: 1 arg (string)", ex.Callee)
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cString, nil
 	case "regex_match":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("regex_match: 2 args (s, pattern)")


### PR DESCRIPTION
machin used base64 internally (its packed form) but exposed none to MFL.

- `base64_encode(s) -> string` — standard, padded
- `base64_decode(s) -> string` — **lenient**: accepts standard *and* url-safe (`-`/`_`), ignores padding/whitespace, so it also decodes **JWT** segments

Pure C (no dependency), in the always-on runtime. Verified: encode (`hi machin` → `aGkgbWFjaGlu`), UTF-8 round-trip, and a url-safe JWT header segment → `{"alg":"HS256"}`. Added to the `machin guide` catalog + SPEC §8. `TestBase64` + full suite green. Drove **machin-jwt** (decode header/payload, extract a claim with `json_get`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `base64_encode` and `base64_decode` builtins for string encoding and decoding. Features standard padded Base64 with a lenient decoder supporting both standard and URL-safe alphabets while ignoring padding and whitespace.

* **Tests**
  * Added test coverage for base64 round-trip operations and JWT payload decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->