### PR TITLE
feat: SQLite builtins — sqlite_open/exec/query/close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.26.0
+
+- **SQLite builtins — `sqlite_open`, `sqlite_exec`, `sqlite_query`, `sqlite_close`.**
+  Real database storage, backed by `libsqlite3`. `sqlite_open(path)` returns a
+  handle (`:memory:` for in-memory); `sqlite_exec` runs result-less SQL;
+  `sqlite_query` runs a SELECT and returns a **JSON array of row objects**
+  (INTEGER/REAL unquoted, TEXT escaped, NULL null) — so it composes with
+  `json_get`. Emitted and linked (`-lsqlite3`) only when a program calls
+  `sqlite_*`. Surfaced building a persistent key-value store.
+
 ## v0.25.0
 
 - **`read_stdin()` builtin.** Reads all of stdin verbatim until EOF — exact

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.25.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.26.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.25.0
+Version 0.26.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -260,6 +260,10 @@ throughout the function body).
 | `base64_decode` | `(string) -> string` | base64-decode (lenient: standard + url-safe; ignores padding) |
 | `sha256` | `(string) -> string` | SHA-256 of text, lowercase hex |
 | `hmac_sha256` | `(string, string) -> string` | HMAC-SHA256(key, message), lowercase hex |
+| `sqlite_open` | `(string) -> int` | open/create a SQLite db file → handle (0 on fail); `:memory:` for in-memory |
+| `sqlite_exec` | `(int, string) -> int` | run SQL with no result (CREATE/INSERT/…); 0 on success |
+| `sqlite_query` | `(int, string) -> string` | run a SELECT → JSON array of row objects (composes with `json_get`) |
+| `sqlite_close` | `(int) -> int` | close the database |
 | `regex_match` | `(string, string) -> bool` | does a POSIX ERE pattern match anywhere in s |
 | `regex_find` | `(string, string) -> string` | first ERE match in s (`""` if none) |
 | `regex_groups` | `(string, string) -> []string` | first match's groups: `[0]` whole, `[1..]` captures (`[]` if none) |

--- a/build.go
+++ b/build.go
@@ -50,6 +50,10 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 	if strings.Contains(csrc, "mfl_tls_dial") {
 		libs = append(libs, "-lssl", "-lcrypto")
 	}
+	// native SQLite (sqlite_*) links libsqlite3 — only when actually used.
+	if strings.Contains(csrc, "mfl_sqlite_") {
+		libs = append(libs, "-lsqlite3")
+	}
 	args = append(args, "-o", outPath, tmp.Name())
 	args = append(args, libs...)
 

--- a/codegen.go
+++ b/codegen.go
@@ -64,6 +64,7 @@ type cgen struct {
 	usesTLS   bool   // program calls https_get/https_post -> emit + link OpenSSL
 	usesWSS   bool   // program calls wss_* -> emit WebSocket runtime + link OpenSSL
 	usesRegex bool   // program calls regex_* -> emit POSIX regex runtime
+	usesSQLite bool  // program calls sqlite_* -> emit SQLite runtime + link -lsqlite3
 }
 
 const cRuntime = `#define _GNU_SOURCE
@@ -1267,6 +1268,75 @@ static char* mfl_regex_replace(const char* s, const char* pat, const char* repl)
 }
 `
 
+// sqliteRuntime is a thin SQLite client over libsqlite3, emitted (and linked
+// -lsqlite3) only when a program calls sqlite_*. A connection is an int handle
+// (the sqlite3* pointer). sqlite_query returns the result set as a JSON array of
+// row objects, so it composes with json_get. INTEGER/REAL are unquoted, TEXT is
+// JSON-escaped, NULL is null.
+const sqliteRuntime = `#include <sqlite3.h>
+
+static int64_t mfl_sqlite_open(const char* path) {
+    sqlite3* db = NULL;
+    if (sqlite3_open(path, &db) != SQLITE_OK) { sqlite3_close(db); return 0; }
+    return (int64_t)(intptr_t)db;
+}
+static int64_t mfl_sqlite_exec(int64_t h, const char* sql) {
+    sqlite3* db = (sqlite3*)(intptr_t)h;
+    if (!db) return -1;
+    char* err = NULL;
+    int r = sqlite3_exec(db, sql, NULL, NULL, &err);
+    if (err) sqlite3_free(err);
+    return r;
+}
+static int64_t mfl_sqlite_close(int64_t h) {
+    return sqlite3_close((sqlite3*)(intptr_t)h);
+}
+/* run a query, returning a JSON array of row objects. */
+static char* mfl_sqlite_query(int64_t h, const char* sql) {
+    sqlite3* db = (sqlite3*)(intptr_t)h;
+    sqlite3_stmt* st = NULL;
+    if (!db || sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK) return mfl_dup_arena("[]", 2);
+    size_t cap = 256, len = 0;
+    char* out = (char*)malloc(cap);
+    out[len++] = '[';
+    int ncol = sqlite3_column_count(st);
+    int row = 0;
+    while (sqlite3_step(st) == SQLITE_ROW) {
+        if (row++) { if (len + 1 >= cap) { cap *= 2; out = realloc(out, cap); } out[len++] = ','; }
+        if (len + 1 >= cap) { cap *= 2; out = realloc(out, cap); }
+        out[len++] = '{';
+        for (int i = 0; i < ncol; i++) {
+            char* cell;
+            const char* name = sqlite3_column_name(st, i);
+            char* jname = mfl_json_str(name ? name : "");
+            int t = sqlite3_column_type(st, i);
+            if (t == SQLITE_INTEGER || t == SQLITE_FLOAT) {
+                const unsigned char* txt = sqlite3_column_text(st, i);
+                cell = mfl_dup((const char*)(txt ? txt : (const unsigned char*)"0"));
+            } else if (t == SQLITE_NULL) {
+                cell = mfl_dup("null");
+            } else {
+                const unsigned char* txt = sqlite3_column_text(st, i);
+                cell = mfl_json_str((const char*)(txt ? txt : (const unsigned char*)""));
+            }
+            char* piece = mfl_cat(mfl_cat(jname, ":"), cell);
+            if (i) piece = mfl_cat(",", piece);
+            size_t pl = strlen(piece);
+            while (len + pl + 2 >= cap) { cap *= 2; out = realloc(out, cap); }
+            memcpy(out + len, piece, pl); len += pl;
+        }
+        if (len + 1 >= cap) { cap *= 2; out = realloc(out, cap); }
+        out[len++] = '}';
+    }
+    if (len + 1 >= cap) { cap *= 2; out = realloc(out, cap); }
+    out[len++] = ']';
+    sqlite3_finalize(st);
+    char* r = mfl_dup_arena(out, len);
+    free(out);
+    return r;
+}
+`
+
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
 func isFFIScalar(t string) bool {
 	switch t {
@@ -1411,6 +1481,12 @@ func (g *cgen) program(p *Program) (string, error) {
 		// POSIX regex (libc) — emitted only when a program calls regex_*, so other
 		// programs don't pull in <regex.h> (keeps them portable to libcs without it).
 		out.WriteString(regexRuntime)
+		out.WriteByte('\n')
+	}
+	if g.usesSQLite {
+		// SQLite (libsqlite3) — emitted and linked (-lsqlite3) only when a program
+		// calls sqlite_*, so other programs don't depend on it.
+		out.WriteString(sqliteRuntime)
 		out.WriteByte('\n')
 	}
 	// foreign (extern) declarations. With a header, its prototypes + C structs are
@@ -2808,6 +2884,18 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_sha256(%s)", args[0]), nil
 	case "hmac_sha256":
 		return fmt.Sprintf("mfl_hmac_sha256(%s, %s)", args[0], args[1]), nil
+	case "sqlite_open":
+		g.usesSQLite = true
+		return fmt.Sprintf("mfl_sqlite_open(%s)", args[0]), nil
+	case "sqlite_exec":
+		g.usesSQLite = true
+		return fmt.Sprintf("mfl_sqlite_exec(%s, %s)", args[0], args[1]), nil
+	case "sqlite_query":
+		g.usesSQLite = true
+		return fmt.Sprintf("mfl_sqlite_query(%s, %s)", args[0], args[1]), nil
+	case "sqlite_close":
+		g.usesSQLite = true
+		return fmt.Sprintf("mfl_sqlite_close(%s)", args[0]), nil
 	case "regex_match":
 		g.usesRegex = true
 		return fmt.Sprintf("mfl_regex_match(%s, %s)", args[0], args[1]), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.25.0"
+const machinVersion = "0.26.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -114,6 +114,11 @@ func machinGuide() guideCatalog {
 			{"base64_decode", "(string) -> string", "base64-decode (lenient: standard + url-safe; ignores padding)", "string"},
 			{"sha256", "(string) -> string", "SHA-256 of text, lowercase hex", "crypto"},
 			{"hmac_sha256", "(string, string) -> string", "HMAC-SHA256(key, message), lowercase hex (webhook signatures)", "crypto"},
+			// sqlite (libsqlite3, linked only when used)
+			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
+			{"sqlite_exec", "(int, string) -> int", "run SQL with no result (CREATE/INSERT/...); 0 ok", "db"},
+			{"sqlite_query", "(int, string) -> string", "run a SELECT -> JSON array of row objects (composes with json_get)", "db"},
+			{"sqlite_close", "(int) -> int", "close the database", "db"},
 			// regex (POSIX extended)
 			{"regex_match", "(string, string) -> bool", "does the ERE pattern match anywhere in s", "regex"},
 			{"regex_find", "(string, string) -> string", "first ERE match in s (\"\" if none)", "regex"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -660,6 +660,23 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+// SQLite: open in-memory, create/insert, and query back a JSON row array
+// (INTEGER unquoted, TEXT escaped) — links libsqlite3 only because sqlite_* is used.
+func TestSQLite(t *testing.T) {
+	main := `func main() {
+	db := sqlite_open(":memory:")
+	sqlite_exec(db, "CREATE TABLE t(n int, s text)")
+	sqlite_exec(db, "INSERT INTO t VALUES(1, 'a')")
+	sqlite_exec(db, "INSERT INTO t VALUES(2, 'b')")
+	println(sqlite_query(db, "SELECT n, s FROM t ORDER BY n"))
+	sqlite_close(db)
+}`
+	out, _ := buildRun(t, main)
+	if out != "[{\"n\":1,\"s\":\"a\"},{\"n\":2,\"s\":\"b\"}]\n" {
+		t.Fatalf("sqlite: got %q", out)
+	}
+}
+
 // SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
 func TestHashes(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -1823,6 +1823,28 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cString)
 		c.addPair(argSlots[1], c.cString)
 		return c.cString, nil
+	case "sqlite_open":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("sqlite_open: 1 arg (path string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cInt, nil
+	case "sqlite_exec", "sqlite_query":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("%s: 2 args (db int, sql string)", ex.Callee)
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cString)
+		if ex.Callee == "sqlite_query" {
+			return c.cString, nil
+		}
+		return c.cInt, nil
+	case "sqlite_close":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("sqlite_close: 1 arg (db int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cInt, nil
 	case "regex_match":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("regex_match: 2 args (s, pattern)")


### PR DESCRIPTION
machin had file I/O but no real **database**. This adds SQLite over `libsqlite3`.

## Surface
- `sqlite_open(path) -> int` — handle (`:memory:` for in-memory; 0 on fail)
- `sqlite_exec(db, sql) -> int` — result-less SQL (CREATE/INSERT/…); 0 ok
- `sqlite_query(db, sql) -> string` — a SELECT → **JSON array of row objects**
- `sqlite_close(db) -> int`

## Composition
`sqlite_query` returns JSON (INTEGER/REAL unquoted, TEXT escaped, NULL null), so results flow straight into **`json_get`** — e.g. `json_get(rows, ".[0].v")`. No bespoke row API needed.

## Gating
Why FFI builtins and not raw `extern`: the SQLite C API uses out-params (`sqlite3**`) and callbacks that the FFI can't express. The runtime + `-lsqlite3` link are emitted **only when a program calls `sqlite_*`** (verified: a plain program links no sqlite3), like OpenSSL for TLS.

## Verified
Create/insert/query → `[{"n":1,"s":"a"},...]`; **persistence across separate processes** (a fresh run reads the same db file). `TestSQLite` (in-memory) + full suite green. Added to the `machin guide` catalog (new `db` category) + SPEC §8. Drove **machin-kv** (a persistent key-value store).

Needs `libsqlite3-dev` to build a program that uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)