### PR TITLE
feat: read_stdin() builtin — slurp all of stdin verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.25.0
+
+- **`read_stdin()` builtin.** Reads all of stdin verbatim until EOF — exact
+  bytes, no line splitting — unlike the line-based `input()` (which strips
+  newlines and loses the trailing-newline distinction). This is what lets a tool
+  process its input byte-exact (an exact byte count, a precise webhook body, a
+  binary-ish payload). Surfaced building a `wc` clone.
+
 ## v0.24.0
 
 - **Hash builtins — `sha256`, `hmac_sha256`.** `sha256(s)` and

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.24.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.25.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.24.0
+Version 0.25.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -226,6 +226,7 @@ throughout the function body).
 |---------|-----------|---------|
 | `print`, `println` | `(...) -> ` | write arguments (no / trailing newline) |
 | `input` | `() -> string` | read one line from stdin (newline stripped; `""` at EOF) |
+| `read_stdin` | `() -> string` | read all of stdin verbatim until EOF (exact bytes; no line splitting) |
 | `args` | `() -> []string` | command-line arguments (`args()[0]` is the program path) |
 | `env` | `(string) -> string` | environment variable (`""` if unset) |
 | `now` | `() -> int` | wall-clock time in Unix seconds |

--- a/codegen.go
+++ b/codegen.go
@@ -623,6 +623,20 @@ static char* mfl_input(void) {
     buf[len] = 0;
     return buf;
 }
+/* read all of stdin verbatim until EOF (no line splitting). Exact for text;
+   an embedded NUL would truncate the string view (machin strings are C strings). */
+static char* mfl_read_stdin(void) {
+    size_t cap = 65536, len = 0;
+    char* buf = (char*)malloc(cap);
+    size_t n;
+    while ((n = fread(buf + len, 1, cap - len - 1, stdin)) > 0) {
+        len += n;
+        if (len + 1 >= cap) { cap *= 2; buf = (char*)realloc(buf, cap); }
+    }
+    char* r = mfl_dup_arena(buf, len);
+    free(buf);
+    return r;
+}
 
 /* command-line arguments, environment, and wall-clock time */
 static int mfl_argc = 0;
@@ -2830,6 +2844,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_close(%s)", args[0]), nil
 	case "input":
 		return "mfl_input()", nil
+	case "read_stdin":
+		return "mfl_read_stdin()", nil
 	case "args":
 		return "mfl_args()", nil
 	case "env":

--- a/flags_test.go
+++ b/flags_test.go
@@ -7,6 +7,30 @@ import (
 	"testing"
 )
 
+// read_stdin slurps stdin verbatim — exact bytes (including newlines, no
+// trailing-newline assumption), unlike the line-based input().
+func TestReadStdin(t *testing.T) {
+	fn := parseFuncs(t, `func main() { s := read_stdin()  println(str(len(s))) }`)
+	bin, err := os.CreateTemp("", "mfl-stdin-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fn}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cmd := exec.Command(bin.Name())
+	cmd.Stdin = strings.NewReader("a\nb\nc") // 5 bytes, no trailing newline
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "5" {
+		t.Fatalf("read_stdin byte count: got %q, want 5", strings.TrimSpace(string(out)))
+	}
+}
+
 // framework/flags.src composed with an app must parse short/long flags, the
 // `=` and space value forms, bool flags, defaults, and positionals — exercised
 // by building the real binary and passing it argv (parse_flags reads args()).

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.24.0"
+const machinVersion = "0.25.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -73,6 +73,7 @@ func machinGuide() guideCatalog {
 			{"print", "(...) ->", "write args, no trailing newline", "io"},
 			{"println", "(...) ->", "write args + trailing newline", "io"},
 			{"input", "() -> string", "read one stdin line (newline stripped; \"\" at EOF)", "io"},
+			{"read_stdin", "() -> string", "read all of stdin verbatim until EOF (exact bytes; no line splitting)", "io"},
 			{"flush", "() ->", "flush buffered stdout (prompt output through a pipe)", "io"},
 			{"read_file", "(string) -> string", "read a whole file (\"\" on error)", "io"},
 			{"write_file", "(string, string) -> int", "write a file (bytes; -1 on error)", "io"},

--- a/types.go
+++ b/types.go
@@ -1729,6 +1729,11 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("input: no args")
 		}
 		return c.cString, nil
+	case "read_stdin":
+		if len(argSlots) != 0 {
+			return 0, fmt.Errorf("read_stdin: no args")
+		}
+		return c.cString, nil
 	case "args":
 		if len(argSlots) != 0 {
 			return 0, fmt.Errorf("args: no args")


### PR DESCRIPTION
`input()` reads stdin **one line at a time with the newline stripped**, so it can't reproduce a stream's exact bytes (it loses the trailing-newline distinction, blank lines, `\r`). The most-surfaced limitation lately (flagged by machin-hmac, which had to read its body from a file or `-m`).

## Surface
- `read_stdin() -> string` — read all of stdin until EOF, **verbatim** (no line splitting).

Exact for text; an embedded NUL would truncate the string view (machin strings are C strings) — documented.

## Verified
`printf 'no newline' | prog` reports **exact** byte counts; `a\nb\nc` (no trailing newline) → 5 bytes, matching `wc -c`. `TestReadStdin` builds a binary and pipes it newline-less stdin. Added to the `machin guide` catalog + SPEC §8. Drove **machin-wc**, whose counts match coreutils `wc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)