### PR TITLE
feat: time_format_utc builtin (strftime in UTC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.31.0
+
+- **`time_format_utc(unix, fmt)` builtin.** Like `time_format` but in UTC
+  (`gmtime` instead of `localtime`) — the form iCalendar `.ics` and RFC-3339
+  timestamps want, without the `%z`-offset arithmetic dance. Surfaced finishing
+  machin-meet, whose `.ics` `DTSTART`/`DTEND` must be in UTC.
+
 ## v0.30.0
 
 - **`time_make(y, mo, d, h, mi, s)` builtin.** Build a Unix timestamp from local

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.30.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.31.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">
@@ -45,7 +45,7 @@ bin/machin pack   app.mfl                # dense base64 form (distribution)
 - **Flow**: `if`/`for`/`while`/`range`, `break`/`continue`, multiple & named returns, comma-ok, variadics, closures (by-reference), implicit generics (monomorphized)
 - **Concurrency**: goroutines (`go`), channels (`close`, `for v := range ch`, `v, ok := <-ch`), `select` (multi-way + `default` + timeouts); per-goroutine arena GC + scoped `arena{}`; `--safe` checks
 - **Networking**: `dial` (client) + `listen`/`accept`/`read`/`write`/`close` (server); native TLS — `https_get`/`https_post` and a `wss_*` WebSocket client (OpenSSL, linked only when used)
-- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`time_fields`/`time_format`/`time_make`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
+- **I/O & data**: `read_file`/`write_file`/`list_dir`/`mkdir`, `input`/`read_stdin`, `json`/`parse`/`json_get` (jq-style path), `args`/`env`/`now`/`now_ms`/`time_fields`/`time_format`/`time_format_utc`/`time_make`/`parse_int`/`exit`/`flush`, string ops, regex, base64, hashes (sha256/hmac_sha256)
 - **Error handling**: `http_get` returns `(status, body, err)` — the `v, err :=` idiom at the builtin layer (a 404, a 503, and an unreachable host are distinguishable)
 - **C FFI**: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib **GUI**)
 - **machweb**: a web framework written in MFL ([`framework/`](framework/))

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.30.0
+Version 0.31.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -233,6 +233,7 @@ throughout the function body).
 | `now_ms` | `() -> int` | wall-clock time in milliseconds (for latency) |
 | `time_fields` | `(int) -> []int` | decompose a Unix timestamp (local time) → `[year, month(1-12), day, hour, minute, second, weekday(0=Sun), yearday]` |
 | `time_format` | `(int, string) -> string` | format a Unix timestamp (local time) with a `strftime(3)` pattern (`%Y %m %d %H %M %S %A %B %z %Z %F %T` …) |
+| `time_format_utc` | `(int, string) -> string` | like `time_format` but in UTC (`gmtime`) — the form iCalendar / RFC-3339 timestamps want |
 | `time_make` | `(int, int, int, int, int, int) -> int` | build a Unix timestamp from local calendar fields `(year, month, day, hour, minute, second)` — inverse of `time_fields`; `mktime(3)` normalizes out-of-range fields |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
 | `exit` | `(int) -> ` | terminate the process with a status code |

--- a/codegen.go
+++ b/codegen.go
@@ -690,6 +690,18 @@ static int64_t mfl_time_make(int64_t y, int64_t mo, int64_t d, int64_t h, int64_
     tmv.tm_isdst = -1;
     return (int64_t)mktime(&tmv);
 }
+/* like time_format but in UTC (gmtime): the form .ics / RFC-3339 timestamps want. */
+static char* mfl_time_format_utc(int64_t unix, const char* fmt) {
+    time_t t = (time_t)unix;
+    struct tm tmv;
+    gmtime_r(&t, &tmv);
+    char buf[512];
+    size_t n = strftime(buf, sizeof(buf), fmt, &tmv);
+    char* out = mfl_alloc(n + 1);
+    memcpy(out, buf, n);
+    out[n] = 0;
+    return out;
+}
 static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 10); }
 
 /* file system: read/write whole files, list a directory, make a directory */
@@ -3020,6 +3032,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_time_fields(%s)", args[0]), nil
 	case "time_format":
 		return fmt.Sprintf("mfl_time_format(%s, %s)", args[0], args[1]), nil
+	case "time_format_utc":
+		return fmt.Sprintf("mfl_time_format_utc(%s, %s)", args[0], args[1]), nil
 	case "time_make":
 		return fmt.Sprintf("mfl_time_make(%s, %s, %s, %s, %s, %s)", args[0], args[1], args[2], args[3], args[4], args[5]), nil
 	case "parse_int":

--- a/flags_test.go
+++ b/flags_test.go
@@ -80,6 +80,30 @@ func TestTimeMake(t *testing.T) {
 	}
 }
 
+// time_format_utc renders in UTC regardless of $TZ: with TZ pinned to a +0530
+// zone, the iCalendar stamp for 1782172800 must still be the UTC wall clock.
+func TestTimeFormatUTC(t *testing.T) {
+	fn := parseFuncs(t, `func main() { println(time_format_utc(1782172800, "%Y%m%dT%H%M%SZ")) }`)
+	bin, err := os.CreateTemp("", "mfl-tfu-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fn}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cmd := exec.Command(bin.Name())
+	cmd.Env = append(os.Environ(), "TZ=Asia/Kolkata")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "20260623T000000Z" {
+		t.Fatalf("time_format_utc: got %q, want %q", strings.TrimSpace(string(out)), "20260623T000000Z")
+	}
+}
+
 // read_stdin slurps stdin verbatim — exact bytes (including newlines, no
 // trailing-newline assumption), unlike the line-based input().
 func TestReadStdin(t *testing.T) {

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.30.0"
+const machinVersion = "0.31.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -89,6 +89,7 @@ func machinGuide() guideCatalog {
 			{"sleep", "(int) ->", "pause for N milliseconds", "time"},
 			{"time_fields", "(int) -> []int", "decompose a unix timestamp (local) -> [year,month,day,hour,min,sec,weekday(0=Sun),yearday]", "time"},
 			{"time_format", "(int, string) -> string", "format a unix timestamp (local) with a strftime pattern (%Y %m %d %H %M %S %A %B %z %Z %F %T ...)", "time"},
+			{"time_format_utc", "(int, string) -> string", "like time_format but in UTC (gmtime) — the form .ics / RFC-3339 stamps want", "time"},
 			{"time_make", "(int, int, int, int, int, int) -> int", "build a unix timestamp from local calendar fields (year,month,day,hour,min,sec); inverse of time_fields, normalizes overflow", "time"},
 			// convert
 			{"str", "(int|float) -> string", "format a number", "convert"},

--- a/types.go
+++ b/types.go
@@ -1761,9 +1761,9 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return newSliceSlot(c, c.cInt), nil
-	case "time_format":
+	case "time_format", "time_format_utc":
 		if len(argSlots) != 2 {
-			return 0, fmt.Errorf("time_format: 2 args (unix seconds, strftime pattern)")
+			return 0, fmt.Errorf("%s: 2 args (unix seconds, strftime pattern)", ex.Callee)
 		}
 		c.addPair(argSlots[0], c.cInt)
 		c.addPair(argSlots[1], c.cString)


### PR DESCRIPTION
## What

Adds `time_format_utc(unix, fmt) -> string` — the `gmtime` sibling of
`time_format`. Same strftime patterns, rendered in **UTC** instead of local
time. The form iCalendar `.ics` (`DTSTART:...Z`) and RFC-3339 timestamps want.

## Why

Dogfood-driven: finishing **machin-meet**, the `.ics` `DTSTART`/`DTEND` must be
UTC. The tool currently fakes it by formatting `(epoch - %z-offset)` in local
time — `time_format_utc` makes it a one-liner and kills the arithmetic.

## Changes

- C runtime `mfl_time_format_utc` (gmtime) + codegen emission
- Folds into the existing `time_format` type case `(int, string) -> string`
- `machin guide` entry, SPEC row, CHANGELOG `v0.31.0`, version markers → `0.31.0`
- `TestTimeFormatUTC` — runs under `TZ=Asia/Kolkata`, asserts 1782172800 → `20260623T000000Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)