### PR TITLE
fix: str() accepts bool and string (v0.42.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.42.0
+
+- **`str` accepts `bool` and `string`.** `str(true)` → `"true"`, `str(false)`
+  → `"false"`, and `str` of a string is the identity. `str` was numeric-only, so
+  `"moved=" + str(moved)` was a `bool vs num` type error — a papercut everyone
+  worked around with a hand-written `b2s` helper. Surfaced repeatedly building
+  the game logic in machin-game-snake / machin-game-2048. Non-stringable kinds
+  (slice, map, struct, …) are still a clean compile error.
+
 ## v0.41.0
 
 - **Terminal input: `raw_mode(on)` + `read_key()`.** Real-time, per-keypress

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.41.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.42.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.41.0
+Version 0.42.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -249,7 +249,7 @@ throughout the function body).
 | `list_dir` | `(string) -> []string` | directory entries (excludes `.`/`..`) |
 | `mkdir` | `(string) -> int` | create a directory (0 ok; -1 on error) |
 | `len` | `(string\|slice\|map) -> int` | length |
-| `str` | `(int\|float) -> string` | format a number |
+| `str` | `(int\|float\|bool\|string) -> string` | format a value: a number, a bool (`"true"`/`"false"`), or a string (identity) |
 | `int` | `(number) -> int` | truncate to int |
 | `append` | `([]T, T) -> []T` | grow a slice |
 | `has`, `delete` | `(map, K) -> bool` / `-> ` | membership / removal |

--- a/codegen.go
+++ b/codegen.go
@@ -342,6 +342,7 @@ static char* mfl_cat(const char* a, const char* b) {
 }
 static char* mfl_str_i(int64_t v) { char* b = mfl_alloc(24); snprintf(b, 24, "%lld", (long long)v); return b; }
 static char* mfl_str_d(double v)  { char* b = mfl_alloc(32); snprintf(b, 32, "%g", v); return b; }
+static char* mfl_str_b(int64_t v) { return v ? "true" : "false"; }
 static char* mfl_dup(const char* s) { size_t n = strlen(s); char* r = mfl_alloc(n+1); memcpy(r, s, n+1); return r; }
 /* base64 (standard alphabet, padded) over text. */
 static char* mfl_base64_encode(const char* s) {
@@ -3560,8 +3561,13 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		g.usesRegex = true
 		return fmt.Sprintf("mfl_regex_groups(%s, %s)", args[0], args[1]), nil
 	case "str":
-		if g.c.NodeKind(g.curFn, ex.Args[0]) == KFloat {
+		switch g.c.NodeKind(g.curFn, ex.Args[0]) {
+		case KFloat:
 			return fmt.Sprintf("mfl_str_d(%s)", args[0]), nil
+		case KBool:
+			return fmt.Sprintf("mfl_str_b(%s)", args[0]), nil
+		case KString:
+			return args[0], nil
 		}
 		return fmt.Sprintf("mfl_str_i(%s)", args[0]), nil
 	case "int":

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.41.0"
+const machinVersion = "0.42.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -95,7 +95,7 @@ func machinGuide() guideCatalog {
 			{"time_format_utc", "(int, string) -> string", "like time_format but in UTC (gmtime) — the form .ics / RFC-3339 stamps want", "time"},
 			{"time_make", "(int, int, int, int, int, int) -> int", "build a unix timestamp from local calendar fields (year,month,day,hour,min,sec); inverse of time_fields, normalizes overflow", "time"},
 			// convert
-			{"str", "(int|float) -> string", "format a number", "convert"},
+			{"str", "(int|float|bool|string) -> string", "format a value: number, bool (\"true\"/\"false\"), or string (identity)", "convert"},
 			{"int", "(number) -> int", "truncate to int", "convert"},
 			{"parse_int", "(string) -> int", "parse an integer (0 if non-numeric)", "convert"},
 			// collections

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -862,6 +862,26 @@ func TestBitwise(t *testing.T) {
 	}
 }
 
+// str() over each accepted kind: number, bool, and string. Bool renders as
+// "true"/"false" (the papercut fix); a non-stringable kind is a clean error.
+func TestStrKinds(t *testing.T) {
+	main := `func main() {
+	println(str(42) + " " + str(3.5))
+	println(str(true) + " " + str(false) + " " + str(10 > 3))
+	println(str("hi"))
+}`
+	out, _ := buildRun(t, main)
+	want := "42 3.5\ntrue false true\nhi\n"
+	if out != want {
+		t.Fatalf("str: got %q, want %q", out, want)
+	}
+	// a slice (or any non-number/bool/string) is still a type error
+	bad := `func main() { xs := []int{1, 2}  println(str(xs)) }`
+	if _, err := CompileToC(&Program{Funcs: parseFuncs(t, bad)}, false); err == nil {
+		t.Fatal("str of a slice should be a type error")
+	}
+}
+
 // Terminal input builtins: raw_mode (int -> int) and read_key (-> string).
 // Interactive behavior can't be unit-tested, so this checks the type contract
 // and that the C transport helpers are emitted.

--- a/types.go
+++ b/types.go
@@ -93,6 +93,7 @@ type Checker struct {
 	plus  []plusCons // overloaded '+' constraints, resolved by fixpoint
 
 	lenArgs   []int      // slots passed to len(); must resolve to string/slice/map
+	strArgs   []int      // slots passed to str(); must resolve to a number, bool, or string
 	fieldUses []fieldUse // struct field access/assign, resolved after solve
 	indexUses []indexUse // x[i] access/assign, resolved after solve (slice or map)
 	rangeUses []rangeUse // for-range loops, resolved after solve
@@ -674,6 +675,12 @@ func Check(p *Program) (*Checker, error) {
 	for _, slot := range c.lenArgs {
 		if k := c.kindOf(slot); k != KString && k != KSlice && k != KMap && k != KBytes {
 			return nil, fmt.Errorf("len: argument must be a string, slice, map, or bytes, got %s", k)
+		}
+	}
+	// 5b. validate str() arguments: a number, bool, or string.
+	for _, slot := range c.strArgs {
+		if k := c.kindOf(slot); !isNumeric(k) && k != KBool && k != KString {
+			return nil, fmt.Errorf("str: argument must be a number, bool, or string, got %s", k)
 		}
 	}
 	// 6. dedup instances by concrete signature and assign C names
@@ -1823,7 +1830,10 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("str: 1 arg")
 		}
-		c.addPair(argSlots[0], newSlot(c, KNum))
+		// str accepts a number, bool, or string; the exact emission is picked by
+		// the arg's resolved kind at codegen. Validated after solve (strArgs) so
+		// we neither force the arg numeric (which rejected bool) nor lose safety.
+		c.strArgs = append(c.strArgs, argSlots[0])
 		return c.cString, nil
 	case "int":
 		if len(argSlots) != 1 {


### PR DESCRIPTION
## What

Closes #194. `str` was numeric-only, so `str(true)` / `"moved=" + str(moved)` was a `bool vs num` type error — a papercut everyone worked around with a hand-written `b2s` helper (hit repeatedly building the game logic in machin-game-snake / machin-game-2048).

Now:
- `str(true)` → `"true"`, `str(false)` → `"false"`
- `str` of a `string` is the identity
- numbers unchanged
- non-stringable kinds (slice, map, struct, …) stay a **clean compile error**

## How

`str`'s arg is no longer force-unified to numeric (which is what rejected bool). Instead its slot is recorded in `c.strArgs` and validated after `solve()` — mirroring the existing `len()` arg check — so the arg type is whatever it resolves to, but must be number/bool/string. Codegen picks the emission by resolved kind: `mfl_str_d` (float), `mfl_str_b` (bool → `"true"/"false"`), pass-through (string), else `mfl_str_i`.

## Test

`TestStrKinds` covers number/bool/string/comparison output and that `str([]int)` is still a type error; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the `str()` builtin to accept boolean and string types in addition to its existing numeric support. Boolean values render as "true" or "false" depending on their content. String inputs remain unchanged, functioning as pass-through identity operations.

* **Documentation**
  * Updated specification, changelog, readme, and version tracking to 0.42.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->