### PR TITLE
feat: float() int->float conversion (v0.43.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.43.0
+
+- **`float()` — int → float conversion.** The counterpart to `int()`. MFL has no
+  implicit `int`→`float`: only a flexible numeric *literal* promotes against a
+  float; a *concrete* int (a function return, `byte_at`, `len`, a typed param, an
+  `int`-slice element, or an `f32`/`f64` FFI struct field) was a hard
+  `int vs float` mismatch. `float(x)` lifts it. Surfaced building the physics and
+  random-pipe placement in [machin-game-flappy](https://github.com/javimosch/machin-game-flappy),
+  where `byte_at`-derived randomness and pixel coordinates are all float.
+
 ## v0.42.0
 
 - **`str` accepts `bool` and `string`.** `str(true)` → `"true"`, `str(false)`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.42.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.43.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.42.0
+Version 0.43.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -179,8 +179,11 @@ throughout the function body).
 - **Bitwise** `& | ^ << >>` (and unary `^`, complement) are **`int`-only** —
   Go semantics and precedence (`<< >> &` bind like `* / %`; `| ^` like `+ -`).
 - **Arithmetic** `+ - * / %`: numeric operands. `/` of two `int` is integer
-  division; `%` is `int`-only. Mixing an `int` with a `float` promotes to
-  `float`.
+  division; `%` is `int`-only. A flexible numeric **literal** promotes to `float`
+  on contact (`3.0 + 2`), but a **concrete** `int` — a function return, `byte_at`,
+  `len`, a typed parameter, an `int`-slice element — does **not**; mixing it with
+  a `float` is an `int vs float` error. Convert it with `float(x)` (and `int(x)`
+  the other way). The same applies to `f32`/`f64` fields of FFI `cstruct`s.
 - **`+`** on two `string`s concatenates.
 - **Comparisons** yield `bool`; `&&`/`||` short-circuit.
 - **Indexing** `x[i]`: slice (by `int`) or map (by key); also map/slice
@@ -251,6 +254,7 @@ throughout the function body).
 | `len` | `(string\|slice\|map) -> int` | length |
 | `str` | `(int\|float\|bool\|string) -> string` | format a value: a number, a bool (`"true"`/`"false"`), or a string (identity) |
 | `int` | `(number) -> int` | truncate to int |
+| `float` | `(number) -> float` | `int` → `float` (identity on `float`); there is no implicit `int`→`float`, so a concrete `int` needs this to enter float arithmetic |
 | `append` | `([]T, T) -> []T` | grow a slice |
 | `has`, `delete` | `(map, K) -> bool` / `-> ` | membership / removal |
 | `keys` | `(map[K]V) -> []K` | a map's keys |

--- a/codegen.go
+++ b/codegen.go
@@ -3572,6 +3572,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_str_i(%s)", args[0]), nil
 	case "int":
 		return fmt.Sprintf("((int64_t)(%s))", args[0]), nil
+	case "float":
+		return fmt.Sprintf("((double)(%s))", args[0]), nil
 	case "dial":
 		return fmt.Sprintf("mfl_dial(%s, %s)", args[0], args[1]), nil
 	case "listen":

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.42.0"
+const machinVersion = "0.43.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -97,6 +97,7 @@ func machinGuide() guideCatalog {
 			// convert
 			{"str", "(int|float|bool|string) -> string", "format a value: number, bool (\"true\"/\"false\"), or string (identity)", "convert"},
 			{"int", "(number) -> int", "truncate to int", "convert"},
+			{"float", "(number) -> float", "int -> float (identity on float). MFL has no implicit int->float, so a concrete int (fn return, byte_at, len, ...) needs this to enter float math", "convert"},
 			{"parse_int", "(string) -> int", "parse an integer (0 if non-numeric)", "convert"},
 			// collections
 			{"len", "(string|slice|map) -> int", "length", "collection"},
@@ -225,6 +226,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"map-comma-ok", "There is no map comma-ok: `v, ok := m[k]` does NOT compile. A read of an absent key returns the value type's zero value; use has(m, k) to test presence. (comma-ok is for channel receives: `v, ok := <-ch`.)"},
 			{"parse-witness", "parse(s, T{}) needs a value of T as a type witness, e.g. `u := parse(body, User{})`. For schemaless extraction use json_get(s, path); json(x) serializes any value."},
 			{"multi-assign-only", "http_get and json_get return multiple values; use `a, b, c := http_get(u)`. Calling them as a single value is a compile error."},
+			{"int-float-no-implicit", "There is NO implicit int->float. Only a flexible numeric LITERAL (e.g. 5) promotes against a float; a CONCRETE int — a fn return, byte_at, len, a typed param, or an int-slice element — is a hard `int vs float` mismatch with a float. Wrap it: float(byte_at(b,0)) / 2.0. (int() goes the other way.) This also applies to f32/f64 struct fields in FFI cstructs."},
 			{"eval-order", "Operands and arguments evaluate left-to-right (as in Go), including side effects: `f() + g()` runs f() before g(). Holds for binary ops, call args, slice/struct literals, and multi-return lists."},
 			{"composite-literal", "T{...} literals need T to be a known struct type at parse time. `machin encode` registers all `type` decls first, so this just works in normal builds."},
 			{"stdout-buffering", "libc fully buffers stdout when it's a pipe; a streaming program must call flush() after a write to appear promptly downstream. A TTY is line-buffered."},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -862,6 +862,27 @@ func TestBitwise(t *testing.T) {
 	}
 }
 
+// float() lifts a concrete int into float arithmetic (the counterpart to int()).
+// MFL has no implicit int->float, so a value typed int (a function return,
+// byte_at, len, ...) can't mix with a float without this.
+func TestFloatCast(t *testing.T) {
+	main := `func main() {
+	xs := []int{7, 0, 0}
+	avg := float(xs[0]) / 2.0
+	println(str(avg) + " " + str(float(3.5)) + " " + str(int(float(9))))
+}`
+	out, _ := buildRun(t, main)
+	want := "3.5 3.5 9\n"
+	if out != want {
+		t.Fatalf("float: got %q, want %q", out, want)
+	}
+	// float() of a non-number is a type error
+	bad := `func main() { println(str(float("x"))) }`
+	if _, err := CompileToC(&Program{Funcs: parseFuncs(t, bad)}, false); err == nil {
+		t.Fatal("float of a string should be a type error")
+	}
+}
+
 // str() over each accepted kind: number, bool, and string. Bool renders as
 // "true"/"false" (the papercut fix); a non-stringable kind is a clean error.
 func TestStrKinds(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -1841,6 +1841,15 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], newSlot(c, KNum))
 		return c.cInt, nil
+	case "float":
+		// int -> float (and identity on float). The counterpart to int(): MFL
+		// has no implicit int->float, so a concrete int (a function return,
+		// byte_at, len, ...) needs this to enter float arithmetic.
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("float: 1 arg")
+		}
+		c.addPair(argSlots[0], newSlot(c, KNum))
+		return c.cFloat, nil
 	case "listen", "accept":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("%s: 1 arg", ex.Callee)


### PR DESCRIPTION
## What

Adds `float()` — the counterpart to `int()`. MFL has **no implicit `int`→`float`**: only a flexible numeric *literal* promotes against a float (`3.0 + 2`); a **concrete** int — a function return, `byte_at`, `len`, a typed parameter, an `int`-slice element, or an `f32`/`f64` FFI `cstruct` field — was a hard `int vs float` mismatch with no way out. `float(x)` lifts it into float arithmetic.

Surfaced building [machin-game-flappy](https://github.com/javimosch/machin-game-flappy): `byte_at`-derived random pipe gaps and pixel coordinates are float, but the values feeding them are concrete ints.

## Changes

- `types.go` / `codegen.go` — `float` builtin: `(number) -> float`, emits `((double)(x))`. Rejects non-numbers (like `int()`).
- Docs: SPEC builtins table + a corrected §6 promotion paragraph; guide builtin + an `int-float-no-implicit` gotcha; CHANGELOG v0.43.0.
- Version → 0.43.0.

## Test

`TestFloatCast` (concrete-int→float in float math, identity on float, `int(float(...))` round-trip, string rejected); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)