### PR TITLE
feat: crypto builtins over bytes (X25519/Ed25519/AES/HKDF)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.35.0
+
+- **Crypto builtins over `bytes` (OpenSSL libcrypto).** Step 2 of the native-crypto
+  path: `rand_bytes`, `sha256_bytes`, `hmac_sha256_bytes`, `hkdf_sha256`,
+  `x25519_pub`/`x25519_shared`, `ed25519_pub`/`ed25519_sign`/`ed25519_verify`,
+  `aes_gcm_encrypt`/`decrypt`, `aes_cbc_encrypt`/`decrypt` — thin wrappers over
+  OpenSSL, all operating on `bytes`. Emitted and linked (`-lcrypto`) only when a
+  program uses one, so crypto-free programs stay lean. This proves the viability
+  checkpoint: machin can do an X25519 ECDH handshake natively. (Digests match
+  OpenSSL byte-for-byte; X25519 agreement, Ed25519 sign/verify, and AES-GCM/CBC
+  round-trips all verified.)
+
 ## v0.34.0
 
 - **`bytes` type — a NUL-safe binary buffer.** machin strings are NUL-terminated

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.34.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.35.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.34.0
+Version 0.35.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -270,6 +270,19 @@ throughout the function body).
 | `byte_at` | `(bytes, int) -> int` | byte value 0–255 at an index (`-1` if out of range) |
 | `bytes_sub` | `(bytes, int, int) -> bytes` | sub-range `[start, end)` |
 | `bytes_concat` | `(bytes, bytes) -> bytes` | concatenate two `bytes` values |
+| `rand_bytes` | `(int) -> bytes` | `n` cryptographically-random bytes (CSPRNG) |
+| `sha256_bytes` | `(bytes) -> bytes` | SHA-256 of binary → 32-byte digest (binary-safe) |
+| `hmac_sha256_bytes` | `(bytes, bytes) -> bytes` | HMAC-SHA256(key, msg) → 32 bytes |
+| `hkdf_sha256` | `(bytes, bytes, bytes, int) -> bytes` | HKDF-SHA256(ikm, salt, info, length) |
+| `x25519_pub` | `(bytes) -> bytes` | X25519 public key from a 32-byte private key |
+| `x25519_shared` | `(bytes, bytes) -> bytes` | X25519 ECDH shared secret (my private, their public) |
+| `ed25519_pub` | `(bytes) -> bytes` | Ed25519 public key from a 32-byte seed |
+| `ed25519_sign` | `(bytes, bytes) -> bytes` | Ed25519 signature (seed, msg) → 64 bytes |
+| `ed25519_verify` | `(bytes, bytes, bytes) -> bool` | Ed25519 verify (pub, msg, sig) |
+| `aes_gcm_encrypt` | `(bytes, bytes, bytes, bytes) -> bytes` | AES-GCM (key, iv, plaintext, aad) → ciphertext‖16-byte tag |
+| `aes_gcm_decrypt` | `(bytes, bytes, bytes, bytes) -> bytes` | AES-GCM decrypt → plaintext (empty `bytes` on auth failure) |
+| `aes_cbc_encrypt` | `(bytes, bytes, bytes) -> bytes` | AES-CBC (key, iv, plaintext), PKCS#7 padded |
+| `aes_cbc_decrypt` | `(bytes, bytes, bytes) -> bytes` | AES-CBC decrypt → plaintext (empty on bad padding) |
 | `url_encode` | `(string) -> string` | percent-encode for URLs (RFC 3986: keeps `A-Za-z0-9-._~`, encodes the rest, space → `%20`) |
 | `url_decode` | `(string) -> string` | percent-decode a URL component (lenient: `+` → space, malformed `%XX` passes through) |
 | `sha256` | `(string) -> string` | SHA-256 of text, lowercase hex |

--- a/build.go
+++ b/build.go
@@ -54,6 +54,11 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 	if strings.Contains(csrc, "mfl_sqlite_") {
 		libs = append(libs, "-lsqlite3")
 	}
+	// crypto builtins (rand/sha/hmac/hkdf/x25519/ed25519/aes) link OpenSSL
+	// libcrypto — only when used. Harmless if -lcrypto is already added for TLS.
+	if strings.Contains(csrc, "mfl_crypto_") {
+		libs = append(libs, "-lcrypto")
+	}
 	args = append(args, "-o", outPath, tmp.Name())
 	args = append(args, libs...)
 

--- a/codegen.go
+++ b/codegen.go
@@ -65,6 +65,7 @@ type cgen struct {
 	usesWSS   bool   // program calls wss_* -> emit WebSocket runtime + link OpenSSL
 	usesRegex bool   // program calls regex_* -> emit POSIX regex runtime
 	usesSQLite bool  // program calls sqlite_* -> emit SQLite runtime + link -lsqlite3
+	usesCrypto bool  // program calls crypto builtins -> emit crypto runtime + link -lcrypto
 }
 
 const cRuntime = `#define _GNU_SOURCE
@@ -1540,6 +1541,164 @@ static int64_t mfl_sqlite_exec_p(int64_t h, const char* sql, mfl_slice params) {
 }
 `
 
+// cryptoRuntime wraps OpenSSL libcrypto primitives over the bytes type. Emitted
+// (and linked, -lcrypto) only when a program calls a crypto builtin. All inputs
+// and outputs are mfl_bytes (arena-allocated); ed25519_verify returns a bool.
+const cryptoRuntime = `#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#include <openssl/kdf.h>
+
+static mfl_bytes mfl_crypto_buf(int64_t n) {
+    mfl_bytes b; b.len = n < 0 ? 0 : n; b.data = (uint8_t*)mfl_alloc(b.len ? b.len : 1); return b;
+}
+static mfl_bytes mfl_crypto_rand(int64_t n) {
+    mfl_bytes b = mfl_crypto_buf(n);
+    if (b.len > 0) RAND_bytes(b.data, (int)b.len);
+    return b;
+}
+static mfl_bytes mfl_crypto_sha256(mfl_bytes m) {
+    mfl_bytes out = mfl_crypto_buf(32);
+    SHA256(m.data, (size_t)m.len, out.data);
+    return out;
+}
+static mfl_bytes mfl_crypto_hmac256(mfl_bytes key, mfl_bytes msg) {
+    mfl_bytes out = mfl_crypto_buf(32);
+    unsigned int n = 32;
+    HMAC(EVP_sha256(), key.data, (int)key.len, msg.data, (size_t)msg.len, out.data, &n);
+    out.len = n;
+    return out;
+}
+static mfl_bytes mfl_crypto_hkdf(mfl_bytes ikm, mfl_bytes salt, mfl_bytes info, int64_t length) {
+    mfl_bytes out = mfl_crypto_buf(length);
+    EVP_PKEY_CTX* c = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+    if (c) {
+        size_t l = (size_t)out.len;
+        if (EVP_PKEY_derive_init(c) > 0 &&
+            EVP_PKEY_CTX_set_hkdf_md(c, EVP_sha256()) > 0 &&
+            EVP_PKEY_CTX_set1_hkdf_salt(c, salt.data, (int)salt.len) > 0 &&
+            EVP_PKEY_CTX_set1_hkdf_key(c, ikm.data, (int)ikm.len) > 0 &&
+            EVP_PKEY_CTX_add1_hkdf_info(c, info.data, (int)info.len) > 0 &&
+            EVP_PKEY_derive(c, out.data, &l) > 0) out.len = (int64_t)l;
+        else out.len = 0;
+        EVP_PKEY_CTX_free(c);
+    }
+    return out;
+}
+static mfl_bytes mfl_crypto_x25519_pub(mfl_bytes priv) {
+    mfl_bytes out = mfl_crypto_buf(32); out.len = 0;
+    EVP_PKEY* pk = EVP_PKEY_new_raw_private_key(EVP_PKEY_X25519, NULL, priv.data, (size_t)priv.len);
+    if (pk) { size_t l = 32; if (EVP_PKEY_get_raw_public_key(pk, out.data, &l) > 0) out.len = (int64_t)l; EVP_PKEY_free(pk); }
+    return out;
+}
+static mfl_bytes mfl_crypto_x25519_shared(mfl_bytes priv, mfl_bytes peer) {
+    mfl_bytes out = mfl_crypto_buf(32); out.len = 0;
+    EVP_PKEY* sk = EVP_PKEY_new_raw_private_key(EVP_PKEY_X25519, NULL, priv.data, (size_t)priv.len);
+    EVP_PKEY* pubk = EVP_PKEY_new_raw_public_key(EVP_PKEY_X25519, NULL, peer.data, (size_t)peer.len);
+    if (sk && pubk) {
+        EVP_PKEY_CTX* c = EVP_PKEY_CTX_new(sk, NULL);
+        if (c && EVP_PKEY_derive_init(c) > 0 && EVP_PKEY_derive_set_peer(c, pubk) > 0) {
+            size_t l = 32; if (EVP_PKEY_derive(c, out.data, &l) > 0) out.len = (int64_t)l;
+        }
+        if (c) EVP_PKEY_CTX_free(c);
+    }
+    if (sk) EVP_PKEY_free(sk);
+    if (pubk) EVP_PKEY_free(pubk);
+    return out;
+}
+static mfl_bytes mfl_crypto_ed25519_pub(mfl_bytes seed) {
+    mfl_bytes out = mfl_crypto_buf(32); out.len = 0;
+    EVP_PKEY* pk = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, seed.data, (size_t)seed.len);
+    if (pk) { size_t l = 32; if (EVP_PKEY_get_raw_public_key(pk, out.data, &l) > 0) out.len = (int64_t)l; EVP_PKEY_free(pk); }
+    return out;
+}
+static mfl_bytes mfl_crypto_ed25519_sign(mfl_bytes seed, mfl_bytes msg) {
+    mfl_bytes out = mfl_crypto_buf(64); out.len = 0;
+    EVP_PKEY* pk = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, seed.data, (size_t)seed.len);
+    if (pk) {
+        EVP_MD_CTX* c = EVP_MD_CTX_new();
+        if (c && EVP_DigestSignInit(c, NULL, NULL, NULL, pk) > 0) {
+            size_t l = 64; if (EVP_DigestSign(c, out.data, &l, msg.data, (size_t)msg.len) > 0) out.len = (int64_t)l;
+        }
+        if (c) EVP_MD_CTX_free(c);
+        EVP_PKEY_free(pk);
+    }
+    return out;
+}
+static int mfl_crypto_ed25519_verify(mfl_bytes pub, mfl_bytes msg, mfl_bytes sig) {
+    int ok = 0;
+    EVP_PKEY* pk = EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, NULL, pub.data, (size_t)pub.len);
+    if (pk) {
+        EVP_MD_CTX* c = EVP_MD_CTX_new();
+        if (c && EVP_DigestVerifyInit(c, NULL, NULL, NULL, pk) > 0)
+            ok = EVP_DigestVerify(c, sig.data, (size_t)sig.len, msg.data, (size_t)msg.len) == 1;
+        if (c) EVP_MD_CTX_free(c);
+        EVP_PKEY_free(pk);
+    }
+    return ok;
+}
+static mfl_bytes mfl_crypto_aes_gcm_enc(mfl_bytes key, mfl_bytes iv, mfl_bytes pt, mfl_bytes aad) {
+    mfl_bytes out = mfl_crypto_buf(pt.len + 16); out.len = 0;
+    EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+    const EVP_CIPHER* ciph = (key.len == 16) ? EVP_aes_128_gcm() : EVP_aes_256_gcm();
+    if (c && EVP_EncryptInit_ex(c, ciph, NULL, NULL, NULL) > 0 &&
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_IVLEN, (int)iv.len, NULL) > 0 &&
+        EVP_EncryptInit_ex(c, NULL, NULL, key.data, iv.data) > 0) {
+        int l = 0, t = 0;
+        if (aad.len > 0) EVP_EncryptUpdate(c, NULL, &l, aad.data, (int)aad.len);
+        EVP_EncryptUpdate(c, out.data, &l, pt.data, (int)pt.len); t = l;
+        EVP_EncryptFinal_ex(c, out.data + t, &l); t += l;
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_GET_TAG, 16, out.data + t);
+        out.len = t + 16;
+    }
+    if (c) EVP_CIPHER_CTX_free(c);
+    return out;
+}
+static mfl_bytes mfl_crypto_aes_gcm_dec(mfl_bytes key, mfl_bytes iv, mfl_bytes ct, mfl_bytes aad) {
+    mfl_bytes out = mfl_crypto_buf(ct.len > 16 ? ct.len - 16 : 1); out.len = 0;
+    if (ct.len < 16) return out;
+    int64_t ctlen = ct.len - 16;
+    EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+    const EVP_CIPHER* ciph = (key.len == 16) ? EVP_aes_128_gcm() : EVP_aes_256_gcm();
+    if (c && EVP_DecryptInit_ex(c, ciph, NULL, NULL, NULL) > 0 &&
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_IVLEN, (int)iv.len, NULL) > 0 &&
+        EVP_DecryptInit_ex(c, NULL, NULL, key.data, iv.data) > 0) {
+        int l = 0, t = 0;
+        if (aad.len > 0) EVP_DecryptUpdate(c, NULL, &l, aad.data, (int)aad.len);
+        EVP_DecryptUpdate(c, out.data, &l, ct.data, (int)ctlen); t = l;
+        EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_GCM_SET_TAG, 16, ct.data + ctlen);
+        if (EVP_DecryptFinal_ex(c, out.data + t, &l) > 0) out.len = t + l;  /* else stays 0: auth fail */
+    }
+    if (c) EVP_CIPHER_CTX_free(c);
+    return out;
+}
+static mfl_bytes mfl_crypto_aes_cbc_enc(mfl_bytes key, mfl_bytes iv, mfl_bytes pt) {
+    mfl_bytes out = mfl_crypto_buf(pt.len + 16); out.len = 0;
+    EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+    const EVP_CIPHER* ciph = (key.len == 16) ? EVP_aes_128_cbc() : EVP_aes_256_cbc();
+    if (c && EVP_EncryptInit_ex(c, ciph, NULL, key.data, iv.data) > 0) {
+        int l = 0, t = 0;
+        EVP_EncryptUpdate(c, out.data, &l, pt.data, (int)pt.len); t = l;
+        EVP_EncryptFinal_ex(c, out.data + t, &l); out.len = t + l;
+    }
+    if (c) EVP_CIPHER_CTX_free(c);
+    return out;
+}
+static mfl_bytes mfl_crypto_aes_cbc_dec(mfl_bytes key, mfl_bytes iv, mfl_bytes ct) {
+    mfl_bytes out = mfl_crypto_buf(ct.len ? ct.len : 1); out.len = 0;
+    EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+    const EVP_CIPHER* ciph = (key.len == 16) ? EVP_aes_128_cbc() : EVP_aes_256_cbc();
+    if (c && EVP_DecryptInit_ex(c, ciph, NULL, key.data, iv.data) > 0) {
+        int l = 0, t = 0;
+        EVP_DecryptUpdate(c, out.data, &l, ct.data, (int)ct.len); t = l;
+        if (EVP_DecryptFinal_ex(c, out.data + t, &l) > 0) out.len = t + l;  /* else 0: bad pad */
+    }
+    if (c) EVP_CIPHER_CTX_free(c);
+    return out;
+}
+`
+
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
 func isFFIScalar(t string) bool {
 	switch t {
@@ -1692,6 +1851,12 @@ func (g *cgen) program(p *Program) (string, error) {
 		// SQLite (libsqlite3) — emitted and linked (-lsqlite3) only when a program
 		// calls sqlite_*, so other programs don't depend on it.
 		out.WriteString(sqliteRuntime)
+		out.WriteByte('\n')
+	}
+	if g.usesCrypto {
+		// OpenSSL libcrypto (rand/sha/hmac/hkdf/x25519/ed25519/aes) — emitted and
+		// linked (-lcrypto) only when a program calls a crypto builtin.
+		out.WriteString(cryptoRuntime)
 		out.WriteByte('\n')
 	}
 	// foreign (extern) declarations. With a header, its prototypes + C structs are
@@ -3041,6 +3206,45 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_bytes_sub(%s, %s, %s)", args[0], args[1], args[2]), nil
 	case "bytes_concat":
 		return fmt.Sprintf("mfl_bytes_concat(%s, %s)", args[0], args[1]), nil
+	case "rand_bytes":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_rand(%s)", args[0]), nil
+	case "sha256_bytes":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_sha256(%s)", args[0]), nil
+	case "hmac_sha256_bytes":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_hmac256(%s, %s)", args[0], args[1]), nil
+	case "hkdf_sha256":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_hkdf(%s, %s, %s, %s)", args[0], args[1], args[2], args[3]), nil
+	case "x25519_pub":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_x25519_pub(%s)", args[0]), nil
+	case "x25519_shared":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_x25519_shared(%s, %s)", args[0], args[1]), nil
+	case "ed25519_pub":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_ed25519_pub(%s)", args[0]), nil
+	case "ed25519_sign":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_ed25519_sign(%s, %s)", args[0], args[1]), nil
+	case "ed25519_verify":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_ed25519_verify(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "aes_gcm_encrypt":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_aes_gcm_enc(%s, %s, %s, %s)", args[0], args[1], args[2], args[3]), nil
+	case "aes_gcm_decrypt":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_aes_gcm_dec(%s, %s, %s, %s)", args[0], args[1], args[2], args[3]), nil
+	case "aes_cbc_encrypt":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_aes_cbc_enc(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "aes_cbc_decrypt":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_aes_cbc_dec(%s, %s, %s)", args[0], args[1], args[2]), nil
 	case "has":
 		ik, sk := g.mapKeyArgs(ex.Args[0], args[1])
 		return fmt.Sprintf("mfl_map_has(%s, %s, %s)", args[0], ik, sk), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.34.0"
+const machinVersion = "0.35.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -129,6 +129,20 @@ func machinGuide() guideCatalog {
 			{"byte_at", "(bytes, int) -> int", "byte value 0-255 at an index (-1 if out of range)", "bytes"},
 			{"bytes_sub", "(bytes, int, int) -> bytes", "sub-range [start, end) of a bytes value", "bytes"},
 			{"bytes_concat", "(bytes, bytes) -> bytes", "concatenate two bytes values", "bytes"},
+			// crypto over bytes (OpenSSL libcrypto, linked only when used)
+			{"rand_bytes", "(int) -> bytes", "n cryptographically-random bytes (CSPRNG)", "crypto"},
+			{"sha256_bytes", "(bytes) -> bytes", "SHA-256 of binary -> 32-byte digest (binary-safe, unlike sha256)", "crypto"},
+			{"hmac_sha256_bytes", "(bytes, bytes) -> bytes", "HMAC-SHA256(key, msg) -> 32 bytes (binary-safe)", "crypto"},
+			{"hkdf_sha256", "(bytes, bytes, bytes, int) -> bytes", "HKDF-SHA256(ikm, salt, info, length) -> length bytes", "crypto"},
+			{"x25519_pub", "(bytes) -> bytes", "X25519 public key from a 32-byte private key", "crypto"},
+			{"x25519_shared", "(bytes, bytes) -> bytes", "X25519 ECDH shared secret (my private, their public) -> 32 bytes", "crypto"},
+			{"ed25519_pub", "(bytes) -> bytes", "Ed25519 public key from a 32-byte seed", "crypto"},
+			{"ed25519_sign", "(bytes, bytes) -> bytes", "Ed25519 sign (seed, msg) -> 64-byte signature", "crypto"},
+			{"ed25519_verify", "(bytes, bytes, bytes) -> bool", "Ed25519 verify (pub, msg, sig)", "crypto"},
+			{"aes_gcm_encrypt", "(bytes, bytes, bytes, bytes) -> bytes", "AES-GCM (key, iv, plaintext, aad) -> ciphertext||16-byte tag (key 16 or 32)", "crypto"},
+			{"aes_gcm_decrypt", "(bytes, bytes, bytes, bytes) -> bytes", "AES-GCM decrypt (key, iv, ct||tag, aad) -> plaintext (empty bytes on auth failure)", "crypto"},
+			{"aes_cbc_encrypt", "(bytes, bytes, bytes) -> bytes", "AES-CBC encrypt (key, iv, plaintext), PKCS#7 padded", "crypto"},
+			{"aes_cbc_decrypt", "(bytes, bytes, bytes) -> bytes", "AES-CBC decrypt (key, iv, ciphertext) -> plaintext (empty on bad padding)", "crypto"},
 			// sqlite (libsqlite3, linked only when used)
 			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
 			{"sqlite_exec", "(int, string[, []string]) -> int", "run SQL with no result; optional []string binds the ? params (injection-safe); 0 ok", "db"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -756,6 +756,33 @@ func TestBytes(t *testing.T) {
 	}
 }
 
+// The OpenSSL-backed crypto builtins over bytes: digests match known vectors,
+// X25519 agreement holds, Ed25519 sign/verify works (and rejects tampering), and
+// AES-GCM round-trips (with auth failure -> empty on a wrong AAD).
+func TestCrypto(t *testing.T) {
+	main := `func main() {
+	println(to_hex(sha256_bytes(bytes("abc"))))
+	println(to_hex(hmac_sha256_bytes(bytes("key"), bytes("msg"))))
+	a := rand_bytes(32)  b := rand_bytes(32)
+	println(to_hex(x25519_shared(a, x25519_pub(b))) == to_hex(x25519_shared(b, x25519_pub(a))))
+	seed := rand_bytes(32)  m := bytes("hi")
+	sig := ed25519_sign(seed, m)
+	println(ed25519_verify(ed25519_pub(seed), m, sig))
+	println(ed25519_verify(ed25519_pub(seed), bytes("no"), sig))
+	k := rand_bytes(32)  iv := rand_bytes(12)
+	ct := aes_gcm_encrypt(k, iv, m, bytes(""))
+	println(bytes_str(aes_gcm_decrypt(k, iv, ct, bytes(""))) == "hi")
+	println(str(len(aes_gcm_decrypt(k, iv, ct, bytes("x")))))
+}`
+	out, _ := buildRun(t, main)
+	want := "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\n" +
+		"2d93cbc1be167bcb1637a4a23cbff01a7878f0c50ee833954ea5221bb1b8c628\n" +
+		"true\ntrue\nfalse\ntrue\n0\n"
+	if out != want {
+		t.Fatalf("crypto: got %q, want %q", out, want)
+	}
+}
+
 // SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
 func TestHashes(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -1631,6 +1631,58 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cBytes)
 		c.addPair(argSlots[1], c.cBytes)
 		return c.cBytes, nil
+	case "rand_bytes":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("rand_bytes: 1 arg (count)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cBytes, nil
+	case "sha256_bytes", "x25519_pub", "ed25519_pub":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("%s: 1 arg (bytes)", ex.Callee)
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		return c.cBytes, nil
+	case "hmac_sha256_bytes", "x25519_shared", "ed25519_sign":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("%s: 2 args (bytes, bytes)", ex.Callee)
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cBytes)
+		return c.cBytes, nil
+	case "ed25519_verify":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("ed25519_verify: 3 args (pub, msg, sig — all bytes)")
+		}
+		for _, sl := range argSlots {
+			c.addPair(sl, c.cBytes)
+		}
+		return c.cBool, nil
+	case "aes_cbc_encrypt", "aes_cbc_decrypt":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("%s: 3 args (key, iv, data — all bytes)", ex.Callee)
+		}
+		for _, sl := range argSlots {
+			c.addPair(sl, c.cBytes)
+		}
+		return c.cBytes, nil
+	case "aes_gcm_encrypt", "aes_gcm_decrypt":
+		if len(argSlots) != 4 {
+			return 0, fmt.Errorf("%s: 4 args (key, iv, data, aad — all bytes)", ex.Callee)
+		}
+		for _, sl := range argSlots {
+			c.addPair(sl, c.cBytes)
+		}
+		return c.cBytes, nil
+	case "hkdf_sha256":
+		if len(argSlots) != 4 {
+			return 0, fmt.Errorf("hkdf_sha256: 4 args (ikm, salt, info — bytes — and length int)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cBytes)
+		c.addPair(argSlots[2], c.cBytes)
+		c.addPair(argSlots[3], c.cInt)
+		return c.cBytes, nil
 	case "append":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("append: 2 args")


### PR DESCRIPTION
## What

13 OpenSSL-backed crypto builtins, all operating on the `bytes` type:

- `rand_bytes(n)` (CSPRNG)
- `sha256_bytes`, `hmac_sha256_bytes`, `hkdf_sha256` (binary-safe)
- `x25519_pub`, `x25519_shared` (ECDH)
- `ed25519_pub`, `ed25519_sign`, `ed25519_verify`
- `aes_gcm_encrypt/decrypt` (ct‖tag; empty on auth failure), `aes_cbc_encrypt/decrypt`

Emitted and linked (`-lcrypto`) **only when used** — gated on `mfl_crypto_` in
the generated C, like the TLS/SQLite runtimes — so crypto-free programs stay lean.

## Why

Step 2 of doing WhatsApp natively in machin. The crypto was never a
reimplementation — OpenSSL (already linked for TLS) has it all; we just expose it
over the new `bytes` type. **This proves the viability checkpoint: machin can do
an X25519 handshake natively.**

## Verified

- SHA-256 / HMAC match OpenSSL byte-for-byte (test vectors).
- X25519: both parties derive the same shared secret.
- Ed25519: valid sig verifies, tampered message rejected.
- AES-GCM round-trips; wrong AAD → empty (auth failure). AES-CBC round-trips.

`TestCrypto` + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)