### PR TITLE
feat: time_fields builtin (calendar decomposition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.28.0
+
+- **`time_fields(unix)` builtin.** Decompose a Unix timestamp (local time) into
+  `[year, month, day, hour, minute, second, weekday(0=Sun), yearday]` — the
+  calendar view machin lacked (it had `now()` but no way to read its parts).
+  Backed by `localtime_r`. Surfaced building a cron-expression evaluator.
+
 ## v0.27.0
 
 - **Parameterized SQLite queries.** `sqlite_exec` and `sqlite_query` now take an

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.27.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.28.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`time_fields`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.27.0
+Version 0.28.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -231,6 +231,7 @@ throughout the function body).
 | `env` | `(string) -> string` | environment variable (`""` if unset) |
 | `now` | `() -> int` | wall-clock time in Unix seconds |
 | `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
+| `time_fields` | `(int) -> []int` | decompose a Unix timestamp (local time) → `[year, month(1-12), day, hour, minute, second, weekday(0=Sun), yearday]` |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
 | `exit` | `(int) -> ` | terminate the process with a status code |
 | `flush` | `() -> ` | flush buffered stdout (for prompt output through a pipe) |

--- a/codegen.go
+++ b/codegen.go
@@ -650,6 +650,18 @@ static mfl_slice mfl_args(void) {
 static char* mfl_env(const char* k) { char* v = getenv(k); return v ? v : ""; }
 static int64_t mfl_now(void) { return (int64_t)time(NULL); }
 static int64_t mfl_now_ms(void) { struct timeval tv; gettimeofday(&tv, NULL); return (int64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000; }
+/* decompose a Unix timestamp (local time) into
+   [year, month(1-12), day(1-31), hour, minute, second, weekday(0=Sun), yearday(1-366)] */
+static mfl_slice mfl_time_fields(int64_t unix) {
+    time_t t = (time_t)unix;
+    struct tm tmv;
+    localtime_r(&t, &tmv);
+    int64_t v[8] = { tmv.tm_year + 1900, tmv.tm_mon + 1, tmv.tm_mday,
+        tmv.tm_hour, tmv.tm_min, tmv.tm_sec, tmv.tm_wday, tmv.tm_yday + 1 };
+    mfl_slice s = { mfl_alloc(8 * sizeof(int64_t)), 8, 8 };
+    memcpy(s.data, v, sizeof(v));
+    return s;
+}
 static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 10); }
 
 /* file system: read/write whole files, list a directory, make a directory */
@@ -2976,6 +2988,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return "mfl_now()", nil
 	case "now_ms":
 		return "mfl_now_ms()", nil
+	case "time_fields":
+		return fmt.Sprintf("mfl_time_fields(%s)", args[0]), nil
 	case "parse_int":
 		return fmt.Sprintf("mfl_parse_int(%s)", args[0]), nil
 	case "read_file":

--- a/flags_test.go
+++ b/flags_test.go
@@ -7,6 +7,30 @@ import (
 	"testing"
 )
 
+// time_fields decomposes a unix timestamp into calendar fields (local time);
+// pinned with TZ=UTC for determinism (2026-06-23 00:00 UTC -> Tuesday).
+func TestTimeFields(t *testing.T) {
+	fn := parseFuncs(t, `func main() { f := time_fields(1782172800)  println(str(f[0]) + "-" + str(f[1]) + "-" + str(f[2]) + " " + str(f[3]) + ":" + str(f[4]) + " w" + str(f[6])) }`)
+	bin, err := os.CreateTemp("", "mfl-tf-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fn}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cmd := exec.Command(bin.Name())
+	cmd.Env = append(os.Environ(), "TZ=UTC")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "2026-6-23 0:0 w2" {
+		t.Fatalf("time_fields: got %q, want %q", strings.TrimSpace(string(out)), "2026-6-23 0:0 w2")
+	}
+}
+
 // read_stdin slurps stdin verbatim — exact bytes (including newlines, no
 // trailing-newline assumption), unlike the line-based input().
 func TestReadStdin(t *testing.T) {

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.27.0"
+const machinVersion = "0.28.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -87,6 +87,7 @@ func machinGuide() guideCatalog {
 			{"now", "() -> int", "wall-clock Unix seconds", "time"},
 			{"now_ms", "() -> int", "wall-clock milliseconds", "time"},
 			{"sleep", "(int) ->", "pause for N milliseconds", "time"},
+			{"time_fields", "(int) -> []int", "decompose a unix timestamp (local) -> [year,month,day,hour,min,sec,weekday(0=Sun),yearday]", "time"},
 			// convert
 			{"str", "(int|float) -> string", "format a number", "convert"},
 			{"int", "(number) -> int", "truncate to int", "convert"},

--- a/types.go
+++ b/types.go
@@ -1755,6 +1755,12 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("now_ms: no args")
 		}
 		return c.cInt, nil
+	case "time_fields":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("time_fields: 1 arg (unix seconds)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return newSliceSlot(c, c.cInt), nil
 	case "parse_int":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("parse_int: 1 arg (string)")


### PR DESCRIPTION
## What

Adds `time_fields(unix) -> []int` — decompose a Unix timestamp (local time) into
`[year, month(1-12), day, hour, minute, second, weekday(0=Sun), yearday]`,
backed by `localtime_r`.

machin had `now()`/`now_ms()` but no way to read a timestamp's calendar parts,
so it couldn't reason about *when* something fires. This fills that gap.

## Why

Dogfood-driven: surfaced building **machin-cron**, a cron-expression evaluator
that needs to match a candidate minute's calendar fields against a crontab line.

## Changes

- C runtime `mfl_time_fields` + type case + codegen emission (gated on use)
- `machin guide` catalog entry, SPEC builtins row, CHANGELOG `v0.28.0`
- Version markers bumped to `0.28.0` (README badge, SPEC, guide.go, CHANGELOG)
- `TestTimeFields` — TZ=UTC-pinned, asserts 1782172800 -> 2026-06-23 00:00 Tue

🤖 Generated with [Claude Code](https://claude.com/claude-code)