### PR TITLE
feat: hash builtins — sha256 / hmac_sha256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.24.0
+
+- **Hash builtins — `sha256`, `hmac_sha256`.** `sha256(s)` and
+  `hmac_sha256(key, msg)` return a lowercase hex digest. Pure C (no dependency),
+  byte-exact against `sha256sum`/`openssl` (FIPS-180-4 + RFC 2104 test vectors).
+  The common use is verifying webhook signatures (GitHub `X-Hub-Signature-256`,
+  Stripe). Surfaced building a webhook signature verifier; completes the
+  decode-then-verify story machin-jwt started.
+
 ## v0.23.0
 
 - **Base64 builtins — `base64_encode`, `base64_decode`.** `base64_encode` emits

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.23.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.24.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops, regex, base64
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.23.0
+Version 0.24.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -257,6 +257,8 @@ throughout the function body).
 | `join` | `([]string, string) -> string` | join |
 | `base64_encode` | `(string) -> string` | base64-encode text (standard, padded) |
 | `base64_decode` | `(string) -> string` | base64-decode (lenient: standard + url-safe; ignores padding) |
+| `sha256` | `(string) -> string` | SHA-256 of text, lowercase hex |
+| `hmac_sha256` | `(string, string) -> string` | HMAC-SHA256(key, message), lowercase hex |
 | `regex_match` | `(string, string) -> bool` | does a POSIX ERE pattern match anywhere in s |
 | `regex_find` | `(string, string) -> string` | first ERE match in s (`""` if none) |
 | `regex_groups` | `(string, string) -> []string` | first match's groups: `[0]` whole, `[1..]` captures (`[]` if none) |

--- a/codegen.go
+++ b/codegen.go
@@ -383,6 +383,86 @@ static char* mfl_base64_decode(const char* s) {
     out[j] = 0;
     return out;
 }
+/* SHA-256 + HMAC-SHA256 (pure C, no dependency). Operate on NUL-terminated text
+   and return a lowercase hex digest. */
+static uint32_t mfl_ror32(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
+static void mfl_sha256_raw(const unsigned char* msg, size_t len, unsigned char out[32]) {
+    static const uint32_t k[64] = {
+        0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+        0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+        0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+        0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+        0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+        0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+        0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+        0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2 };
+    uint32_t h[8] = {0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19};
+    size_t newlen = ((len + 8) / 64 + 1) * 64;
+    unsigned char* m = (unsigned char*)calloc(newlen, 1);
+    memcpy(m, msg, len);
+    m[len] = 0x80;
+    uint64_t bits = (uint64_t)len * 8;
+    for (int i = 0; i < 8; i++) m[newlen - 1 - i] = (unsigned char)(bits >> (8 * i));
+    for (size_t off = 0; off < newlen; off += 64) {
+        uint32_t w[64];
+        for (int i = 0; i < 16; i++)
+            w[i] = ((uint32_t)m[off+i*4] << 24) | ((uint32_t)m[off+i*4+1] << 16) | ((uint32_t)m[off+i*4+2] << 8) | m[off+i*4+3];
+        for (int i = 16; i < 64; i++) {
+            uint32_t s0 = mfl_ror32(w[i-15],7) ^ mfl_ror32(w[i-15],18) ^ (w[i-15] >> 3);
+            uint32_t s1 = mfl_ror32(w[i-2],17) ^ mfl_ror32(w[i-2],19) ^ (w[i-2] >> 10);
+            w[i] = w[i-16] + s0 + w[i-7] + s1;
+        }
+        uint32_t a=h[0],b=h[1],c=h[2],d=h[3],e=h[4],f=h[5],g=h[6],hh=h[7];
+        for (int i = 0; i < 64; i++) {
+            uint32_t S1 = mfl_ror32(e,6) ^ mfl_ror32(e,11) ^ mfl_ror32(e,25);
+            uint32_t ch = (e & f) ^ ((~e) & g);
+            uint32_t t1 = hh + S1 + ch + k[i] + w[i];
+            uint32_t S0 = mfl_ror32(a,2) ^ mfl_ror32(a,13) ^ mfl_ror32(a,22);
+            uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+            uint32_t t2 = S0 + maj;
+            hh=g; g=f; f=e; e=d+t1; d=c; c=b; b=a; a=t1+t2;
+        }
+        h[0]+=a; h[1]+=b; h[2]+=c; h[3]+=d; h[4]+=e; h[5]+=f; h[6]+=g; h[7]+=hh;
+    }
+    free(m);
+    for (int i = 0; i < 8; i++) { out[i*4]=(unsigned char)(h[i]>>24); out[i*4+1]=(unsigned char)(h[i]>>16); out[i*4+2]=(unsigned char)(h[i]>>8); out[i*4+3]=(unsigned char)h[i]; }
+}
+static char* mfl_hex32(const unsigned char d[32]) {
+    static const char* h = "0123456789abcdef";
+    char* s = (char*)mfl_alloc(65);
+    for (int i = 0; i < 32; i++) { s[i*2] = h[d[i] >> 4]; s[i*2+1] = h[d[i] & 15]; }
+    s[64] = 0;
+    return s;
+}
+static char* mfl_sha256(const char* s) {
+    unsigned char d[32];
+    mfl_sha256_raw((const unsigned char*)s, strlen(s), d);
+    return mfl_hex32(d);
+}
+static char* mfl_hmac_sha256(const char* key, const char* msg) {
+    unsigned char k[64];
+    size_t klen = strlen(key);
+    if (klen > 64) {
+        unsigned char kh[32];
+        mfl_sha256_raw((const unsigned char*)key, klen, kh);
+        memcpy(k, kh, 32); memset(k + 32, 0, 32);
+    } else {
+        memcpy(k, key, klen); memset(k + klen, 0, 64 - klen);
+    }
+    unsigned char ipad[64], opad[64];
+    for (int i = 0; i < 64; i++) { ipad[i] = k[i] ^ 0x36; opad[i] = k[i] ^ 0x5c; }
+    size_t mlen = strlen(msg);
+    unsigned char* ibuf = (unsigned char*)malloc(64 + mlen);
+    memcpy(ibuf, ipad, 64); memcpy(ibuf + 64, msg, mlen);
+    unsigned char inner[32];
+    mfl_sha256_raw(ibuf, 64 + mlen, inner);
+    free(ibuf);
+    unsigned char obuf[96];
+    memcpy(obuf, opad, 64); memcpy(obuf + 64, inner, 32);
+    unsigned char d[32];
+    mfl_sha256_raw(obuf, 96, d);
+    return mfl_hex32(d);
+}
 static char* mfl_json_str(const char* s) { /* quote + escape a string */
     if (!s) s = "";
     size_t n = strlen(s), j = 0;
@@ -2710,6 +2790,10 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_base64_encode(%s)", args[0]), nil
 	case "base64_decode":
 		return fmt.Sprintf("mfl_base64_decode(%s)", args[0]), nil
+	case "sha256":
+		return fmt.Sprintf("mfl_sha256(%s)", args[0]), nil
+	case "hmac_sha256":
+		return fmt.Sprintf("mfl_hmac_sha256(%s, %s)", args[0], args[1]), nil
 	case "regex_match":
 		g.usesRegex = true
 		return fmt.Sprintf("mfl_regex_match(%s, %s)", args[0], args[1]), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.23.0"
+const machinVersion = "0.24.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -111,6 +111,8 @@ func machinGuide() guideCatalog {
 			{"join", "([]string, string) -> string", "join with a separator", "string"},
 			{"base64_encode", "(string) -> string", "base64-encode text (standard, padded)", "string"},
 			{"base64_decode", "(string) -> string", "base64-decode (lenient: standard + url-safe; ignores padding)", "string"},
+			{"sha256", "(string) -> string", "SHA-256 of text, lowercase hex", "crypto"},
+			{"hmac_sha256", "(string, string) -> string", "HMAC-SHA256(key, message), lowercase hex (webhook signatures)", "crypto"},
 			// regex (POSIX extended)
 			{"regex_match", "(string, string) -> bool", "does the ERE pattern match anywhere in s", "regex"},
 			{"regex_find", "(string, string) -> string", "first ERE match in s (\"\" if none)", "regex"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -660,6 +660,20 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+// SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
+func TestHashes(t *testing.T) {
+	main := `func main() {
+	println(sha256("abc"))
+	println(hmac_sha256("key", "The quick brown fox jumps over the lazy dog"))
+}`
+	out, _ := buildRun(t, main)
+	want := "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\n" +
+		"f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8\n"
+	if out != want {
+		t.Fatalf("hash: got %q, want %q", out, want)
+	}
+}
+
 // base64 encode/decode, round-trip, and lenient url-safe (JWT) decoding.
 func TestBase64(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -1805,11 +1805,18 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("flush: no args")
 		}
 		return c.cInt, nil
-	case "base64_encode", "base64_decode":
+	case "base64_encode", "base64_decode", "sha256":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("%s: 1 arg (string)", ex.Callee)
 		}
 		c.addPair(argSlots[0], c.cString)
+		return c.cString, nil
+	case "hmac_sha256":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("hmac_sha256: 2 args (key, message)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
 		return c.cString, nil
 	case "regex_match":
 		if len(argSlots) != 2 {


### PR DESCRIPTION
machin-jwt could *decode* a token but not *verify* it — there was no HMAC. This adds:

- `sha256(s) -> string` — SHA-256, lowercase hex
- `hmac_sha256(key, msg) -> string` — HMAC-SHA256, lowercase hex

## Implementation
**Pure C** (no dependency), in the always-on runtime — a standard SHA-256 plus the HMAC construction. **Byte-exact** against `sha256sum`/`openssl` on the published vectors: `sha256("abc")`, `sha256("")`, and `HMAC("key", "The quick brown fox…")`. Hex output keeps it **text-safe** (no binary-in-strings / NUL-truncation issue).

The common use is verifying **webhook signatures** (GitHub `X-Hub-Signature-256: sha256=<hex>`, Stripe). `TestHashes` pins the vectors; added to the `machin guide` catalog (new `crypto` category) + SPEC §8. Drove **machin-hmac** (sign/verify webhook signatures), completing the decode-then-verify story machin-jwt started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)