### PR TITLE
feat: FFI opaque handles — cstruct Name {} (v0.44.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.44.0
+
+- **FFI opaque handles — `cstruct Name {}`.** An empty-body `cstruct` declares a
+  by-value C type (from the `header`) that machin holds and passes back **without
+  naming its fields**. This is for by-value structs that contain pointers and so
+  can't be a numeric `cstruct` — e.g. raylib's `Sound`/`Music`/`Font`. MFL can
+  receive one from a `fn`, store it (a variable or `[]Name`), and pass it to
+  another `fn`; it can't construct or field-access it. machin wraps the real C
+  struct in one hidden field and copies it whole at the boundary, so the existing
+  by-value marshaling path carries it. Surfaced building
+  [machin-game-simon](https://github.com/javimosch/machin-game-simon), whose audio
+  needs `LoadSound`→`PlaySound` over raylib's pointer-bearing `Sound`. Unlocks
+  every "load a handle, pass it back" C library, not just audio.
+
 ## v0.43.0
 
 - **`float()` — int → float conversion.** The counterpart to `int()`. MFL has no

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.43.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.44.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.43.0
+Version 0.44.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -502,9 +502,17 @@ extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) 
   machin synthesizes a matching MFL struct `Name` (so MFL can construct and
   field-access it) and marshals between the MFL value and the C struct by value
   at the boundary. Field types are sized C scalars (below).
+- `cstruct Name {}` — an **opaque handle** (Phase 3): an empty body declares a
+  by-value C type (from the `header`) that machin holds and passes back **without
+  naming its fields**. This is for by-value structs that contain pointers and so
+  can't be a numeric `cstruct` — e.g. raylib's `Sound`/`Music`/`Font`. MFL can
+  receive one from a `fn`, store it (in a variable or `[]Name`), and pass it to
+  another `fn`; it cannot construct or field-access it. (Distinct from `ptr`,
+  which is a single pointer held as an `int`; an opaque `cstruct` is the whole
+  by-value aggregate.)
 - `fn Name(t, ...) ret` — a foreign function. Parameter and return types are FFI
-  scalar types, or the name of a declared `cstruct`; a missing return type means
-  `void`.
+  scalar types, or the name of a declared `cstruct` (numeric or opaque); a
+  missing return type means `void`.
 
 **FFI scalar types** → C: `int`/`i64`→`int64_t`, `i32`→`int32_t`, `i16`→`int16_t`,
 `i8`→`int8_t`, `u64`→`uint64_t` … `u8`→`uint8_t`, `float`/`f64`→`double`,

--- a/ast.go
+++ b/ast.go
@@ -30,6 +30,11 @@ type ExternDecl struct {
 type ExternStruct struct {
 	Name   string
 	Fields []ExternField
+	// Opaque marks a handle type declared with an empty body (`cstruct Sound {}`):
+	// machin holds the real C struct (from the header) by value without naming its
+	// fields, so by-value APIs whose structs contain pointers (raylib Sound/Music,
+	// …) can be loaded, stored, and passed back. No MFL field access/construction.
+	Opaque bool
 }
 
 // ExternField is one C struct field with a sized C scalar type (i8..u64, f32, f64).
@@ -57,9 +62,12 @@ type Field struct {
 }
 
 // TypeDecl is a struct type declaration: type Name struct { ... }.
+// COpaque, when non-empty, names a C type to wrap by value in one hidden field
+// (an opaque FFI handle synthesized from `cstruct Name {}`); Fields is then empty.
 type TypeDecl struct {
-	Name   string
-	Fields []Field
+	Name    string
+	Fields  []Field
+	COpaque string
 }
 
 func (TypeDecl) node() {}

--- a/codegen.go
+++ b/codegen.go
@@ -2089,6 +2089,11 @@ func (g *cgen) program(p *Program) (string, error) {
 	}
 	// struct typedefs, in declaration order (a struct may reference earlier ones)
 	for _, td := range p.Types {
+		if td.COpaque != "" {
+			// an opaque FFI handle: wrap the real C type by value in one hidden field
+			fmt.Fprintf(&out, "typedef struct { %s _c; } mfl_%s;\n", td.COpaque, td.Name)
+			continue
+		}
 		fmt.Fprintf(&out, "typedef struct {")
 		for _, f := range td.Fields {
 			fmt.Fprintf(&out, " %s f_%s;", cTypeName(f.Type), f.Name)
@@ -2099,6 +2104,12 @@ func (g *cgen) program(p *Program) (string, error) {
 	// with int64/double fields) and the C layout (Name) at the boundary.
 	for _, ed := range p.Externs {
 		for _, cs := range ed.Structs {
+			if cs.Opaque {
+				// copy the whole C struct in/out of the one-field MFL wrapper
+				fmt.Fprintf(&out, "static mfl_%s mfl_from_%s(%s c) { return (mfl_%s){ ._c = c }; }\n", cs.Name, cs.Name, cs.Name, cs.Name)
+				fmt.Fprintf(&out, "static %s mfl_to_%s(mfl_%s m) { return m._c; }\n", cs.Name, cs.Name, cs.Name)
+				continue
+			}
 			fmt.Fprintf(&out, "static mfl_%s mfl_from_%s(%s c) { return (mfl_%s){", cs.Name, cs.Name, cs.Name, cs.Name)
 			for _, f := range cs.Fields {
 				fmt.Fprintf(&out, " .f_%s = c.%s,", f.Name, f.Name)

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.43.0"
+const machinVersion = "0.44.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -227,6 +227,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"parse-witness", "parse(s, T{}) needs a value of T as a type witness, e.g. `u := parse(body, User{})`. For schemaless extraction use json_get(s, path); json(x) serializes any value."},
 			{"multi-assign-only", "http_get and json_get return multiple values; use `a, b, c := http_get(u)`. Calling them as a single value is a compile error."},
 			{"int-float-no-implicit", "There is NO implicit int->float. Only a flexible numeric LITERAL (e.g. 5) promotes against a float; a CONCRETE int — a fn return, byte_at, len, a typed param, or an int-slice element — is a hard `int vs float` mismatch with a float. Wrap it: float(byte_at(b,0)) / 2.0. (int() goes the other way.) This also applies to f32/f64 struct fields in FFI cstructs."},
+			{"ffi-opaque-handle", "For a by-value C struct that contains pointers (raylib Sound/Music/Font/Texture with internals, FILE wrappers, ...), declare an OPAQUE cstruct with an empty body: `cstruct Sound {}`. machin holds the real C struct by value and passes it back to fns without naming its fields — receive it from a fn, store it (incl. []Sound), pass it on; no construct or .field. (A single pointer is simpler: the `ptr` FFI type, held as an int.)"},
 			{"eval-order", "Operands and arguments evaluate left-to-right (as in Go), including side effects: `f() + g()` runs f() before g(). Holds for binary ops, call args, slice/struct literals, and multi-return lists."},
 			{"composite-literal", "T{...} literals need T to be a known struct type at parse time. `machin encode` registers all `type` decls first, so this just works in normal builds."},
 			{"stdout-buffering", "libc fully buffers stdout when it's a pipe; a streaming program must call flush() after a write to appear promptly downstream. A TTY is line-buffered."},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -862,6 +862,35 @@ func TestBitwise(t *testing.T) {
 	}
 }
 
+// Opaque FFI handles: `cstruct Name {}` (empty body) wraps a by-value C struct
+// machin can hold and pass back without naming its fields — for APIs whose
+// structs contain pointers (raylib Sound/Music, ...). Codegen-level (no link).
+func TestOpaqueHandle(t *testing.T) {
+	src := []string{
+		`extern "audio" { header "audio.h" cstruct Sound {} fn LoadSound(string) Sound fn PlaySound(Sound) }`,
+		`func main() { s := LoadSound("a.wav")  PlaySound(s) }`,
+	}
+	prog, err := ParseProgram(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// the MFL wrapper holds the real C type by value in one hidden field...
+	if !strings.Contains(c, "typedef struct { Sound _c; } mfl_Sound;") {
+		t.Fatal("opaque handle must wrap the real C type in mfl_Sound._c")
+	}
+	// ...and marshaling copies the whole struct in/out, not field-by-field
+	if !strings.Contains(c, "mfl_to_Sound(mfl_Sound m) { return m._c; }") {
+		t.Fatal("opaque handle marshaling must copy the whole C struct")
+	}
+	if !strings.Contains(c, "mfl_from_Sound") {
+		t.Fatal("opaque handle must marshal the FFI return back to MFL")
+	}
+}
+
 // float() lifts a concrete int into float arithmetic (the counterpart to int()).
 // MFL has no implicit int->float, so a value typed int (a function return,
 // byte_at, len, ...) can't mix with a float without this.

--- a/parser.go
+++ b/parser.go
@@ -82,6 +82,13 @@ func ParseProgram(decls []string) (*Program, error) {
 	// its TypeDecl so MFL code can construct and field-access it.
 	for _, ed := range prog.Externs {
 		for _, cs := range ed.Structs {
+			if cs.Opaque {
+				// an opaque handle: wrap the real C type (from the header) by value;
+				// no MFL fields to construct or access.
+				prog.Types = append(prog.Types, &TypeDecl{Name: cs.Name, COpaque: cs.Name})
+				structs[cs.Name] = true
+				continue
+			}
 			fields := make([]Field, len(cs.Fields))
 			for i, f := range cs.Fields {
 				fields[i] = Field{Name: f.Name, Type: ffiMFLType(f.CType)}
@@ -189,7 +196,7 @@ func (p *Parser) parseExternDecl() (*ExternDecl, error) {
 			if _, err := p.expect(TPunct, "}"); err != nil {
 				return nil, err
 			}
-			ed.Structs = append(ed.Structs, ExternStruct{Name: name.Val, Fields: fields})
+			ed.Structs = append(ed.Structs, ExternStruct{Name: name.Val, Fields: fields, Opaque: len(fields) == 0})
 		case "fn":
 			name, err := p.expect(TIdent, "")
 			if err != nil {


### PR DESCRIPTION
## What

Adds **opaque FFI handles**: an empty-body `cstruct Name {}` declares a by-value C type (from the `header`) that machin holds and passes back **without naming its fields**.

This is for by-value structs that **contain pointers** and so can't be a numeric `cstruct` — e.g. raylib's `Sound`/`Music`/`Font`. MFL can receive one from a `fn`, store it (a variable or `[]Name`), and pass it to another `fn`; it cannot construct or field-access it.

```
extern "raylib" { header "raylib.h" link "raylib" ...
  cstruct Sound {}                 // opaque: Sound has pointers inside
  fn LoadSound(string) Sound
  fn PlaySound(Sound)
}
func main() { s := LoadSound("a.wav")  PlaySound(s) }   // round-trips by value
```

## How

`cstruct Name {}` synthesizes a TypeDecl with `COpaque = Name`. Codegen emits `typedef struct { Name _c; } mfl_Name;` (wrapping the real C type in one hidden field) and `mfl_from_Name`/`mfl_to_Name` that copy the whole struct. The existing generic FFI marshaling path (`mfl_to_<N>` on args, `mfl_from_<N>` on returns) then carries it unchanged — no per-type call-site work.

Distinct from `ptr` (a single pointer held as an `int`); an opaque `cstruct` is the whole by-value aggregate.

## Changes

- `ast.go` — `ExternStruct.Opaque`, `TypeDecl.COpaque`.
- `parser.go` — empty cstruct body ⇒ opaque; synthesize the wrapping TypeDecl.
- `codegen.go` — opaque `mfl_` typedef + whole-struct marshaling.
- Docs: SPEC §15, a guide `ffi-opaque-handle` gotcha, CHANGELOG v0.44.0.

## Test

`TestOpaqueHandle` (codegen-level: wrapper typedef + whole-struct marshaling + return marshaling); full suite green. Verified live: [machin-game-simon](https://github.com/javimosch/machin-game-simon) loads 5 sounds and plays them through raylib over these handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)