### PR TITLE
feat: HTTP client supports plain http:// (not just TLS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.39.0
+
+- **The HTTP client now does plain `http://`, not just TLS.** `http_get`,
+  `https_get`/`https_post`, and `http_request` previously rejected `http://` with
+  `err="scheme"`; now they connect over a plain TCP socket for `http://` URLs
+  (default port 80) and TLS for `https://` (443), sharing the same
+  request/redirect/chunked/Content-Length handling — so `http→https` redirects
+  follow transparently. Surfaced building machin-watch (an uptime monitor wants
+  to watch plain-HTTP endpoints).
+
 ## v0.38.0
 
 - **`xeddsa_sign` / `xeddsa_verify` builtins — XEdDSA (Curve25519 signatures).**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.38.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.39.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.38.0
+Version 0.39.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -304,7 +304,7 @@ throughout the function body).
 | `close` | `(int\|chan) -> ` | close a socket/fd, or a channel (dispatched by argument) |
 | `https_get` | `(string) -> string` | HTTPS GET over TLS; response body ("" on error) |
 | `https_post` | `(string, string) -> string` | HTTPS POST (JSON body) over TLS; response body |
-| `http_get` | `(string) -> (int, string, string)` | GET returning `(status, body, err)`; `err==""` ⇒ a response, else `"dns"`/`"connect"`/`"tls"`/`"scheme"`. Multi-assign only. |
+| `http_get` | `(string) -> (int, string, string)` | GET (plain `http://` or `https://`) returning `(status, body, err)`; `err==""` ⇒ a response, else `"dns"`/`"connect"`/`"tls"`. Multi-assign only. |
 | `http_request` | `(string, string, []string, string) -> (int, string, string)` | authenticated HTTPS: `(method, url, header lines, body)` → `(status, body, err)`. Each header is a `"Key: Value"` line (e.g. `"Authorization: Bearer …"`); caller owns `Content-Type`. Multi-assign only. |
 | `wss_open` | `(string) -> int` | open a `wss://` WebSocket; a connection handle, or 0 on failure |
 | `wss_send` | `(int, string) -> int` | send a text message on a WebSocket |

--- a/codegen.go
+++ b/codegen.go
@@ -1079,6 +1079,43 @@ typedef struct { int64_t status; char* body; char* err; } mfl_http_result;
 
 static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, const char* extra, int redirects);
 
+/* plain (non-TLS) transport for http:// URLs, mirroring the TLS path's staged
+   error vocabulary ("dns"/"connect"). */
+static int mfl_tcp_dial_e(const char* host, int port, const char** stage) {
+    struct addrinfo hints, *res, *rp;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC; hints.ai_socktype = SOCK_STREAM;
+    char ps[16]; snprintf(ps, sizeof(ps), "%d", port);
+    if (getaddrinfo(host, ps, &hints, &res) != 0) { if (stage) *stage = "dns"; return -1; }
+    int fd = -1;
+    for (rp = res; rp; rp = rp->ai_next) {
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) continue;
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) break;
+        close(fd); fd = -1;
+    }
+    freeaddrinfo(res);
+    if (fd < 0 && stage) *stage = "connect";
+    return fd;
+}
+static void mfl_sock_writeall(int fd, const char* buf, size_t n) {
+    size_t off = 0;
+    while (off < n) { ssize_t w = send(fd, buf + off, n - off, 0); if (w <= 0) break; off += (size_t)w; }
+}
+static char* mfl_sock_readall(int fd, size_t* outlen) {
+    size_t cap = 16384, len = 0;
+    char* buf = (char*)malloc(cap);
+    for (;;) {
+        if (len + 8192 > cap) { cap *= 2; buf = (char*)realloc(buf, cap); }
+        ssize_t n = recv(fd, buf + len, 8192, 0);
+        if (n <= 0) break;
+        len += (size_t)n;
+    }
+    buf[len] = 0;
+    *outlen = len;
+    return buf;
+}
+
 static mfl_http_result mfl_http_do(const char* method, const char* url, const char* reqbody, const char* ctype, const char* extra, int redirects) {
     mfl_http_result R;
     R.status = 0;
@@ -1086,21 +1123,18 @@ static mfl_http_result mfl_http_do(const char* method, const char* url, const ch
     R.err = mfl_dup_arena("", 0);
 
     char host[256] = {0}, path[2048] = {0};
-    int port = 443;
+    int is_https = 1;
     const char* p = url;
     if (strncmp(p, "https://", 8) == 0) p += 8;
-    else if (strncmp(p, "http://", 7) == 0) { R.err = mfl_dup_arena("scheme", 6); return R; } /* TLS only */
+    else if (strncmp(p, "http://", 7) == 0) { p += 7; is_https = 0; }
     /* else: no scheme — assume https */
+    int port = is_https ? 443 : 80;
     int i = 0;
     while (*p && *p != '/' && *p != ':' && i < 255) host[i++] = *p++;
     host[i] = 0;
     if (*p == ':') { p++; port = atoi(p); while (*p && *p != '/') p++; }
     if (*p == '/') strncpy(path, p, sizeof(path) - 1);
     else { path[0] = '/'; path[1] = 0; }
-
-    const char* stage = "connect";
-    SSL* ssl = mfl_tls_dial_e(host, port, &stage);
-    if (!ssl) { R.err = mfl_dup_arena(stage, strlen(stage)); return R; }
 
     size_t blen = reqbody ? strlen(reqbody) : 0;
     const char* ex = extra ? extra : "";   /* caller-supplied header lines (each ending \r\n) */
@@ -1125,12 +1159,23 @@ static mfl_http_result mfl_http_do(const char* method, const char* url, const ch
             "%s %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: machin/0.8\r\nAccept: */*\r\n%sConnection: close\r\n\r\n",
             method, path, host, ex);
     }
-    SSL_write(ssl, req, rl);
-    free(req);
-
     size_t rlen;
-    char* raw = mfl_tls_readall(ssl, &rlen);
-    mfl_tls_hangup(ssl);
+    char* raw;
+    const char* stage = "connect";
+    if (is_https) {
+        SSL* ssl = mfl_tls_dial_e(host, port, &stage);
+        if (!ssl) { R.err = mfl_dup_arena(stage, strlen(stage)); free(req); return R; }
+        SSL_write(ssl, req, rl);
+        raw = mfl_tls_readall(ssl, &rlen);
+        mfl_tls_hangup(ssl);
+    } else {
+        int fd = mfl_tcp_dial_e(host, port, &stage);
+        if (fd < 0) { R.err = mfl_dup_arena(stage, strlen(stage)); free(req); return R; }
+        mfl_sock_writeall(fd, req, rl);
+        raw = mfl_sock_readall(fd, &rlen);
+        close(fd);
+    }
+    free(req);
 
     int status = 0;
     { const char* sp = strchr(raw, ' '); if (sp) status = atoi(sp + 1); }

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.38.0"
+const machinVersion = "0.39.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -167,10 +167,10 @@ func machinGuide() guideCatalog {
 			{"read", "(int) -> string", "read a chunk from an fd (blocks)", "net"},
 			{"write", "(int, string) -> int", "write to an fd", "net"},
 			{"close", "(int|chan) ->", "close an fd, or a channel (by argument type)", "net"},
-			{"https_get", "(string) -> string", "HTTPS GET over TLS; body (\"\" on error)", "net"},
-			{"https_post", "(string, string) -> string", "HTTPS POST (JSON body) over TLS; body", "net"},
-			{"http_get", "(string) -> (int, string, string)", "GET -> (status, body, err); err \"\"/dns/connect/tls/scheme. MULTI-ASSIGN ONLY", "net"},
-			{"http_request", "(string, string, []string, string) -> (int, string, string)", "auth'd HTTPS: (method, url, header lines like \"Authorization: Bearer x\", body) -> (status, body, err). MULTI-ASSIGN ONLY", "net"},
+			{"https_get", "(string) -> string", "GET over TLS (or plain http:// URLs); body (\"\" on error)", "net"},
+			{"https_post", "(string, string) -> string", "POST (JSON body) over TLS (or plain http://); body", "net"},
+			{"http_get", "(string) -> (int, string, string)", "GET (http:// or https://) -> (status, body, err); err \"\"/dns/connect/tls. MULTI-ASSIGN ONLY", "net"},
+			{"http_request", "(string, string, []string, string) -> (int, string, string)", "auth'd HTTP(S): (method, url [http/https], header lines like \"Authorization: Bearer x\", body) -> (status, body, err). MULTI-ASSIGN ONLY", "net"},
 			// websocket
 			{"wss_open", "(string) -> int", "open a wss:// WebSocket -> handle (0 on fail)", "ws"},
 			{"wss_send", "(int, string) -> int", "send a text message", "ws"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -598,6 +598,25 @@ func TestHTTPRequest(t *testing.T) {
 	}
 }
 
+// The HTTP client speaks both plain http:// (a raw TCP socket) and https:// (TLS)
+// from the same path — so the generated client must contain the plain-socket
+// transport, and must NOT keep the old "scheme" rejection.
+func TestHTTPPlainAndTLS(t *testing.T) {
+	c, err := CompileToC(&Program{Funcs: parseFuncs(t, `func main() { s, b, e := http_get("http://x")  println(str(s) + b + e) }`)}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_tcp_dial_e") || !strings.Contains(c, "mfl_sock_readall") {
+		t.Fatal("the HTTP client must emit the plain-socket transport")
+	}
+	if !strings.Contains(c, "mfl_tls_dial_e") {
+		t.Fatal("the HTTP client must still emit the TLS transport")
+	}
+	if strings.Contains(c, `R.err = mfl_dup_arena("scheme"`) {
+		t.Fatal("the old http:// 'scheme' rejection must be gone")
+	}
+}
+
 // A string (or a struct's string fields) allocated in a short-lived goroutine
 // and sent over a channel must survive that goroutine's arena being reclaimed —
 // the channel deep-copies strings on send and adopts them on receive.


### PR DESCRIPTION
## What

`http_get`, `https_get`/`https_post`, and `http_request` previously rejected
`http://` URLs with `err="scheme"`. Now the shared client connects over a plain
TCP socket for `http://` (default port 80) and TLS for `https://` (443), sharing
the same request building, redirect following, chunked decoding, and
`Content-Length` handling — so `http→https` redirects just work.

## Why

Dogfood-driven: surfaced building **machin-watch** (an uptime monitor that wants
to watch plain-HTTP endpoints).

## How

`mfl_http_do` parses the scheme into a flag, picks the default port, builds the
request, then branches transport: TLS (`mfl_tls_dial_e` + `SSL_*`) or plain
(`mfl_tcp_dial_e` + `mfl_sock_writeall`/`mfl_sock_readall`, with the same
`dns`/`connect` staged errors). Everything after the response bytes is shared.

## Verified

- Live: `http://example.org`, `httpforever.com`, `duckduckgo.com` (170 KB body),
  `neverssl.com` → all `200`; `http://example.com` follows the `http→https`
  redirect to `200`; a refused port → `err="connect"`. `https://` unchanged.
- `TestHTTPPlainAndTLS` (compile-level: plain-socket transport emitted, TLS still
  emitted, old "scheme" rejection gone). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP client now supports plain `http://` URLs (defaulting to port 80) in addition to HTTPS (port 443)
  * Request, redirect, chunked transfer, and Content-Length handling unified across HTTP and HTTPS protocols
  * Transparent `http→https` redirects supported

* **Documentation**
  * Specification and release documentation updated to version 0.39.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->