### PR TITLE
feat: parameterized SQLite queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.27.0
+
+- **Parameterized SQLite queries.** `sqlite_exec` and `sqlite_query` now take an
+  optional third argument — a `[]string` whose values bind to the `?`
+  placeholders, in order (via `sqlite3_bind_text`). This is **injection-safe**: a
+  value containing SQL is stored/compared literally, never executed. The two-arg
+  forms are unchanged.
+
 ## v0.26.0
 
 - **SQLite builtins — `sqlite_open`, `sqlite_exec`, `sqlite_query`, `sqlite_close`.**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.26.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.27.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.26.0
+Version 0.27.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -261,8 +261,8 @@ throughout the function body).
 | `sha256` | `(string) -> string` | SHA-256 of text, lowercase hex |
 | `hmac_sha256` | `(string, string) -> string` | HMAC-SHA256(key, message), lowercase hex |
 | `sqlite_open` | `(string) -> int` | open/create a SQLite db file → handle (0 on fail); `:memory:` for in-memory |
-| `sqlite_exec` | `(int, string) -> int` | run SQL with no result (CREATE/INSERT/…); 0 on success |
-| `sqlite_query` | `(int, string) -> string` | run a SELECT → JSON array of row objects (composes with `json_get`) |
+| `sqlite_exec` | `(int, string[, []string]) -> int` | run SQL with no result; an optional `[]string` binds the `?` placeholders (injection-safe); 0 on success |
+| `sqlite_query` | `(int, string[, []string]) -> string` | run a SELECT → JSON array of row objects; an optional `[]string` binds the `?` placeholders; composes with `json_get` |
 | `sqlite_close` | `(int) -> int` | close the database |
 | `regex_match` | `(string, string) -> bool` | does a POSIX ERE pattern match anywhere in s |
 | `regex_find` | `(string, string) -> string` | first ERE match in s (`""` if none) |

--- a/codegen.go
+++ b/codegen.go
@@ -1291,11 +1291,16 @@ static int64_t mfl_sqlite_exec(int64_t h, const char* sql) {
 static int64_t mfl_sqlite_close(int64_t h) {
     return sqlite3_close((sqlite3*)(intptr_t)h);
 }
-/* run a query, returning a JSON array of row objects. */
-static char* mfl_sqlite_query(int64_t h, const char* sql) {
-    sqlite3* db = (sqlite3*)(intptr_t)h;
-    sqlite3_stmt* st = NULL;
-    if (!db || sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK) return mfl_dup_arena("[]", 2);
+/* bind a []string of params positionally to ?1, ?2, ... (all as text). */
+static void mfl_sqlite_bind(sqlite3_stmt* st, mfl_slice params) {
+    for (int64_t i = 0; i < params.len; i++) {
+        const char* p = ((char**)params.data)[i];
+        sqlite3_bind_text(st, (int)(i + 1), p ? p : "", -1, SQLITE_TRANSIENT);
+    }
+}
+/* step a prepared statement to completion, returning a JSON array of row
+   objects; finalizes the statement. */
+static char* mfl_sqlite_rows_json(sqlite3_stmt* st) {
     size_t cap = 256, len = 0;
     char* out = (char*)malloc(cap);
     out[len++] = '[';
@@ -1334,6 +1339,29 @@ static char* mfl_sqlite_query(int64_t h, const char* sql) {
     char* r = mfl_dup_arena(out, len);
     free(out);
     return r;
+}
+static char* mfl_sqlite_query(int64_t h, const char* sql) {
+    sqlite3* db = (sqlite3*)(intptr_t)h;
+    sqlite3_stmt* st = NULL;
+    if (!db || sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK) return mfl_dup_arena("[]", 2);
+    return mfl_sqlite_rows_json(st);
+}
+/* parameterized variants: bind a []string of params to the ? placeholders. */
+static char* mfl_sqlite_query_p(int64_t h, const char* sql, mfl_slice params) {
+    sqlite3* db = (sqlite3*)(intptr_t)h;
+    sqlite3_stmt* st = NULL;
+    if (!db || sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK) return mfl_dup_arena("[]", 2);
+    mfl_sqlite_bind(st, params);
+    return mfl_sqlite_rows_json(st);
+}
+static int64_t mfl_sqlite_exec_p(int64_t h, const char* sql, mfl_slice params) {
+    sqlite3* db = (sqlite3*)(intptr_t)h;
+    sqlite3_stmt* st = NULL;
+    if (!db || sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK) return -1;
+    mfl_sqlite_bind(st, params);
+    int r = sqlite3_step(st);
+    sqlite3_finalize(st);
+    return (r == SQLITE_DONE || r == SQLITE_ROW) ? 0 : r;
 }
 `
 
@@ -2889,9 +2917,15 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_sqlite_open(%s)", args[0]), nil
 	case "sqlite_exec":
 		g.usesSQLite = true
+		if len(args) == 3 {
+			return fmt.Sprintf("mfl_sqlite_exec_p(%s, %s, %s)", args[0], args[1], args[2]), nil
+		}
 		return fmt.Sprintf("mfl_sqlite_exec(%s, %s)", args[0], args[1]), nil
 	case "sqlite_query":
 		g.usesSQLite = true
+		if len(args) == 3 {
+			return fmt.Sprintf("mfl_sqlite_query_p(%s, %s, %s)", args[0], args[1], args[2]), nil
+		}
 		return fmt.Sprintf("mfl_sqlite_query(%s, %s)", args[0], args[1]), nil
 	case "sqlite_close":
 		g.usesSQLite = true

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.26.0"
+const machinVersion = "0.27.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -116,8 +116,8 @@ func machinGuide() guideCatalog {
 			{"hmac_sha256", "(string, string) -> string", "HMAC-SHA256(key, message), lowercase hex (webhook signatures)", "crypto"},
 			// sqlite (libsqlite3, linked only when used)
 			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
-			{"sqlite_exec", "(int, string) -> int", "run SQL with no result (CREATE/INSERT/...); 0 ok", "db"},
-			{"sqlite_query", "(int, string) -> string", "run a SELECT -> JSON array of row objects (composes with json_get)", "db"},
+			{"sqlite_exec", "(int, string[, []string]) -> int", "run SQL with no result; optional []string binds the ? params (injection-safe); 0 ok", "db"},
+			{"sqlite_query", "(int, string[, []string]) -> string", "run a SELECT -> JSON array of rows; optional []string binds the ? params; composes with json_get", "db"},
 			{"sqlite_close", "(int) -> int", "close the database", "db"},
 			// regex (POSIX extended)
 			{"regex_match", "(string, string) -> bool", "does the ERE pattern match anywhere in s", "regex"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -677,6 +677,23 @@ func TestSQLite(t *testing.T) {
 	}
 }
 
+// Parameterized queries bind a []string to the ? placeholders — injection-safe
+// (a value containing SQL is stored literally, not executed).
+func TestSQLiteParams(t *testing.T) {
+	main := `func main() {
+	db := sqlite_open(":memory:")
+	sqlite_exec(db, "CREATE TABLE u(name TEXT)")
+	sqlite_exec(db, "INSERT INTO u VALUES(?)", []string{"'; DROP TABLE u; --"})
+	r := sqlite_query(db, "SELECT name FROM u WHERE name = ?", []string{"'; DROP TABLE u; --"})
+	println(r)
+	sqlite_close(db)
+}`
+	out, _ := buildRun(t, main)
+	if out != "[{\"name\":\"'; DROP TABLE u; --\"}]\n" {
+		t.Fatalf("sqlite params: got %q", out)
+	}
+}
+
 // SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
 func TestHashes(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -1830,11 +1830,14 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cString)
 		return c.cInt, nil
 	case "sqlite_exec", "sqlite_query":
-		if len(argSlots) != 2 {
-			return 0, fmt.Errorf("%s: 2 args (db int, sql string)", ex.Callee)
+		if len(argSlots) != 2 && len(argSlots) != 3 {
+			return 0, fmt.Errorf("%s: 2 or 3 args (db int, sql string[, params []string])", ex.Callee)
 		}
 		c.addPair(argSlots[0], c.cInt)
 		c.addPair(argSlots[1], c.cString)
+		if len(argSlots) == 3 {
+			c.addPair(argSlots[2], newSliceSlot(c, c.cString))
+		}
 		if ex.Callee == "sqlite_query" {
 			return c.cString, nil
 		}


### PR DESCRIPTION
Addresses the scope note from the SQLite PR (#167): no bound parameters.

`sqlite_exec` and `sqlite_query` now take an **optional 3rd argument — a `[]string`** whose values bind to the `?` placeholders in order (`sqlite3_bind_text`):

```machin
sqlite_exec(db, "INSERT INTO kv VALUES(?, ?)", []string{key, value})
rows := sqlite_query(db, "SELECT v FROM kv WHERE k = ?", []string{key})
```

**Injection-safe**: a value containing SQL (e.g. `'; DROP TABLE u; --`) is stored/compared **literally**, never executed (verified — the table survives). The two-arg forms are unchanged. `TestSQLiteParams` pins it; full suite green. guide + SPEC updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)