### PR TITLE
feat: url_encode / url_decode builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.32.0
+
+- **`url_encode` / `url_decode` builtins.** Percent-encoding for URLs (RFC 3986):
+  `url_encode` keeps the unreserved set `A-Za-z0-9-._~` and `%XX`-encodes the rest
+  (space → `%20`); `url_decode` reverses it leniently (`+` → space, malformed `%XX`
+  passes through). Surfaced building machin-qs (a query-string ⇄ JSON converter),
+  and lets servers like machin-meet decode query/form values safely.
+
 ## v0.31.0
 
 - **`time_format_utc(unix, fmt)` builtin.** Like `time_format` but in UTC

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.31.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.32.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.31.0
+Version 0.32.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -262,6 +262,8 @@ throughout the function body).
 | `join` | `([]string, string) -> string` | join |
 | `base64_encode` | `(string) -> string` | base64-encode text (standard, padded) |
 | `base64_decode` | `(string) -> string` | base64-decode (lenient: standard + url-safe; ignores padding) |
+| `url_encode` | `(string) -> string` | percent-encode for URLs (RFC 3986: keeps `A-Za-z0-9-._~`, encodes the rest, space → `%20`) |
+| `url_decode` | `(string) -> string` | percent-decode a URL component (lenient: `+` → space, malformed `%XX` passes through) |
 | `sha256` | `(string) -> string` | SHA-256 of text, lowercase hex |
 | `hmac_sha256` | `(string, string) -> string` | HMAC-SHA256(key, message), lowercase hex |
 | `sqlite_open` | `(string) -> int` | open/create a SQLite db file → handle (0 on fail); `:memory:` for in-memory |

--- a/codegen.go
+++ b/codegen.go
@@ -384,6 +384,53 @@ static char* mfl_base64_decode(const char* s) {
     out[j] = 0;
     return out;
 }
+/* URL percent-encoding (RFC 3986). url_encode keeps the unreserved set
+   A-Za-z0-9-._~ and %XX-encodes everything else (space -> %20). url_decode
+   reverses it and is lenient: it also maps '+' to space (form style) and passes
+   a malformed % through unchanged. */
+static int mfl_hexval(int c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+static char* mfl_url_encode(const char* s) {
+    static const char hex[] = "0123456789ABCDEF";
+    size_t n = strlen(s), j = 0;
+    char* out = (char*)mfl_alloc(n * 3 + 1);
+    for (size_t i = 0; i < n; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+            c == '-' || c == '_' || c == '.' || c == '~') {
+            out[j++] = (char)c;
+        } else {
+            out[j++] = '%';
+            out[j++] = hex[c >> 4];
+            out[j++] = hex[c & 15];
+        }
+    }
+    out[j] = 0;
+    return out;
+}
+static char* mfl_url_decode(const char* s) {
+    size_t n = strlen(s), j = 0;
+    char* out = (char*)mfl_alloc(n + 1);
+    for (size_t i = 0; i < n; i++) {
+        char c = s[i];
+        if (c == '+') {
+            out[j++] = ' ';
+        } else if (c == '%' && i + 2 < n) {
+            int hi = mfl_hexval((unsigned char)s[i+1]);
+            int lo = mfl_hexval((unsigned char)s[i+2]);
+            if (hi >= 0 && lo >= 0) { out[j++] = (char)((hi << 4) | lo); i += 2; }
+            else { out[j++] = c; }
+        } else {
+            out[j++] = c;
+        }
+    }
+    out[j] = 0;
+    return out;
+}
 /* SHA-256 + HMAC-SHA256 (pure C, no dependency). Operate on NUL-terminated text
    and return a lowercase hex digest. */
 static uint32_t mfl_ror32(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
@@ -2960,6 +3007,10 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_base64_encode(%s)", args[0]), nil
 	case "base64_decode":
 		return fmt.Sprintf("mfl_base64_decode(%s)", args[0]), nil
+	case "url_encode":
+		return fmt.Sprintf("mfl_url_encode(%s)", args[0]), nil
+	case "url_decode":
+		return fmt.Sprintf("mfl_url_decode(%s)", args[0]), nil
 	case "sha256":
 		return fmt.Sprintf("mfl_sha256(%s)", args[0]), nil
 	case "hmac_sha256":

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.31.0"
+const machinVersion = "0.32.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -116,6 +116,8 @@ func machinGuide() guideCatalog {
 			{"join", "([]string, string) -> string", "join with a separator", "string"},
 			{"base64_encode", "(string) -> string", "base64-encode text (standard, padded)", "string"},
 			{"base64_decode", "(string) -> string", "base64-decode (lenient: standard + url-safe; ignores padding)", "string"},
+			{"url_encode", "(string) -> string", "percent-encode for URLs (RFC 3986; keeps A-Za-z0-9-._~, space -> %20)", "string"},
+			{"url_decode", "(string) -> string", "percent-decode a URL component (lenient: + -> space, bad %XX passes through)", "string"},
 			{"sha256", "(string) -> string", "SHA-256 of text, lowercase hex", "crypto"},
 			{"hmac_sha256", "(string, string) -> string", "HMAC-SHA256(key, message), lowercase hex (webhook signatures)", "crypto"},
 			// sqlite (libsqlite3, linked only when used)

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -694,6 +694,25 @@ func TestSQLiteParams(t *testing.T) {
 	}
 }
 
+// url_encode follows RFC 3986 (space -> %20, reserved chars escaped, unreserved
+// kept); url_decode reverses it and also treats '+' as space.
+func TestURLEncoding(t *testing.T) {
+	main := `func main() {
+	println(url_encode("a b&c=d/e?f+g~h"))
+	println(url_decode("a%20b%26c%3Dd%2Fe%3Ff%2Bg~h"))
+	println(url_decode("a+b%20c"))
+	println(url_decode(url_encode("héllo, wörld! 100%")))
+}`
+	out, _ := buildRun(t, main)
+	want := "a%20b%26c%3Dd%2Fe%3Ff%2Bg~h\n" +
+		"a b&c=d/e?f+g~h\n" +
+		"a b c\n" +
+		"héllo, wörld! 100%\n"
+	if out != want {
+		t.Fatalf("url encoding: got %q, want %q", out, want)
+	}
+}
+
 // SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
 func TestHashes(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -1831,7 +1831,7 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("flush: no args")
 		}
 		return c.cInt, nil
-	case "base64_encode", "base64_decode", "sha256":
+	case "base64_encode", "base64_decode", "url_encode", "url_decode", "sha256":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("%s: 1 arg (string)", ex.Callee)
 		}


### PR DESCRIPTION
## What

Adds `url_encode(s) -> string` and `url_decode(s) -> string` — percent-encoding
for URLs (RFC 3986).

- `url_encode` keeps the unreserved set `A-Za-z0-9-._~` and `%XX`-encodes the
  rest; space → `%20`.
- `url_decode` reverses it, leniently: `+` → space (form style), and a malformed
  `%XX` passes through unchanged.

Pure C, no dependency — same shape as the base64 builtins.

## Why

Dogfood-driven: surfaced building **machin-qs**, a query-string ⇄ JSON
converter. Also the gap flagged when machin-meet's `query_get` couldn't decode
percent-escapes in query/form values.

## Changes

- C runtime `mfl_url_encode` / `mfl_url_decode` + codegen emission
- Folds into the `(string) -> string` type case shared with base64/sha256
- `machin guide` entries, SPEC rows, CHANGELOG `v0.32.0`, version markers → `0.32.0`
- `TestURLEncoding` — reserved/space escaping, `+`→space, and a full round-trip incl. UTF-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `url_encode` builtin function for percent-encoding strings according to RFC 3986, while preserving unreserved characters to safely construct URL components and query strings
  * Added `url_decode` builtin function for lenient percent-decoding, treating `+` characters as whitespace and gracefully handling malformed `%XX` sequences for flexible processing of query and form values

* **Chores**
  * Version bumped to 0.32.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->