### PR TITLE
feat: terminal input — raw_mode + read_key (v0.41.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.41.0
+
+- **Terminal input: `raw_mode(on)` + `read_key()`.** Real-time, per-keypress
+  terminal input. `raw_mode(1)` puts the tty in cbreak/no-echo mode (and
+  `raw_mode(0)` restores it); `read_key()` is a non-blocking single-key read —
+  a 1-char string, or `""` if nothing is waiting. `input()` was line-buffered
+  (it blocks for a whole line + Enter), which interactive TUIs and games can't
+  use. Surfaced by [machin-game-snake](https://github.com/javimosch/machin-game-snake)
+  — and it unlocks every future terminal UI (pickers, progress views, REPLs).
+
 ## v0.40.0
 
 - **Bitwise operators + hex/binary/octal literals.** `& | ^ << >>` (and unary `^`,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.40.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.41.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.40.0
+Version 0.41.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -242,6 +242,8 @@ throughout the function body).
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
 | `exit` | `(int) -> ` | terminate the process with a status code |
 | `flush` | `() -> ` | flush buffered stdout (for prompt output through a pipe) |
+| `raw_mode` | `(int) -> int` | put the terminal in cbreak/no-echo mode (`1`) or restore it (`0`); pair them and restore before exit (TUIs/games) |
+| `read_key` | `() -> string` | non-blocking single-key read: a 1-char string, or `""` if no key is waiting (needs `raw_mode` for live input) |
 | `read_file` | `(string) -> string` | read a whole file ("" on error) |
 | `write_file` | `(string, string) -> int` | write a file (bytes written; -1 on error) |
 | `list_dir` | `(string) -> []string` | directory entries (excludes `.`/`..`) |

--- a/codegen.go
+++ b/codegen.go
@@ -87,6 +87,8 @@ const cRuntime = `#define _GNU_SOURCE
 #include <dirent.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <termios.h>
+#include <sys/select.h>
 
 /* slices: a Go-style header over an unboxed backing array */
 typedef struct { void* data; int64_t len; int64_t cap; } mfl_slice;
@@ -722,6 +724,47 @@ static char* mfl_input(void) {
         buf[len++] = (char)c;
     }
     buf[len] = 0;
+    return buf;
+}
+/* terminal raw mode + non-blocking single-key read (for TUIs and games).
+   raw_mode(1) puts the tty in cbreak + no-echo with VMIN=0/VTIME=0 so reads
+   never block; raw_mode(0) restores the saved settings. */
+static struct termios mfl_tty_saved;
+static int mfl_tty_raw = 0;
+static int64_t mfl_raw_mode(int64_t on) {
+    if (on) {
+        if (mfl_tty_raw) return 0;
+        struct termios t;
+        if (tcgetattr(STDIN_FILENO, &t) != 0) return -1;
+        mfl_tty_saved = t;
+        t.c_lflag &= ~(ICANON | ECHO);
+        t.c_cc[VMIN] = 0;
+        t.c_cc[VTIME] = 0;
+        if (tcsetattr(STDIN_FILENO, TCSANOW, &t) != 0) return -1;
+        mfl_tty_raw = 1;
+    } else {
+        if (!mfl_tty_raw) return 0;
+        tcsetattr(STDIN_FILENO, TCSANOW, &mfl_tty_saved);
+        mfl_tty_raw = 0;
+    }
+    return 0;
+}
+/* non-blocking read of one key; a 1-char string, or "" if nothing is waiting.
+   In raw mode VMIN=0 already makes read() return immediately; otherwise poll
+   with select() so we never block. */
+static char* mfl_read_key(void) {
+    char* buf = mfl_alloc(2);
+    buf[0] = 0; buf[1] = 0;
+    unsigned char c = 0;
+    if (mfl_tty_raw) {
+        if (read(STDIN_FILENO, &c, 1) == 1) buf[0] = (char)c;
+    } else {
+        fd_set fds; FD_ZERO(&fds); FD_SET(STDIN_FILENO, &fds);
+        struct timeval tv; tv.tv_sec = 0; tv.tv_usec = 0;
+        if (select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv) > 0) {
+            if (read(STDIN_FILENO, &c, 1) == 1) buf[0] = (char)c;
+        }
+    }
     return buf;
 }
 /* read all of stdin verbatim until EOF (no line splitting). Exact for text;
@@ -3470,6 +3513,10 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_exit(%s)", args[0]), nil
 	case "flush":
 		return "mfl_flush()", nil
+	case "raw_mode":
+		return fmt.Sprintf("mfl_raw_mode(%s)", args[0]), nil
+	case "read_key":
+		return "mfl_read_key()", nil
 	case "base64_encode":
 		return fmt.Sprintf("mfl_base64_encode(%s)", args[0]), nil
 	case "base64_decode":

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.40.0"
+const machinVersion = "0.41.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -76,6 +76,8 @@ func machinGuide() guideCatalog {
 			{"input", "() -> string", "read one stdin line (newline stripped; \"\" at EOF)", "io"},
 			{"read_stdin", "() -> string", "read all of stdin verbatim until EOF (exact bytes; no line splitting)", "io"},
 			{"flush", "() ->", "flush buffered stdout (prompt output through a pipe)", "io"},
+			{"raw_mode", "(int) -> int", "put the terminal in cbreak/no-echo mode (1) or restore it (0); pair them and restore before exit (for TUIs/games)", "io"},
+			{"read_key", "() -> string", "non-blocking single-key read: a 1-char string, or \"\" if no key is waiting (needs raw_mode for live input)", "io"},
 			{"read_file", "(string) -> string", "read a whole file (\"\" on error)", "io"},
 			{"write_file", "(string, string) -> int", "write a file (bytes; -1 on error)", "io"},
 			{"list_dir", "(string) -> []string", "directory entries (excludes . / ..)", "io"},
@@ -183,6 +185,7 @@ func machinGuide() guideCatalog {
 			{"hello", `func main() { println("hello") }`},
 			{"bytes", `func main() { b := from_hex("deadbeef")  b = bytes_concat(b, bytes("!"))  println(to_hex(b) + " len=" + str(len(b)) + " b0=" + str(byte_at(b, 0))) }`},
 			{"bitwise", `func main() { x := 0xa5  println(str(x >> 4 & 0x0f) + " " + str(x | 0x100) + " " + str(^x & 0xff)) }`},
+			{"terminal-input", `func main() { raw_mode(1)  esc := bytes_str(from_hex("1b"))  k := read_key()  if k == "q" { print(esc + "[2J") }  raw_mode(0) }`},
 			{"types", `type P struct { name string  age int }
 func main() { p := P{name: "ada", age: 36}  xs := []int{1, 2, 3}  m := make(map[string]int)  m["k"] = 1  println(p.name + " " + str(len(xs)) + " " + str(m["k"])) }`},
 			{"goroutine-channel", `func work(ch) { ch <- 42 }

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -862,6 +862,25 @@ func TestBitwise(t *testing.T) {
 	}
 }
 
+// Terminal input builtins: raw_mode (int -> int) and read_key (-> string).
+// Interactive behavior can't be unit-tested, so this checks the type contract
+// and that the C transport helpers are emitted.
+func TestTerminalInput(t *testing.T) {
+	src := `func main() { r := raw_mode(1)  k := read_key()  if k == "q" { println("bye " + str(r)) }  raw_mode(0) }`
+	c, err := CompileToC(&Program{Funcs: parseFuncs(t, src)}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_raw_mode") || !strings.Contains(c, "mfl_read_key") {
+		t.Fatal("terminal input must emit mfl_raw_mode / mfl_read_key")
+	}
+	// raw_mode needs its on/off argument
+	bad := `func main() { raw_mode() }`
+	if _, err := CompileToC(&Program{Funcs: parseFuncs(t, bad)}, false); err == nil {
+		t.Fatal("raw_mode() with no argument should be an arity error")
+	}
+}
+
 // SHA-256 and HMAC-SHA256 against published test vectors (must be byte-exact).
 func TestHashes(t *testing.T) {
 	main := `func main() {

--- a/types.go
+++ b/types.go
@@ -1855,6 +1855,17 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("input: no args")
 		}
 		return c.cString, nil
+	case "raw_mode":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("raw_mode: 1 arg (on: 1 enable, 0 restore)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cInt, nil
+	case "read_key":
+		if len(argSlots) != 0 {
+			return 0, fmt.Errorf("read_key: no args")
+		}
+		return c.cString, nil
 	case "read_stdin":
 		if len(argSlots) != 0 {
 			return 0, fmt.Errorf("read_stdin: no args")


### PR DESCRIPTION
## What

Real-time, per-keypress terminal input — the gap surfaced by [machin-game-snake](https://github.com/javimosch/machin-game-snake). `input()` is line-buffered (it blocks for a whole line + Enter), which interactive TUIs and games can't use.

- **`raw_mode(on) -> int`** — `raw_mode(1)` puts the tty in cbreak/no-echo (`VMIN=0`/`VTIME=0`, so reads never block); `raw_mode(0)` restores the saved `termios`.
- **`read_key() -> string`** — non-blocking single-key read: a 1-char string, or `""` if nothing is waiting. In raw mode `VMIN=0` makes `read()` return immediately; outside raw mode it polls with `select()` so it still never blocks.

Unlocks every future terminal UI (pickers, progress views, REPLs), not just games.

## Changes

- `codegen.go` — `#include <termios.h>`/`<sys/select.h>`; `mfl_raw_mode`/`mfl_read_key` runtime helpers; emission cases.
- `types.go` — `raw_mode (int -> int)`, `read_key (-> string)`.
- Docs: SPEC builtins table, CHANGELOG v0.41.0, guide builtins + a `terminal-input` idiom.
- Version → 0.41.0 (README badge, SPEC, guide.go, CHANGELOG).

## Test

`TestTerminalInput` (type contract + emitted transport + arity error) and the guide tests pass; full suite green. Verified live: [machin-game-snake](https://github.com/javimosch/machin-game-snake) builds and plays on these builtins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)