### PR TITLE
feat(machweb): request headers via header(req, name)

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -36,7 +36,9 @@ A handler is a closure `func(Request) Response`. `serve(port, handler)` runs the
 server, dispatching every request to it in its own goroutine (whose memory is
 reclaimed when the response is sent).
 
-**Request** — `req.method`, `req.path`, `req.body`. The full request body is
+**Request** — `req.method`, `req.path`, `req.body`, and `header(req, name)` for a
+request header (case-insensitive; `""` if absent — handy for `Authorization`).
+The full request body is
 read before dispatch (it keeps reading until `Content-Length` bytes arrive, so a
 `POST` whose body lands in a later TCP segment than its headers — as browsers
 often send — still parses).

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -9,9 +9,10 @@
 // own goroutine; the goroutine's memory is reclaimed when the response is sent.
 
 type Request struct {
-    method string
-    path   string
-    body   string
+    method  string
+    path    string
+    body    string
+    headers map[string]string   // lowercased header name -> value; read via header(req, name)
 }
 
 type Response struct {
@@ -35,7 +36,24 @@ func not_found() (r) { r = response("404 Not Found", "text/plain", "not found") 
 
 // ---- request helpers ----
 
-// parse_request extracts the method, path, and body from a raw HTTP request.
+// parse_headers builds a map of the request headers (names lowercased), reading
+// the lines between the request line and the blank line before the body.
+func parse_headers(raw) (h) {
+    h = make(map[string]string)
+    start := index(raw, "\r\n")
+    if start < 0 { return }
+    sep := index(raw, "\r\n\r\n")
+    if sep < 0 { sep = len(raw) }
+    block := substr(raw, start + 2, sep)
+    for _, line := range split(block, "\r\n") {
+        ci := index(line, ":")
+        if ci > 0 {
+            h[to_lower(trim(substr(line, 0, ci)))] = trim(substr(line, ci + 1, len(line)))
+        }
+    }
+}
+
+// parse_request extracts the method, path, headers, and body from a raw request.
 func parse_request(raw) (req) {
     nl := index(raw, "\r\n")
     line := substr(raw, 0, nl)
@@ -46,7 +64,14 @@ func parse_request(raw) (req) {
         m = parts[0]
         p = parts[1]
     }
-    req = Request{method: m, path: p, body: http_body(raw)}
+    req = Request{method: m, path: p, body: http_body(raw), headers: parse_headers(raw)}
+}
+
+// header returns a request header value (case-insensitive), or "" if absent.
+func header(req, name) (v) {
+    v = ""
+    k := to_lower(name)
+    if has(req.headers, k) { v = req.headers[k] }
 }
 
 // param returns the path segment after a prefix:


### PR DESCRIPTION
## What

`machweb`'s `Request` now carries parsed headers (`map[string]string`, names
lowercased), read with **`header(req, name)`** — case-insensitive, `""` if
absent. Enough for `Authorization: Bearer`, `Content-Type`, etc.

## Why

Dogfood-driven: **machin-notify** wants `Authorization: Bearer <token>` instead
of a token in the JSON body. Every future machin web service benefits.

## Notes

Library-only (no compiler change). `parse_request` fills `req.headers` via a new
`parse_headers`; `framework/router_app.src` and `framework/example.src` still
compile; verified `header(req, "Authorization")` round-trips over the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accessing request headers through the framework API. Headers can be queried case-insensitively, returning an empty string when not found.

* **Documentation**
  * Updated framework API documentation with comprehensive guidance on accessing request headers, including lookup behavior and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->