### PR TITLE
feat: binary WebSocket frames (wss_send_bin / wss_recv_bin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.36.0
+
+- **Binary WebSocket frames: `wss_send_bin(conn, bytes)` / `wss_recv_bin(conn) -> bytes`.**
+  The existing `wss_send`/`wss_recv` are text (`char*`) and truncate at a NUL; the
+  binary variants carry a `bytes` payload (send as opcode `0x2`, recv NUL-safe).
+  The frame loop is refactored into a shared core, so text and binary recv behave
+  identically (ping/pong, fragmentation, close). Step 3 of the native-WhatsApp path
+  (the protocol is binary framing).
+
 ## v0.35.0
 
 - **Crypto builtins over `bytes` (OpenSSL libcrypto).** Step 2 of the native-crypto

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.35.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.36.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.35.0
+Version 0.36.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -307,6 +307,8 @@ throughout the function body).
 | `wss_open` | `(string) -> int` | open a `wss://` WebSocket; a connection handle, or 0 on failure |
 | `wss_send` | `(int, string) -> int` | send a text message on a WebSocket |
 | `wss_recv` | `(int) -> string` | next message (blocks); `""` on close (auto ping/pong) |
+| `wss_send_bin` | `(int, bytes) -> int` | send a binary message (opcode `0x2`) — NUL-safe |
+| `wss_recv_bin` | `(int) -> bytes` | next message as `bytes` (blocks); empty `bytes` on close |
 | `wss_close` | `(int) -> int` | send close and tear down the connection |
 
 ---

--- a/codegen.go
+++ b/codegen.go
@@ -1314,47 +1314,75 @@ static int64_t mfl_wss_send(int64_t h, const char* msg) {
     return 0;
 }
 
-/* block until a full text/binary message arrives; "" on close or error.
-   Replies to pings, ignores pongs, and reassembles fragmented messages. */
-static char* mfl_wss_recv(int64_t h) {
-    mfl_ws* w = (mfl_ws*)(intptr_t)h;
-    if (!w) return mfl_dup_arena("", 0);
+/* core: block until a full message; returns a malloc'd buffer (caller frees) and
+   its length via *outlen, or NULL on close/error. Replies to pings, ignores
+   pongs, reassembles fragments. An empty message returns a non-NULL 1-byte buf. */
+static unsigned char* mfl_ws_recv_raw(mfl_ws* w, size_t* outlen) {
+    *outlen = 0;
+    if (!w) return NULL;
     unsigned char* msg = NULL;
     size_t mlen = 0;
     for (;;) {
         unsigned char hd[2];
-        if (mfl_ssl_read_n(w->ssl, hd, 2) < 0) { free(msg); return mfl_dup_arena("", 0); }
+        if (mfl_ssl_read_n(w->ssl, hd, 2) < 0) { free(msg); return NULL; }
         int fin = hd[0] & 0x80;
         int opcode = hd[0] & 0x0f;
         int masked = hd[1] & 0x80;
         uint64_t len = hd[1] & 0x7f;
         if (len == 126) {
             unsigned char e[2];
-            if (mfl_ssl_read_n(w->ssl, e, 2) < 0) { free(msg); return mfl_dup_arena("", 0); }
+            if (mfl_ssl_read_n(w->ssl, e, 2) < 0) { free(msg); return NULL; }
             len = ((uint64_t)e[0] << 8) | e[1];
         } else if (len == 127) {
             unsigned char e[8];
-            if (mfl_ssl_read_n(w->ssl, e, 8) < 0) { free(msg); return mfl_dup_arena("", 0); }
+            if (mfl_ssl_read_n(w->ssl, e, 8) < 0) { free(msg); return NULL; }
             len = 0;
             for (int s = 0; s < 8; s++) len = (len << 8) | e[s];
         }
         unsigned char mk[4] = {0,0,0,0};
-        if (masked && mfl_ssl_read_n(w->ssl, mk, 4) < 0) { free(msg); return mfl_dup_arena("", 0); }
+        if (masked && mfl_ssl_read_n(w->ssl, mk, 4) < 0) { free(msg); return NULL; }
         unsigned char* pl = (unsigned char*)malloc(len ? len : 1);
-        if (len && mfl_ssl_read_n(w->ssl, pl, len) < 0) { free(pl); free(msg); return mfl_dup_arena("", 0); }
+        if (len && mfl_ssl_read_n(w->ssl, pl, len) < 0) { free(pl); free(msg); return NULL; }
         if (masked) for (uint64_t k = 0; k < len; k++) pl[k] ^= mk[k & 3];
 
         if (opcode == 0x9) { mfl_ws_frame(w, 0xA, pl, len); free(pl); continue; } /* ping -> pong */
         if (opcode == 0xA) { free(pl); continue; }                                /* pong */
-        if (opcode == 0x8) { mfl_ws_frame(w, 0x8, pl, len); free(pl); free(msg); return mfl_dup_arena("", 0); } /* close */
+        if (opcode == 0x8) { mfl_ws_frame(w, 0x8, pl, len); free(pl); free(msg); return NULL; } /* close */
 
         unsigned char* nm = (unsigned char*)realloc(msg, mlen + len);
         msg = nm;
         if (len) memcpy(msg + mlen, pl, len);
         mlen += len;
         free(pl);
-        if (fin) { char* r = mfl_dup_arena((char*)msg, mlen); free(msg); return r; }
+        if (fin) { *outlen = mlen; return msg ? msg : (unsigned char*)calloc(1, 1); }
     }
+}
+
+/* text recv: "" on close/error (truncates at an embedded NUL — for binary use wss_recv_bin) */
+static char* mfl_wss_recv(int64_t h) {
+    size_t n;
+    unsigned char* m = mfl_ws_recv_raw((mfl_ws*)(intptr_t)h, &n);
+    if (!m) return mfl_dup_arena("", 0);
+    char* r = mfl_dup_arena((char*)m, n);
+    free(m);
+    return r;
+}
+
+/* binary recv: a NUL-safe bytes message; empty bytes on close/error */
+static mfl_bytes mfl_wss_recv_bin(int64_t h) {
+    size_t n = 0;
+    unsigned char* m = mfl_ws_recv_raw((mfl_ws*)(intptr_t)h, &n);
+    mfl_bytes b; b.len = m ? (int64_t)n : 0; b.data = (uint8_t*)mfl_alloc(b.len ? b.len : 1);
+    if (m) { memcpy(b.data, m, n); free(m); }
+    return b;
+}
+
+/* binary send: one masked binary frame (opcode 0x2) carrying the bytes payload */
+static int64_t mfl_wss_send_bin(int64_t h, mfl_bytes b) {
+    mfl_ws* w = (mfl_ws*)(intptr_t)h;
+    if (!w) return -1;
+    mfl_ws_frame(w, 0x2, b.data, (size_t)b.len);
+    return 0;
 }
 
 static int64_t mfl_wss_close(int64_t h) {
@@ -3412,6 +3440,12 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "wss_recv":
 		g.usesWSS = true
 		return fmt.Sprintf("mfl_wss_recv(%s)", args[0]), nil
+	case "wss_send_bin":
+		g.usesWSS = true
+		return fmt.Sprintf("mfl_wss_send_bin(%s, %s)", args[0], args[1]), nil
+	case "wss_recv_bin":
+		g.usesWSS = true
+		return fmt.Sprintf("mfl_wss_recv_bin(%s)", args[0]), nil
 	case "wss_close":
 		g.usesWSS = true
 		return fmt.Sprintf("mfl_wss_close(%s)", args[0]), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.35.0"
+const machinVersion = "0.36.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -173,6 +173,8 @@ func machinGuide() guideCatalog {
 			{"wss_open", "(string) -> int", "open a wss:// WebSocket -> handle (0 on fail)", "ws"},
 			{"wss_send", "(int, string) -> int", "send a text message", "ws"},
 			{"wss_recv", "(int) -> string", "next message (blocks; \"\" on close; auto ping/pong)", "ws"},
+			{"wss_send_bin", "(int, bytes) -> int", "send a binary message (opcode 0x2) — NUL-safe, for binary protocols", "ws"},
+			{"wss_recv_bin", "(int) -> bytes", "next message as bytes (blocks; empty bytes on close; NUL-safe)", "ws"},
 			{"wss_close", "(int) -> int", "send close and tear down", "ws"},
 		},
 		Idioms: []guideIdiom{

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -889,6 +889,23 @@ func TestJSONGet(t *testing.T) {
 	}
 }
 
+// Binary WebSocket frames: wss_send_bin takes a bytes payload, wss_recv_bin
+// returns bytes. Compiling must wire the binary framing + bytes type and gate in
+// the WS/TLS runtime.
+func TestWSSBinary(t *testing.T) {
+	src := `func main() { c := wss_open("wss://x")  wss_send_bin(c, from_hex("00ff"))  b := wss_recv_bin(c)  println(to_hex(b)) }`
+	c, err := CompileToC(&Program{Funcs: parseFuncs(t, src)}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_wss_send_bin") || !strings.Contains(c, "mfl_wss_recv_bin") {
+		t.Fatal("binary wss must emit mfl_wss_send_bin / mfl_wss_recv_bin")
+	}
+	if !strings.Contains(c, "mfl_bytes") || !strings.Contains(c, "mfl_tls_dial") {
+		t.Fatal("binary wss must use the bytes type and the TLS core")
+	}
+}
+
 // The WebSocket runtime is emitted only when a program calls wss_*; it shares
 // the TLS core (mfl_tls_dial) with HTTPS but pulls in the WS framing separately.
 func TestWSSRuntimeGating(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -2027,6 +2027,19 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return c.cString, nil
+	case "wss_send_bin":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("wss_send_bin: 2 args (conn int, payload bytes)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cBytes)
+		return c.cInt, nil
+	case "wss_recv_bin":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("wss_recv_bin: 1 arg (conn int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cBytes, nil
 	case "wss_close":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("wss_close: 1 arg (conn int)")


### PR DESCRIPTION
## What

Adds `wss_send_bin(conn, bytes)` and `wss_recv_bin(conn) -> bytes` — binary
WebSocket frames over the existing TLS WebSocket client.

`wss_send`/`wss_recv` are text (`char*`) and truncate at a NUL; the binary
variants carry a `bytes` payload (send as opcode `0x2`, recv NUL-safe, empty on
close).

## How

The frame-reassembly loop is refactored into a shared core `mfl_ws_recv_raw`
(returns a malloc'd buffer + length, NULL on close), so text and binary recv
behave identically — ping→pong, pong-ignore, fragmentation reassembly, close.

## Why

Step 3 of doing WhatsApp natively in machin — the protocol frames everything as
binary WebSocket messages.

## Verified

Live against `wss://echo.websocket.org`: a payload `00ff4869001234` (with
embedded NUL bytes) round-trips **byte-identical** — a text frame would truncate
at the first `00`. `TestWSSBinary` (compile/gating) + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)