### PR TITLE
feat: time_format builtin (strftime formatting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.29.0
+
+- **`time_format(unix, fmt)` builtin.** Format a Unix timestamp (local time) with
+  a `strftime(3)` pattern — `%Y-%m-%d`, `%H:%M:%S`, weekday/month names (`%A`/`%B`),
+  zone name/offset (`%Z`/`%z`), `%F`, `%T`, and the rest. The pieces `time_fields`
+  can't give you (locale names, zone). Surfaced building machin-date (a `date(1)` clone).
+
 ## v0.28.0
 
 - **`time_fields(unix)` builtin.** Decompose a Unix timestamp (local time) into

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.28.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.29.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`time_fields`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`time_fields`/`time_format`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.28.0
+Version 0.29.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -232,6 +232,7 @@ throughout the function body).
 | `now` | `() -> int` | wall-clock time in Unix seconds |
 | `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
 | `time_fields` | `(int) -> []int` | decompose a Unix timestamp (local time) → `[year, month(1-12), day, hour, minute, second, weekday(0=Sun), yearday]` |
+| `time_format` | `(int, string) -> string` | format a Unix timestamp (local time) with a `strftime(3)` pattern (`%Y %m %d %H %M %S %A %B %z %Z %F %T` …) |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
 | `exit` | `(int) -> ` | terminate the process with a status code |
 | `flush` | `() -> ` | flush buffered stdout (for prompt output through a pipe) |

--- a/codegen.go
+++ b/codegen.go
@@ -662,6 +662,19 @@ static mfl_slice mfl_time_fields(int64_t unix) {
     memcpy(s.data, v, sizeof(v));
     return s;
 }
+/* format a Unix timestamp (local time) with a strftime(3) pattern:
+   %Y %m %d %H %M %S %A %a %B %b %p %j %z %Z %F %T ... ("" if it overflows) */
+static char* mfl_time_format(int64_t unix, const char* fmt) {
+    time_t t = (time_t)unix;
+    struct tm tmv;
+    localtime_r(&t, &tmv);
+    char buf[512];
+    size_t n = strftime(buf, sizeof(buf), fmt, &tmv);
+    char* out = mfl_alloc(n + 1);
+    memcpy(out, buf, n);
+    out[n] = 0;
+    return out;
+}
 static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 10); }
 
 /* file system: read/write whole files, list a directory, make a directory */
@@ -2990,6 +3003,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return "mfl_now_ms()", nil
 	case "time_fields":
 		return fmt.Sprintf("mfl_time_fields(%s)", args[0]), nil
+	case "time_format":
+		return fmt.Sprintf("mfl_time_format(%s, %s)", args[0], args[1]), nil
 	case "parse_int":
 		return fmt.Sprintf("mfl_parse_int(%s)", args[0]), nil
 	case "read_file":

--- a/flags_test.go
+++ b/flags_test.go
@@ -31,6 +31,30 @@ func TestTimeFields(t *testing.T) {
 	}
 }
 
+// time_format renders a timestamp with a strftime pattern; TZ=UTC pins it
+// (1782172800 -> 2026-06-23 00:00:00 Tuesday).
+func TestTimeFormat(t *testing.T) {
+	fn := parseFuncs(t, `func main() { println(time_format(1782172800, "%Y-%m-%d %H:%M:%S %A")) }`)
+	bin, err := os.CreateTemp("", "mfl-tfmt-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fn}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cmd := exec.Command(bin.Name())
+	cmd.Env = append(os.Environ(), "TZ=UTC")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "2026-06-23 00:00:00 Tuesday" {
+		t.Fatalf("time_format: got %q, want %q", strings.TrimSpace(string(out)), "2026-06-23 00:00:00 Tuesday")
+	}
+}
+
 // read_stdin slurps stdin verbatim — exact bytes (including newlines, no
 // trailing-newline assumption), unlike the line-based input().
 func TestReadStdin(t *testing.T) {

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.28.0"
+const machinVersion = "0.29.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -88,6 +88,7 @@ func machinGuide() guideCatalog {
 			{"now_ms", "() -> int", "wall-clock milliseconds", "time"},
 			{"sleep", "(int) ->", "pause for N milliseconds", "time"},
 			{"time_fields", "(int) -> []int", "decompose a unix timestamp (local) -> [year,month,day,hour,min,sec,weekday(0=Sun),yearday]", "time"},
+			{"time_format", "(int, string) -> string", "format a unix timestamp (local) with a strftime pattern (%Y %m %d %H %M %S %A %B %z %Z %F %T ...)", "time"},
 			// convert
 			{"str", "(int|float) -> string", "format a number", "convert"},
 			{"int", "(number) -> int", "truncate to int", "convert"},

--- a/types.go
+++ b/types.go
@@ -1761,6 +1761,13 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return newSliceSlot(c, c.cInt), nil
+	case "time_format":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("time_format: 2 args (unix seconds, strftime pattern)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cString)
+		return c.cString, nil
 	case "parse_int":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("parse_int: 1 arg (string)")


### PR DESCRIPTION
## What

Adds `time_format(unix, fmt) -> string` — render a Unix timestamp (local time)
with a `strftime(3)` pattern (`%Y-%m-%d`, `%H:%M:%S`, `%A`/`%B`, `%Z`/`%z`,
`%F`, `%T`, …).

`time_fields` (v0.28.0) decomposes a timestamp into integers; `time_format` is
the render side — weekday/month names, zone name/offset, locale formatting —
things `time_fields` fundamentally can't produce.

## Why

Dogfood-driven: surfaced building **machin-date**, a `date(1)` clone whose output
is byte-for-byte identical to GNU `date` (verified for `-R`/RFC-2822 form).

## Changes

- C runtime `mfl_time_format` (strftime) + type case + codegen emission
- `machin guide` catalog entry, SPEC builtins row, CHANGELOG `v0.29.0`
- Version markers bumped to `0.29.0` (README badge, SPEC, guide.go, CHANGELOG)
- `TestTimeFormat` — TZ=UTC-pinned, 1782172800 -> "2026-06-23 00:00:00 Tuesday"

🤖 Generated with [Claude Code](https://claude.com/claude-code)