### PR TITLE
feat: bitwise operators & hex/binary/octal literals (v0.40.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.40.0
+
+- **Bitwise operators + hex/binary/octal literals.** `& | ^ << >>` (and unary `^`,
+  complement), `int`-only, with Go's precedence (`<< >> &` bind like `* / %`;
+  `| ^` like `+ -`). Integer literals now accept `0xff`, `0b1010`, `0o17` (with
+  `_` separators). The whole binary/crypto/protocol surface (machin-protobuf,
+  machin-wabin, machin-signal, machin-noise) had been faking these with `* / %`
+  over powers of two — `cb >> 4 & 0x0f` instead of `(cb / 16) % 16`. Surfaced by
+  that accumulated real usage.
+
 ## v0.39.0
 
 - **The HTTP client now does plain `http://`, not just TLS.** `http_get`,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.39.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.40.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.39.0
+Version 0.40.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -75,12 +75,13 @@ The decoded text of a declaration is tokenized as follows.
 - **Comments.** `// ...` to end of line. (Stripped during encoding; not present
   in the canonical single-line form.)
 - **Identifiers.** `[A-Za-z_][A-Za-z0-9_]*`. `_` is the blank identifier.
-- **Integer literals.** decimal digits, e.g. `0`, `42`.
+- **Integer literals.** decimal (`42`), hex (`0xff`), binary (`0b1010`), or octal
+  (`0o17`); underscores allowed as separators (`0xff_00`).
 - **Float literals.** digits with a `.`, e.g. `3.14`, `0.5`.
 - **String literals.** `"..."` with escapes `\n \t \r \" \\`.
 - **Keywords.** `func return if else while for range true false nil var go type
   struct chan make map arena extern break continue select`.
-- **Operators and punctuation.** `+ - * / % == != < <= > >= && || ! = := <- .
+- **Operators and punctuation.** `+ - * / % & | ^ << >> == != < <= > >= && || ! = := <- .
   : , ; ( ) { } [ ]`.
 
 ---
@@ -174,7 +175,9 @@ throughout the function body).
 - **Composite literals:** `[]T{...}`, `T{f: v, ...}` / `T{v, ...}`.
 - **Construction:** `make(map[K]V)`, `make(chan T)`, `func(params){...}`.
 - **Operators**, by increasing precedence:
-  `||` · `&&` · `== != < <= > >=` · `+ -` · `* / %` · unary `- ! <-`.
+  `||` · `&&` · `== != < <= > >=` · `+ - | ^` · `* / % << >> &` · unary `- ! ^ <-`.
+- **Bitwise** `& | ^ << >>` (and unary `^`, complement) are **`int`-only** —
+  Go semantics and precedence (`<< >> &` bind like `* / %`; `| ^` like `+ -`).
 - **Arithmetic** `+ - * / %`: numeric operands. `/` of two `int` is integer
   division; `%` is `int`-only. Mixing an `int` with a `float` promotes to
   `float`.

--- a/codegen.go
+++ b/codegen.go
@@ -2780,7 +2780,11 @@ func (g *cgen) expr(e Expr) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return "(" + ex.Op + x + ")", nil
+		op := ex.Op
+		if op == "^" { // MFL bitwise complement -> C's ~
+			op = "~"
+		}
+		return "(" + op + x + ")", nil
 	case *Binary:
 		return g.binary(ex)
 	case *Call:

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.39.0"
+const machinVersion = "0.40.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -182,6 +182,7 @@ func machinGuide() guideCatalog {
 		Idioms: []guideIdiom{
 			{"hello", `func main() { println("hello") }`},
 			{"bytes", `func main() { b := from_hex("deadbeef")  b = bytes_concat(b, bytes("!"))  println(to_hex(b) + " len=" + str(len(b)) + " b0=" + str(byte_at(b, 0))) }`},
+			{"bitwise", `func main() { x := 0xa5  println(str(x >> 4 & 0x0f) + " " + str(x | 0x100) + " " + str(^x & 0xff)) }`},
 			{"types", `type P struct { name string  age int }
 func main() { p := P{name: "ada", age: 36}  xs := []int{1, 2, 3}  m := make(map[string]int)  m["k"] = 1  println(p.name + " " + str(len(xs)) + " " + str(m["k"])) }`},
 			{"goroutine-channel", `func work(ch) { ch <- 42 }

--- a/lexer.go
+++ b/lexer.go
@@ -74,6 +74,18 @@ func Lex(src string) ([]Token, error) {
 
 func (l *Lexer) lexNumber() {
 	start := l.pos
+	// hex (0x) / binary (0b) / octal (0o) integer literals
+	if l.src[l.pos] == '0' && l.pos+1 < len(l.src) {
+		p := l.src[l.pos+1]
+		if p == 'x' || p == 'X' || p == 'b' || p == 'B' || p == 'o' || p == 'O' {
+			l.pos += 2
+			for l.pos < len(l.src) && isAlnum(l.src[l.pos]) {
+				l.pos++
+			}
+			l.toks = append(l.toks, Token{Kind: TInt, Val: l.src[start:l.pos], Pos: start})
+			return
+		}
+	}
 	isFloat := false
 	for l.pos < len(l.src) && (isDigit(l.src[l.pos]) || l.src[l.pos] == '.') {
 		if l.src[l.pos] == '.' {
@@ -149,7 +161,7 @@ func (l *Lexer) lexOpOrPunct() error {
 		two = l.src[l.pos : l.pos+2]
 	}
 	switch two {
-	case "==", "!=", "<=", ">=", "&&", "||", ":=", "<-":
+	case "==", "!=", "<=", ">=", "&&", "||", ":=", "<-", "<<", ">>":
 		l.pos += 2
 		l.toks = append(l.toks, Token{Kind: TOp, Val: two, Pos: start})
 		return nil
@@ -159,7 +171,7 @@ func (l *Lexer) lexOpOrPunct() error {
 		l.pos++
 		l.toks = append(l.toks, Token{Kind: TPunct, Val: string(c), Pos: start})
 		return nil
-	case '+', '-', '*', '/', '%', '<', '>', '!', '=':
+	case '+', '-', '*', '/', '%', '<', '>', '!', '=', '&', '|', '^':
 		l.pos++
 		l.toks = append(l.toks, Token{Kind: TOp, Val: string(c), Pos: start})
 		return nil

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -841,6 +841,27 @@ func TestXEdDSAGating(t *testing.T) {
 	}
 }
 
+// Bitwise operators (& | ^ << >> and unary ^) plus hex/binary/octal int literals:
+// precedence matches Go (<< >> & like * / %; | ^ like + -), int-only.
+func TestBitwise(t *testing.T) {
+	main := `func main() {
+	println(str(0xff & 0x0f) + " " + str(0xf0 | 0x0f) + " " + str(0xff ^ 0x0f))
+	println(str(1 << 8) + " " + str(0xabcd >> 8) + " " + str(^0))
+	println(str(0b1010) + " " + str(0o17) + " " + str(0xa5 >> 4 & 0x0f))
+	println(str(1 | 2 << 1))
+}`
+	out, _ := buildRun(t, main)
+	want := "15 255 240\n256 171 -1\n10 15 10\n5\n"
+	if out != want {
+		t.Fatalf("bitwise: got %q, want %q", out, want)
+	}
+	// int-only: a float operand is a clean type error, not leaked cc output
+	bad := `func main() { x := 1.5  println(str(x & 2)) }`
+	if _, err := CompileToC(&Program{Funcs: parseFuncs(t, bad)}, false); err == nil {
+		t.Fatal("bitwise on a float operand should be a type error")
+	}
+}
+
 // SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
 func TestHashes(t *testing.T) {
 	main := `func main() {

--- a/parser.go
+++ b/parser.go
@@ -793,8 +793,8 @@ var precedence = map[string]int{
 	"&&": 2,
 	"==": 3, "!=": 3,
 	"<": 4, "<=": 4, ">": 4, ">=": 4,
-	"+": 5, "-": 5,
-	"*": 6, "/": 6, "%": 6,
+	"+": 5, "-": 5, "|": 5, "^": 5,
+	"*": 6, "/": 6, "%": 6, "<<": 6, ">>": 6, "&": 6,
 }
 
 func (p *Parser) parseExpr() (Expr, error) {
@@ -827,7 +827,7 @@ func (p *Parser) parseBinary(minPrec int) (Expr, error) {
 
 func (p *Parser) parseUnary() (Expr, error) {
 	t := p.peek()
-	if t.Kind == TOp && (t.Val == "-" || t.Val == "!") {
+	if t.Kind == TOp && (t.Val == "-" || t.Val == "!" || t.Val == "^") {
 		p.next()
 		x, err := p.parseUnary()
 		if err != nil {
@@ -887,7 +887,7 @@ func (p *Parser) parsePrimary() (Expr, error) {
 	switch t.Kind {
 	case TInt:
 		p.next()
-		n, err := strconv.ParseInt(t.Val, 10, 64)
+		n, err := strconv.ParseInt(t.Val, 0, 64) // base 0: decimal, 0x hex, 0b binary, 0o octal
 		if err != nil {
 			return nil, err
 		}

--- a/types.go
+++ b/types.go
@@ -1224,6 +1224,10 @@ func (c *Checker) genExprInner(fn *FuncDecl, e Expr) (int, error) {
 			c.addPair(xs, c.cBool)
 			return c.cBool, nil
 		}
+		if ex.Op == "^" {              // bitwise complement: int-only
+			c.addPair(xs, c.cInt)
+			return xs, nil
+		}
 		c.addPair(xs, newSlot(c, KNum))
 		return xs, nil
 	case *Binary:
@@ -1353,9 +1357,9 @@ func (c *Checker) genBinary(fn *FuncDecl, ex *Binary) (int, error) {
 		c.addPair(ls, rs)
 		c.addPair(ls, newSlot(c, KNum))
 		return ls, nil
-	case "%":
-		// C's % is integer-only; reject float operands at type-check time
-		// so the user gets a clean MFL error instead of leaked cc output.
+	case "%", "&", "|", "^", "<<", ">>":
+		// integer-only operators (C's %, &, |, ^, <<, >>); reject non-int operands
+		// at type-check time so the user gets a clean MFL error, not leaked cc output.
 		c.addPair(ls, rs)
 		c.addPair(ls, c.cInt)
 		return ls, nil


### PR DESCRIPTION
## What

Adds bitwise operators and non-decimal integer literals, surfaced by the binary/crypto/protocol tools (machin-protobuf, machin-wabin, machin-signal, machin-noise) that had been faking them with `* / %` over powers of two.

- **Operators:** `& | ^ << >>` and unary `^` (complement), `int`-only.
- **Precedence (Go):** `<< >> &` bind like `* / %`; `| ^` like `+ -`.
- **Literals:** `0xff`, `0b1010`, `0o17`, with `_` separators (`0xff_00`).

So `cb >> 4 & 0x0f` now reads like real binary code instead of `(cb / 16) % 16`.

## Changes

- `lexer.go` — `<< >>` two-char tokens; `& | ^` single-char; `0x`/`0b`/`0o` number prefixes.
- `parser.go` — precedence table; unary `^`; `strconv.ParseInt(.., 0, 64)` base auto-detect.
- `types.go` — int-only typing for the bitwise ops + unary complement.
- `codegen.go` — unary `^` → C `~`; binary ops pass through.
- Docs: SPEC (operators, precedence, int literals), CHANGELOG v0.40.0, a guide `bitwise` idiom.
- Version bumped to 0.40.0 (README badge, SPEC, guide.go, CHANGELOG).

## Test

`TestBitwise` (operator semantics + float-operand type error) and `TestGuide` (idiom compiles) pass; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)