### PR TITLE
feat: bytes type (NUL-safe binary buffer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.34.0
+
+- **`bytes` type — a NUL-safe binary buffer.** machin strings are NUL-terminated
+  `char*`, so they can't hold arbitrary binary (anything with a `0x00` byte gets
+  truncated). The new `bytes` type (pointer + length) can. Builtins: `bytes(str)`,
+  `bytes_str(b)`, `to_hex`/`from_hex`, `byte_at`, `bytes_sub`, `bytes_concat`;
+  `len(b)` works, and `println(b)` prints hex. This is the foundation for binary
+  protocols and real crypto (step 1 of a native WhatsApp client — see machin-meet).
+
 ## v0.33.0
 
 - **`http_request(method, url, headers, body)` builtin.** Authenticated HTTPS for

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.33.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.34.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.33.0
+Version 0.34.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -93,6 +93,7 @@ The decoded text of a declaration is tokenized as follows.
 | `float` | IEEE-754 double | `double` |
 | `bool` | boolean | `int` (0/1) |
 | `string` | immutable text; zero value `""` | `char*` |
+| `bytes` | NUL-safe binary buffer (pointer + length) | `mfl_bytes` |
 | `[]T` | slice of `T` (header + backing array) | `mfl_slice` |
 | `map[K]V` | hash map, `K` is `int` or `string` | `mfl_map*` |
 | `chan T` | channel of `T` | `mfl_chan*` |
@@ -262,6 +263,13 @@ throughout the function body).
 | `join` | `([]string, string) -> string` | join |
 | `base64_encode` | `(string) -> string` | base64-encode text (standard, padded) |
 | `base64_decode` | `(string) -> string` | base64-decode (lenient: standard + url-safe; ignores padding) |
+| `bytes` | `(string) -> bytes` | a `bytes` value from a string's raw bytes |
+| `bytes_str` | `(bytes) -> string` | `bytes` → string (NUL-terminated; truncates at an embedded `0`) |
+| `to_hex` | `(bytes) -> string` | lowercase hex of a `bytes` value |
+| `from_hex` | `(string) -> bytes` | parse hex → `bytes` (skips non-hex chars) |
+| `byte_at` | `(bytes, int) -> int` | byte value 0–255 at an index (`-1` if out of range) |
+| `bytes_sub` | `(bytes, int, int) -> bytes` | sub-range `[start, end)` |
+| `bytes_concat` | `(bytes, bytes) -> bytes` | concatenate two `bytes` values |
 | `url_encode` | `(string) -> string` | percent-encode for URLs (RFC 3986: keeps `A-Za-z0-9-._~`, encodes the rest, space → `%20`) |
 | `url_decode` | `(string) -> string` | percent-decode a URL component (lenient: `+` → space, malformed `%XX` passes through) |
 | `sha256` | `(string) -> string` | SHA-256 of text, lowercase hex |

--- a/codegen.go
+++ b/codegen.go
@@ -431,6 +431,57 @@ static char* mfl_url_decode(const char* s) {
     out[j] = 0;
     return out;
 }
+/* bytes: a NUL-safe binary buffer (pointer + length), the type strings can't be.
+   Values are immutable (builtins return fresh arena buffers), so passing one by
+   value just shares the backing — same discipline as strings. */
+typedef struct { uint8_t* data; int64_t len; } mfl_bytes;
+static mfl_bytes mfl_bytes_from_str(const char* s) {
+    int64_t n = (int64_t)strlen(s);
+    mfl_bytes b; b.len = n; b.data = (uint8_t*)mfl_alloc(n ? n : 1);
+    memcpy(b.data, s, (size_t)n);
+    return b;
+}
+static char* mfl_bytes_str(mfl_bytes b) {   /* NUL-terminated; truncates at an embedded 0 */
+    char* out = (char*)mfl_alloc(b.len + 1);
+    memcpy(out, b.data, (size_t)b.len);
+    out[b.len] = 0;
+    return out;
+}
+static char* mfl_bytes_hex(mfl_bytes b) {
+    static const char hx[] = "0123456789abcdef";
+    char* out = (char*)mfl_alloc(b.len * 2 + 1);
+    for (int64_t i = 0; i < b.len; i++) { out[i*2] = hx[b.data[i] >> 4]; out[i*2+1] = hx[b.data[i] & 15]; }
+    out[b.len*2] = 0;
+    return out;
+}
+static mfl_bytes mfl_bytes_unhex(const char* s) {   /* skips non-hex chars (spaces, colons) */
+    int64_t n = (int64_t)strlen(s);
+    mfl_bytes b; b.len = 0; b.data = (uint8_t*)mfl_alloc(n / 2 + 1);
+    int hi = -1;
+    for (int64_t i = 0; i < n; i++) {
+        int v = mfl_hexval((unsigned char)s[i]);
+        if (v < 0) continue;
+        if (hi < 0) hi = v;
+        else { b.data[b.len++] = (uint8_t)((hi << 4) | v); hi = -1; }
+    }
+    return b;
+}
+static int64_t mfl_byte_at(mfl_bytes b, int64_t i) { return (i < 0 || i >= b.len) ? -1 : (int64_t)b.data[i]; }
+static mfl_bytes mfl_bytes_sub(mfl_bytes b, int64_t start, int64_t end) {
+    if (start < 0) start = 0;
+    if (end > b.len) end = b.len;
+    if (end < start) end = start;
+    int64_t n = end - start;
+    mfl_bytes r; r.len = n; r.data = (uint8_t*)mfl_alloc(n ? n : 1);
+    memcpy(r.data, b.data + start, (size_t)n);
+    return r;
+}
+static mfl_bytes mfl_bytes_concat(mfl_bytes a, mfl_bytes b) {
+    mfl_bytes r; r.len = a.len + b.len; r.data = (uint8_t*)mfl_alloc(r.len ? r.len : 1);
+    memcpy(r.data, a.data, (size_t)a.len);
+    memcpy(r.data + a.len, b.data, (size_t)b.len);
+    return r;
+}
 /* SHA-256 + HMAC-SHA256 (pure C, no dependency). Operate on NUL-terminated text
    and return a lowercase hex digest. */
 static uint32_t mfl_ror32(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
@@ -1577,6 +1628,8 @@ func cType(k Kind) string {
 		return "int"
 	case KString:
 		return "char*"
+	case KBytes:
+		return "mfl_bytes"
 	case KVoid:
 		return "void"
 	case KSlice:
@@ -1597,7 +1650,7 @@ func cZero(k Kind) string {
 		return "0.0"
 	case KString:
 		return "\"\"" // the zero value of a string is "", not NULL
-	case KSlice, KStruct, KFunc:
+	case KSlice, KStruct, KFunc, KBytes:
 		return "{0}"
 	default:
 		return "0"
@@ -2355,6 +2408,8 @@ func (g *cgen) printCall(call *Call, depth int) error {
 			fmt.Fprintf(&g.buf, "fputs((%s) ? \"true\" : \"false\", stdout);", e)
 		case KString:
 			fmt.Fprintf(&g.buf, "{ const char* _s = (%s); fputs(_s ? _s : \"\", stdout); }", e)
+		case KBytes:
+			fmt.Fprintf(&g.buf, "fputs(mfl_bytes_hex(%s), stdout);", e) // print bytes as hex
 		case KSlice, KStruct, KChan, KMap:
 			return fmt.Errorf("cannot print a %s value", g.c.NodeKind(g.curFn, a))
 		default:
@@ -2966,12 +3021,26 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	switch ex.Callee {
 	case "len":
 		switch g.c.NodeKind(g.curFn, ex.Args[0]) {
-		case KSlice:
+		case KSlice, KBytes:
 			return fmt.Sprintf("((%s).len)", args[0]), nil
 		case KMap:
 			return fmt.Sprintf("mfl_map_len(%s)", args[0]), nil
 		}
 		return fmt.Sprintf("((int64_t)strlen(%s))", args[0]), nil
+	case "bytes":
+		return fmt.Sprintf("mfl_bytes_from_str(%s)", args[0]), nil
+	case "bytes_str":
+		return fmt.Sprintf("mfl_bytes_str(%s)", args[0]), nil
+	case "to_hex":
+		return fmt.Sprintf("mfl_bytes_hex(%s)", args[0]), nil
+	case "from_hex":
+		return fmt.Sprintf("mfl_bytes_unhex(%s)", args[0]), nil
+	case "byte_at":
+		return fmt.Sprintf("mfl_byte_at(%s, %s)", args[0], args[1]), nil
+	case "bytes_sub":
+		return fmt.Sprintf("mfl_bytes_sub(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "bytes_concat":
+		return fmt.Sprintf("mfl_bytes_concat(%s, %s)", args[0], args[1]), nil
 	case "has":
 		ik, sk := g.mapKeyArgs(ex.Args[0], args[1])
 		return fmt.Sprintf("mfl_map_has(%s, %s, %s)", args[0], ik, sk), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.33.0"
+const machinVersion = "0.34.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -62,6 +62,7 @@ func machinGuide() guideCatalog {
 			{"float", "double"},
 			{"bool", "true/false"},
 			{"string", "immutable UTF-8 bytes; zero value \"\""},
+			{"bytes", "NUL-safe binary buffer (ptr+len); from bytes()/from_hex(); inspect with len/byte_at/to_hex. For binary protocols & crypto (strings truncate at NUL)"},
 			{"[]T", "slice (append to grow); for i, v := range"},
 			{"map[K]V", "K is int or string; make(map[K]V); has/delete/keys"},
 			{"struct", "type T struct { f T ... }; value semantics; T{f: v}"},
@@ -120,6 +121,14 @@ func machinGuide() guideCatalog {
 			{"url_decode", "(string) -> string", "percent-decode a URL component (lenient: + -> space, bad %XX passes through)", "string"},
 			{"sha256", "(string) -> string", "SHA-256 of text, lowercase hex", "crypto"},
 			{"hmac_sha256", "(string, string) -> string", "HMAC-SHA256(key, message), lowercase hex (webhook signatures)", "crypto"},
+			// bytes (a NUL-safe binary buffer — the type strings can't be; for binary protocols/crypto)
+			{"bytes", "(string) -> bytes", "make a bytes value from a string's raw bytes", "bytes"},
+			{"bytes_str", "(bytes) -> string", "bytes -> string (NUL-terminated; truncates at an embedded 0)", "bytes"},
+			{"to_hex", "(bytes) -> string", "lowercase hex of a bytes value", "bytes"},
+			{"from_hex", "(string) -> bytes", "parse hex -> bytes (skips non-hex chars)", "bytes"},
+			{"byte_at", "(bytes, int) -> int", "byte value 0-255 at an index (-1 if out of range)", "bytes"},
+			{"bytes_sub", "(bytes, int, int) -> bytes", "sub-range [start, end) of a bytes value", "bytes"},
+			{"bytes_concat", "(bytes, bytes) -> bytes", "concatenate two bytes values", "bytes"},
 			// sqlite (libsqlite3, linked only when used)
 			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
 			{"sqlite_exec", "(int, string[, []string]) -> int", "run SQL with no result; optional []string binds the ? params (injection-safe); 0 ok", "db"},
@@ -154,6 +163,7 @@ func machinGuide() guideCatalog {
 		},
 		Idioms: []guideIdiom{
 			{"hello", `func main() { println("hello") }`},
+			{"bytes", `func main() { b := from_hex("deadbeef")  b = bytes_concat(b, bytes("!"))  println(to_hex(b) + " len=" + str(len(b)) + " b0=" + str(byte_at(b, 0))) }`},
 			{"types", `type P struct { name string  age int }
 func main() { p := P{name: "ada", age: 36}  xs := []int{1, 2, 3}  m := make(map[string]int)  m["k"] = 1  println(p.name + " " + str(len(xs)) + " " + str(m["k"])) }`},
 			{"goroutine-channel", `func work(ch) { ch <- 42 }

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -735,6 +735,27 @@ func TestURLEncoding(t *testing.T) {
 	}
 }
 
+// bytes is a NUL-safe binary buffer: it must survive an embedded zero byte that
+// would truncate a string, round-trip through hex, and support len/byte_at/
+// sub/concat. The "00" in the middle is the whole point.
+func TestBytes(t *testing.T) {
+	main := `func main() {
+	b := from_hex("48650061ff")            // H e \0 a 0xff  — has an embedded NUL
+	println(str(len(b)))                    // 5, not 2 (a string would stop at the NUL)
+	println(to_hex(b))
+	println(str(byte_at(b, 4)))             // 255
+	println(to_hex(bytes_sub(b, 1, 3)))     // "6500"
+	println(to_hex(bytes_concat(from_hex("aa"), from_hex("bbcc"))))
+	println(to_hex(bytes("ABC")))           // 414243
+	println(b)                              // println of bytes prints hex
+}`
+	out, _ := buildRun(t, main)
+	want := "5\n48650061ff\n255\n6500\naabbcc\n414243\n48650061ff\n"
+	if out != want {
+		t.Fatalf("bytes: got %q, want %q", out, want)
+	}
+}
+
 // SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
 func TestHashes(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -28,6 +28,7 @@ const (
 	KChan   // chan elem; element kind stored in the slot's elem slot
 	KMap    // map[k]v; key/value kinds stored in mkey/mval slots
 	KFunc   // a function value; signature stored in the slot's fsig
+	KBytes  // a NUL-safe binary buffer (pointer + length)
 )
 
 func (k Kind) String() string {
@@ -56,6 +57,8 @@ func (k Kind) String() string {
 		return "map"
 	case KFunc:
 		return "func"
+	case KBytes:
+		return "bytes"
 	}
 	return "?"
 }
@@ -82,7 +85,7 @@ type Checker struct {
 	nodeSlot   map[string]map[Node]int // instance -> expr node -> slot
 
 	// shared concrete slots (no inner type vars, safe to share)
-	cBool, cString, cVoid, cInt, cFloat int
+	cBool, cString, cVoid, cInt, cFloat, cBytes int
 
 	externs map[string]*ExternFunc // foreign C functions, by name
 
@@ -585,6 +588,7 @@ func Check(p *Program) (*Checker, error) {
 	c.cVoid = newSlot(c, KVoid)
 	c.cInt = newSlot(c, KInt)
 	c.cFloat = newSlot(c, KFloat)
+	c.cBytes = newSlot(c, KBytes)
 
 	// 0. register struct types and validate their field types
 	for _, td := range p.Types {
@@ -666,8 +670,8 @@ func Check(p *Program) (*Checker, error) {
 	}
 	// 5. validate len() arguments now that kinds are fully resolved.
 	for _, slot := range c.lenArgs {
-		if k := c.kindOf(slot); k != KString && k != KSlice && k != KMap {
-			return nil, fmt.Errorf("len: argument must be a string, slice, or map, got %s", k)
+		if k := c.kindOf(slot); k != KString && k != KSlice && k != KMap && k != KBytes {
+			return nil, fmt.Errorf("len: argument must be a string, slice, map, or bytes, got %s", k)
 		}
 	}
 	// 6. dedup instances by concrete signature and assign C names
@@ -1581,6 +1585,52 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		// an int) after solving, instead of emitting strlen() on a scalar.
 		c.lenArgs = append(c.lenArgs, argSlots[0])
 		return c.cInt, nil
+	case "bytes":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("bytes: 1 arg (string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cBytes, nil
+	case "bytes_str":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("bytes_str: 1 arg (bytes)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		return c.cString, nil
+	case "to_hex":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("to_hex: 1 arg (bytes)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		return c.cString, nil
+	case "from_hex":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("from_hex: 1 arg (string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cBytes, nil
+	case "byte_at":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("byte_at: 2 args (bytes, index)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cInt, nil
+	case "bytes_sub":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("bytes_sub: 3 args (bytes, start, end)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cInt)
+		c.addPair(argSlots[2], c.cInt)
+		return c.cBytes, nil
+	case "bytes_concat":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("bytes_concat: 2 args (bytes, bytes)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cBytes)
+		return c.cBytes, nil
 	case "append":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("append: 2 args")
@@ -2068,6 +2118,8 @@ func (c *Checker) ctypeSlot(slot int) string {
 		return "int"
 	case KString:
 		return "char*"
+	case KBytes:
+		return "mfl_bytes"
 	case KVoid:
 		return "void"
 	case KSlice:


### PR DESCRIPTION
## What

Adds a **`bytes`** type — a NUL-safe binary buffer (pointer + length). machin
strings are NUL-terminated `char*`, so they truncate at any `0x00`; `bytes` can
hold arbitrary binary.

Surface (inference-only for now — no `var x bytes`/struct fields yet):

| builtin | sig |
|---|---|
| `bytes(string)` | `-> bytes` (raw bytes of a string) |
| `bytes_str(bytes)` | `-> string` (truncates at an embedded NUL) |
| `to_hex` / `from_hex` | `bytes`↔hex `string` |
| `byte_at(bytes, int)` | `-> int` (0–255, −1 OOB) |
| `bytes_sub(bytes, int, int)` | `-> bytes` |
| `bytes_concat(bytes, bytes)` | `-> bytes` |

`len(b)` works; `println(b)` prints hex.

## Why

**Step 1 of doing WhatsApp natively in machin.** Every part of the WhatsApp
protocol (Noise handshake, AES-GCM, protobuf, binary nodes) is binary — and the
real blocker wasn't crypto (OpenSSL is already linked) but the lack of a binary
type. This is the foundation; OpenSSL-backed crypto builtins (x25519, ed25519,
aes-gcm, hkdf, rand) come next, operating on `bytes`.

## Notes

- `KBytes` is wired through the Kind enum, **both** C-type mappers (`cType` and
  the checker's `ctypeSlot` — the latter drives local-var declarations and was
  the subtle one), `cZero`, `print`, and `len` validation.
- Verified: embedded-NUL survival, hex round-trip, UTF-8, NUL-truncation of
  `bytes_str`. `TestBytes` + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.34.0 Release Notes

* **New Features**
  * Introduced a new `bytes` type for handling NUL-safe binary buffers with dedicated operations: `bytes()`, `bytes_str()`, `to_hex()`, `from_hex()`, `byte_at()`, `bytes_sub()`, and `bytes_concat()`.
  * Extended `len()` builtin to support `bytes` values.

* **Tests**
  * Added comprehensive test coverage for bytes functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->