### PR TITLE
feat: time_make builtin (calendar fields -> timestamp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.30.0
+
+- **`time_make(y, mo, d, h, mi, s)` builtin.** Build a Unix timestamp from local
+  calendar fields — the inverse of `time_fields`, backed by `mktime(3)` (which
+  also normalizes out-of-range fields, so day 32 rolls into the next month). This
+  completes the time trio: construct ↔ decompose ↔ render. Surfaced building
+  machin-meet (a one-person self-hostable Calendly), which needs "09:00 local on
+  date X → which Unix second?" to enumerate bookable slots.
+
 ## v0.29.0
 
 - **`time_format(unix, fmt)` builtin.** Format a Unix timestamp (local time) with

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.29.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.30.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`time_fields`/`time_format`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`time_fields`/`time_format`/`time_make`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.29.0
+Version 0.30.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -233,6 +233,7 @@ throughout the function body).
 | `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
 | `time_fields` | `(int) -> []int` | decompose a Unix timestamp (local time) → `[year, month(1-12), day, hour, minute, second, weekday(0=Sun), yearday]` |
 | `time_format` | `(int, string) -> string` | format a Unix timestamp (local time) with a `strftime(3)` pattern (`%Y %m %d %H %M %S %A %B %z %Z %F %T` …) |
+| `time_make` | `(int, int, int, int, int, int) -> int` | build a Unix timestamp from local calendar fields `(year, month, day, hour, minute, second)` — inverse of `time_fields`; `mktime(3)` normalizes out-of-range fields |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
 | `exit` | `(int) -> ` | terminate the process with a status code |
 | `flush` | `() -> ` | flush buffered stdout (for prompt output through a pipe) |

--- a/codegen.go
+++ b/codegen.go
@@ -675,6 +675,21 @@ static char* mfl_time_format(int64_t unix, const char* fmt) {
     out[n] = 0;
     return out;
 }
+/* construct a Unix timestamp from calendar fields (local time, the inverse of
+   time_fields): mktime normalizes out-of-range fields (e.g. day 32 rolls over)
+   and resolves DST via tm_isdst=-1. */
+static int64_t mfl_time_make(int64_t y, int64_t mo, int64_t d, int64_t h, int64_t mi, int64_t s) {
+    struct tm tmv;
+    memset(&tmv, 0, sizeof(tmv));
+    tmv.tm_year = (int)(y - 1900);
+    tmv.tm_mon = (int)(mo - 1);
+    tmv.tm_mday = (int)d;
+    tmv.tm_hour = (int)h;
+    tmv.tm_min = (int)mi;
+    tmv.tm_sec = (int)s;
+    tmv.tm_isdst = -1;
+    return (int64_t)mktime(&tmv);
+}
 static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 10); }
 
 /* file system: read/write whole files, list a directory, make a directory */
@@ -3005,6 +3020,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_time_fields(%s)", args[0]), nil
 	case "time_format":
 		return fmt.Sprintf("mfl_time_format(%s, %s)", args[0], args[1]), nil
+	case "time_make":
+		return fmt.Sprintf("mfl_time_make(%s, %s, %s, %s, %s, %s)", args[0], args[1], args[2], args[3], args[4], args[5]), nil
 	case "parse_int":
 		return fmt.Sprintf("mfl_parse_int(%s)", args[0]), nil
 	case "read_file":

--- a/flags_test.go
+++ b/flags_test.go
@@ -55,6 +55,31 @@ func TestTimeFormat(t *testing.T) {
 	}
 }
 
+// time_make is the inverse of time_fields: building 2026-06-23 00:00:00 local
+// must yield 1782172800 under TZ=UTC, and round-tripping back via time_fields
+// must restore the fields.
+func TestTimeMake(t *testing.T) {
+	fn := parseFuncs(t, `func main() { u := time_make(2026, 6, 23, 0, 0, 0)  f := time_fields(u)  println(str(u) + " " + str(f[0]) + "-" + str(f[1]) + "-" + str(f[2])) }`)
+	bin, err := os.CreateTemp("", "mfl-tmk-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fn}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cmd := exec.Command(bin.Name())
+	cmd.Env = append(os.Environ(), "TZ=UTC")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "1782172800 2026-6-23" {
+		t.Fatalf("time_make: got %q, want %q", strings.TrimSpace(string(out)), "1782172800 2026-6-23")
+	}
+}
+
 // read_stdin slurps stdin verbatim — exact bytes (including newlines, no
 // trailing-newline assumption), unlike the line-based input().
 func TestReadStdin(t *testing.T) {

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.29.0"
+const machinVersion = "0.30.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -89,6 +89,7 @@ func machinGuide() guideCatalog {
 			{"sleep", "(int) ->", "pause for N milliseconds", "time"},
 			{"time_fields", "(int) -> []int", "decompose a unix timestamp (local) -> [year,month,day,hour,min,sec,weekday(0=Sun),yearday]", "time"},
 			{"time_format", "(int, string) -> string", "format a unix timestamp (local) with a strftime pattern (%Y %m %d %H %M %S %A %B %z %Z %F %T ...)", "time"},
+			{"time_make", "(int, int, int, int, int, int) -> int", "build a unix timestamp from local calendar fields (year,month,day,hour,min,sec); inverse of time_fields, normalizes overflow", "time"},
 			// convert
 			{"str", "(int|float) -> string", "format a number", "convert"},
 			{"int", "(number) -> int", "truncate to int", "convert"},

--- a/types.go
+++ b/types.go
@@ -1768,6 +1768,14 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cInt)
 		c.addPair(argSlots[1], c.cString)
 		return c.cString, nil
+	case "time_make":
+		if len(argSlots) != 6 {
+			return 0, fmt.Errorf("time_make: 6 args (year, month, day, hour, minute, second)")
+		}
+		for _, sl := range argSlots {
+			c.addPair(sl, c.cInt)
+		}
+		return c.cInt, nil
 	case "parse_int":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("parse_int: 1 arg (string)")


### PR DESCRIPTION
## What

Adds `time_make(year, month, day, hour, minute, second) -> int` — build a Unix
timestamp from local calendar fields, the inverse of `time_fields`. Backed by
`mktime(3)`, so it also normalizes out-of-range fields (day 32 → next month).

Completes the time trio: **construct** (`time_make`) ↔ **decompose**
(`time_fields`) ↔ **render** (`time_format`).

## Why

Dogfood-driven: surfaced building **machin-meet** (a one-person, self-hostable
Calendly), which enumerates bookable slots and needs "09:00 local on a given
day → which Unix second?".

## Changes

- C runtime `mfl_time_make` (mktime) + type case + codegen emission
- `machin guide` catalog entry, SPEC builtins row, CHANGELOG `v0.30.0`
- Version markers bumped to `0.30.0`
- `TestTimeMake` — TZ=UTC-pinned, asserts time_make(2026,6,23,0,0,0)==1782172800 and round-trips through time_fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)