### PR TITLE
feat: http_request builtin (authenticated HTTPS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.33.0
+
+- **`http_request(method, url, headers, body)` builtin.** Authenticated HTTPS for
+  any method, with caller-supplied header lines — the piece `https_get`/`https_post`
+  lacked (they hard-code the header set, so no `Authorization`). `headers` is a
+  `[]string` of `"Key: Value"` lines; returns `(status, body, err)` like `http_get`.
+  Surfaced wiring WhatsApp booking notifications into machin-meet (the WhatsApp
+  Cloud API and Twilio both require a bearer/basic `Authorization` header).
+
 ## v0.32.0
 
 - **`url_encode` / `url_decode` builtins.** Percent-encoding for URLs (RFC 3986):

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.32.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.33.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.32.0
+Version 0.33.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -282,6 +282,7 @@ throughout the function body).
 | `https_get` | `(string) -> string` | HTTPS GET over TLS; response body ("" on error) |
 | `https_post` | `(string, string) -> string` | HTTPS POST (JSON body) over TLS; response body |
 | `http_get` | `(string) -> (int, string, string)` | GET returning `(status, body, err)`; `err==""` ⇒ a response, else `"dns"`/`"connect"`/`"tls"`/`"scheme"`. Multi-assign only. |
+| `http_request` | `(string, string, []string, string) -> (int, string, string)` | authenticated HTTPS: `(method, url, header lines, body)` → `(status, body, err)`. Each header is a `"Key: Value"` line (e.g. `"Authorization: Bearer …"`); caller owns `Content-Type`. Multi-assign only. |
 | `wss_open` | `(string) -> int` | open a `wss://` WebSocket; a connection handle, or 0 on failure |
 | `wss_send` | `(int, string) -> int` | send a text message on a WebSocket |
 | `wss_recv` | `(int) -> string` | next message (blocks); `""` on close (auto ping/pong) |

--- a/codegen.go
+++ b/codegen.go
@@ -1024,9 +1024,9 @@ static char* mfl_chunk_decode(const char* body, size_t blen, size_t* outlen) {
    transport-failure reason ("dns"/"connect"/"tls"/"scheme") with status 0. */
 typedef struct { int64_t status; char* body; char* err; } mfl_http_result;
 
-static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects);
+static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, const char* extra, int redirects);
 
-static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, int redirects) {
+static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, const char* extra, int redirects) {
     mfl_http_result R;
     R.status = 0;
     R.body = mfl_dup_arena("", 0);
@@ -1050,19 +1050,27 @@ static mfl_http_result mfl_http_do(const char* method, const char* url, const ch
     if (!ssl) { R.err = mfl_dup_arena(stage, strlen(stage)); return R; }
 
     size_t blen = reqbody ? strlen(reqbody) : 0;
-    size_t reqcap = blen + strlen(path) + strlen(host) + 256 + (ctype ? strlen(ctype) : 0);
+    const char* ex = extra ? extra : "";   /* caller-supplied header lines (each ending \r\n) */
+    size_t reqcap = blen + strlen(path) + strlen(host) + 256 + (ctype ? strlen(ctype) : 0) + strlen(ex);
     char* req = (char*)malloc(reqcap);
     int rl;
     if (blen > 0) {
-        rl = snprintf(req, reqcap,
-            "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\nContent-Type: %s\r\nContent-Length: %zu\r\nConnection: close\r\n\r\n",
-            method, path, host, ctype ? ctype : "application/octet-stream", blen);
+        if (ctype) {
+            rl = snprintf(req, reqcap,
+                "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\n%sContent-Type: %s\r\nContent-Length: %zu\r\nConnection: close\r\n\r\n",
+                method, path, host, ex, ctype, blen);
+        } else {
+            /* http_request: caller owns Content-Type (via extra) */
+            rl = snprintf(req, reqcap,
+                "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\n%sContent-Length: %zu\r\nConnection: close\r\n\r\n",
+                method, path, host, ex, blen);
+        }
         memcpy(req + rl, reqbody, blen);
         rl += (int)blen;
     } else {
         rl = snprintf(req, reqcap,
-            "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\nConnection: close\r\n\r\n",
-            method, path, host);
+            "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\n%sConnection: close\r\n\r\n",
+            method, path, host, ex);
     }
     SSL_write(ssl, req, rl);
     free(req);
@@ -1097,7 +1105,7 @@ static mfl_http_result mfl_http_do(const char* method, const char* url, const ch
                 free(raw);
                 const char* m = (status == 307 || status == 308) ? method : "GET";
                 const char* rb = (status == 307 || status == 308) ? reqbody : NULL;
-                return mfl_http_do(m, locurl, rb, ctype, redirects - 1);
+                return mfl_http_do(m, locurl, rb, ctype, extra, redirects - 1);
             }
         }
     }
@@ -1120,9 +1128,26 @@ static mfl_http_result mfl_http_do(const char* method, const char* url, const ch
     return R;
 }
 
-static char* mfl_https_get(const char* url) { return mfl_http_do("GET", url, NULL, NULL, 5).body; }
-static char* mfl_https_post(const char* url, const char* body) { return mfl_http_do("POST", url, body, "application/json", 5).body; }
-static mfl_http_result mfl_http_get(const char* url) { return mfl_http_do("GET", url, NULL, NULL, 5); }
+static char* mfl_https_get(const char* url) { return mfl_http_do("GET", url, NULL, NULL, "", 5).body; }
+static char* mfl_https_post(const char* url, const char* body) { return mfl_http_do("POST", url, body, "application/json", "", 5).body; }
+static mfl_http_result mfl_http_get(const char* url) { return mfl_http_do("GET", url, NULL, NULL, "", 5); }
+/* general authenticated request: caller supplies the method, any extra header
+   lines (e.g. "Authorization: Bearer x", "Content-Type: application/json") as a
+   []string, and a body. Returns (status, body, err) like http_get. */
+static mfl_http_result mfl_http_request(const char* method, const char* url, mfl_slice headers, const char* body) {
+    size_t tot = 1;
+    for (int64_t i = 0; i < headers.len; i++) { char* h = ((char**)headers.data)[i]; if (h) tot += strlen(h) + 2; }
+    char* hb = (char*)malloc(tot);
+    size_t o = 0;
+    for (int64_t i = 0; i < headers.len; i++) {
+        char* h = ((char**)headers.data)[i];
+        if (h) { size_t l = strlen(h); memcpy(hb + o, h, l); o += l; hb[o++] = '\r'; hb[o++] = '\n'; }
+    }
+    hb[o] = 0;
+    mfl_http_result R = mfl_http_do(method, url, body, NULL, hb, 5);
+    free(hb);
+    return R;
+}
 `
 
 // wssRuntime is a WebSocket (RFC 6455) client over TLS, built on tlsCoreRuntime.
@@ -1964,6 +1989,8 @@ func multiRetBuiltinC(name string) (cfn, ctype string, fields []string, needsTLS
 	switch name {
 	case "http_get":
 		return "mfl_http_get", "mfl_http_result", []string{"status", "body", "err"}, true, true
+	case "http_request":
+		return "mfl_http_request", "mfl_http_result", []string{"status", "body", "err"}, true, true
 	case "json_get":
 		return "mfl_json_get", "mfl_json_result", []string{"value", "err"}, false, true
 	}

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.32.0"
+const machinVersion = "0.33.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -145,6 +145,7 @@ func machinGuide() guideCatalog {
 			{"https_get", "(string) -> string", "HTTPS GET over TLS; body (\"\" on error)", "net"},
 			{"https_post", "(string, string) -> string", "HTTPS POST (JSON body) over TLS; body", "net"},
 			{"http_get", "(string) -> (int, string, string)", "GET -> (status, body, err); err \"\"/dns/connect/tls/scheme. MULTI-ASSIGN ONLY", "net"},
+			{"http_request", "(string, string, []string, string) -> (int, string, string)", "auth'd HTTPS: (method, url, header lines like \"Authorization: Bearer x\", body) -> (status, body, err). MULTI-ASSIGN ONLY", "net"},
 			// websocket
 			{"wss_open", "(string) -> int", "open a wss:// WebSocket -> handle (0 on fail)", "ws"},
 			{"wss_send", "(int, string) -> int", "send a text message", "ws"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -576,6 +576,28 @@ func TestHTTPGetMultiReturn(t *testing.T) {
 	}
 }
 
+// http_request(method, url, []string headers, body) -> (status, body, err): an
+// authenticated request with caller-supplied header lines. Same multi-return
+// path as http_get; compiling must wire the accessor and gate the TLS runtime.
+func TestHTTPRequest(t *testing.T) {
+	src := `func main() { h := []string{"Authorization: Bearer x"}  s, b, e := http_request("POST", "https://x", h, "{}")  println(str(s) + b + e) }`
+	c, err := CompileToC(&Program{Funcs: parseFuncs(t, src)}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_http_request") || !strings.Contains(c, "mfl_http_result") {
+		t.Fatal("http_request must emit the result struct + accessor")
+	}
+	if !strings.Contains(c, "SSL_new") && !strings.Contains(c, "mfl_tls_dial_e") {
+		t.Fatal("http_request must gate in the OpenSSL TLS runtime")
+	}
+	// single-value misuse errors helpfully, like http_get
+	bad := `func main() { h := []string{}  x := http_request("GET", "https://x", h, "")  println(x) }`
+	if _, err := CompileToC(&Program{Funcs: parseFuncs(t, bad)}, false); err == nil || !strings.Contains(err.Error(), "returns 3 values") {
+		t.Fatalf("single-value http_request should error helpfully, got: %v", err)
+	}
+}
+
 // A string (or a struct's string fields) allocated in a short-lived goroutine
 // and sent over a channel must survive that goroutine's arena being reclaimed —
 // the channel deep-copies strings on send and adopts them on receive.

--- a/types.go
+++ b/types.go
@@ -1372,6 +1372,8 @@ func (c *Checker) multiRetBuiltin(name string) (args []int, rets []int, ok bool)
 	switch name {
 	case "http_get":
 		return []int{c.cString}, []int{c.cInt, c.cString, c.cString}, true
+	case "http_request":
+		return []int{c.cString, c.cString, newSliceSlot(c, c.cString), c.cString}, []int{c.cInt, c.cString, c.cString}, true
 	case "json_get":
 		return []int{c.cString, c.cString}, []int{c.cString, c.cString}, true
 	}
@@ -1900,6 +1902,8 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		return newSliceSlot(c, c.cString), nil
 	case "http_get":
 		return 0, fmt.Errorf("http_get returns 3 values; use: status, body, err := http_get(url)")
+	case "http_request":
+		return 0, fmt.Errorf("http_request returns 3 values; use: status, body, err := http_request(method, url, headers, body)")
 	case "json_get":
 		return 0, fmt.Errorf("json_get returns 2 values; use: value, err := json_get(json, path)")
 	case "wss_open":


### PR DESCRIPTION
## What

Adds `http_request(method, url, headers, body) -> (status, body, err)` — an
HTTPS request for any method with **caller-supplied header lines**.

`headers` is a `[]string` of `"Key: Value"` lines (e.g.
`"Authorization: Bearer …"`, `"Content-Type: application/json"`). Returns
`(status, body, err)` like `http_get`.

This fills the gap that `https_get`/`https_post` left: they hard-code the header
set, so there's no way to send an `Authorization` header.

## Why

Dogfood-driven: wiring **WhatsApp** booking notifications into machin-meet. Both
the WhatsApp Cloud API (bearer token) and Twilio (basic auth) require an
`Authorization` header on the send call.

## How

Threads an `extra` header block through the existing `mfl_http_do` core, so
redirects / chunked decoding / `Content-Length` all keep working. The caller
owns `Content-Type` (supplied via `headers`).

## Verified

Live against `postman-echo.com/post`: the server echoed back the `Authorization`
and `Content-Type` headers and the JSON body. `TestHTTPRequest` covers the
compile path (emits the result struct, gates the TLS runtime, single-value
misuse errors helpfully). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)