### PR TITLE
fix(machweb): read full POST body across TCP segments

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -36,7 +36,10 @@ A handler is a closure `func(Request) Response`. `serve(port, handler)` runs the
 server, dispatching every request to it in its own goroutine (whose memory is
 reclaimed when the response is sent).
 
-**Request** — `req.method`, `req.path`, `req.body`.
+**Request** — `req.method`, `req.path`, `req.body`. The full request body is
+read before dispatch (it keeps reading until `Content-Length` bytes arrive, so a
+`POST` whose body lands in a later TCP segment than its headers — as browsers
+often send — still parses).
 
 **Response builders:**
 

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -59,8 +59,37 @@ func param(path, prefix) (v) {
 
 // ---- server ----
 
+// content_length parses the Content-Length header value from a request's headers.
+func content_length(head) (n) {
+    n = 0
+    i := index(to_lower(head), "content-length:")
+    if i >= 0 {
+        rest := substr(head, i + 15, len(head))   // text after "content-length:"
+        nl := index(rest, "\r\n")
+        if nl >= 0 { rest = substr(rest, 0, nl) }
+        n = parse_int(trim(rest))
+    }
+}
+
+// read_request reads a whole HTTP request, not just the first packet: a browser
+// often sends the POST body in a separate TCP segment from the headers, so we
+// keep reading until Content-Length bytes of body have arrived.
+func read_request(conn) (raw) {
+    raw = read(conn)
+    sep := index(raw, "\r\n\r\n")
+    if sep >= 0 {
+        clen := content_length(substr(raw, 0, sep))
+        body_start := sep + 4
+        for len(raw) - body_start < clen {
+            chunk := read(conn)
+            if chunk == "" { break }            // connection closed early
+            raw = raw + chunk
+        }
+    }
+}
+
 func machweb_handle(conn, handler) {
-    raw := read(conn)
+    raw := read_request(conn)
     req := parse_request(raw)
     res := handler(req)
     out := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.body)) + "\r\nConnection: close\r\n\r\n" + res.body


### PR DESCRIPTION
## What

`machweb_handle` did a single `read(conn)`. Browsers commonly send a POST body
in a **separate TCP segment** from the headers, so `http_body()` saw an empty
body and the handler got `""`.

Concretely: machin-meet's booking failed with `{"error":"missing start"}` from
real browsers (curl coalesces into one packet, so it wasn't caught in testing).

## Fix

A new `read_request(conn)` parses `Content-Length` from the headers and keeps
reading until the whole body has arrived, with an EOF break so a half-open
connection can't hang it. `machweb_handle` now uses it.

Library-only (no compiler/binary change); `framework/router_app.src` and
`framework/example.src` still compile. Verified end-to-end in machin-meet by
sending the body in a delayed second segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)