### PR TITLE
feat: bytes as a first-class declarable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.37.0
+
+- **`bytes` is now a first-class declarable type.** It was inference-only (locals
+  from `bytes()`/crypto builtins); now it's usable in `struct` fields, `map`
+  values (`map[string]bytes`), and `[]bytes`, so you can hold binary state in a
+  record — needed for protocol state machines (e.g. a Noise handshake). One-line
+  type-checker change; the C type (`mfl_bytes`) already existed.
+
 ## v0.36.0
 
 - **Binary WebSocket frames: `wss_send_bin(conn, bytes)` / `wss_recv_bin(conn) -> bytes`.**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.36.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.37.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.36.0
+Version 0.37.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -123,8 +123,8 @@ type User struct {
 }
 ```
 
-A field type is `int`, `float`, `bool`, `string`, `[]T`, `map[K]V`, `func` (a
-function value), or another struct name. Structs have **value semantics**:
+A field type is `int`, `float`, `bool`, `string`, `bytes`, `[]T`, `map[K]V`,
+`func` (a function value), or another struct name. Structs have **value semantics**:
 assigning or passing one copies it.
 
 The `func` type denotes a function value whose signature is inferred from use —

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.36.0"
+const machinVersion = "0.37.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -756,6 +756,23 @@ func TestBytes(t *testing.T) {
 	}
 }
 
+// bytes is a first-class declarable type: usable as a struct field (and mutable),
+// a map value, and a function return — not just an inferred local.
+func TestBytesDeclarable(t *testing.T) {
+	out := runProg(t,
+		`type Box struct { id int  data bytes }`,
+		`func main() {
+	b := Box{id: 7, data: from_hex("deadbeef")}
+	b.data = bytes_concat(b.data, from_hex("99"))
+	m := make(map[string]bytes)
+	m["k"] = from_hex("00ff")
+	println(str(b.id) + " " + to_hex(b.data) + " " + to_hex(m["k"]))
+}`)
+	if out != "7 deadbeef99 00ff\n" {
+		t.Fatalf("declarable bytes: got %q", out)
+	}
+}
+
 // The OpenSSL-backed crypto builtins over bytes: digests match known vectors,
 // X25519 agreement holds, Ed25519 sign/verify works (and rejects tampering), and
 // AES-GCM round-trips (with auth failure -> empty on a wrong AAD).

--- a/types.go
+++ b/types.go
@@ -279,6 +279,8 @@ func (c *Checker) typeSlot(t string) (int, error) {
 		return newSlot(c, KBool), nil
 	case "string":
 		return newSlot(c, KString), nil
+	case "bytes":
+		return newSlot(c, KBytes), nil
 	case "func":
 		return newSlot(c, KFunc), nil // signature filled in by unification
 	}
@@ -746,7 +748,7 @@ func (c *Checker) checkTypeName(t string) error {
 		return c.checkTypeName(vt)
 	}
 	switch t {
-	case "int", "float", "bool", "string", "func":
+	case "int", "float", "bool", "string", "bytes", "func":
 		return nil
 	}
 	if _, ok := c.structs[t]; ok {


### PR DESCRIPTION
## What

`bytes` was inference-only (locals from `bytes()` / crypto builtins). Now it's a
valid **declared** type, usable in:

- `struct` fields (and mutable: `b.data = ...`)
- `map` values: `map[string]bytes`
- slices: `[]bytes`

## Why

To hold binary protocol state in a record — needed for a Noise handshake state
machine (step 5 of the native-WhatsApp path) and any binary protocol work.

## How

A one-line addition to `checkTypeName` and the type-name→slot resolver (`bytes`
→ `KBytes`). The C type (`mfl_bytes`) already existed, and `cTypeName`'s
fallthrough already rendered `"bytes"` → `mfl_bytes`.

`TestBytesDeclarable` (struct field + mutation + map value) and the full suite
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.37.0

* **New Features**
  * The `bytes` type is now a first-class declarable type. Previously inference-only, it can now be used in struct field declarations, as map value types (`map[string]bytes`), and array types (`[]bytes`).

* **Documentation**
  * Updated documentation and version information to v0.37.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->