### PR TITLE
docs: AGENTS.md — verify machin is current before relying on the guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,25 @@ language). Humans state intent; the machine reads and writes the code.
 > the compiler's own source-of-truth catalog (so it never drifts). This file is
 > about *contributing to the toolchain*; `machin guide` is about *writing MFL*.
 
+> **First, make sure your `machin` is current.** The guide catalog is compiled
+> *into* the binary, so a stale binary advertises a stale feature set — an agent
+> running an old `machin` won't see recently added builtins and may wrongly
+> conclude a capability is missing (this is what produced #196: `http_get`/`parse`
+> already existed, but an out-of-date binary didn't surface them). `make install`
+> copies the build to `$PREFIX/bin`, but nothing rebuilds it after a `git pull`,
+> so the `machin` on your `PATH` can silently lag the source. Before relying on
+> the language surface, rebuild and verify the versions agree:
+>
+> ```sh
+> make install      # or: go build -o "$(command -v machin)" .
+> test "$(machin guide | sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' | head -1)" \
+>      = "$(sed -n 's/.*machinVersion = "\([^"]*\)".*/\1/p' guide.go)" \
+>      && echo "machin is current" || echo "STALE: rebuild/install machin"
+> ```
+>
+> (Also delete any stray `./machin` build artifact in the repo — it is gitignored
+> and easy to run by accident.)
+
 ## Current direction: dogfood
 
 The POC goal is met; machin is now grown by **building real things** and letting


### PR DESCRIPTION
## Why

Diagnosing why the agent that filed #196 didn't discover `http_get`/`parse` (which already existed): **the local `machin` binary was stale.**

The `machin guide` catalog is **compiled into the binary** (`guide.go`, version-stamped, `guide_test.go` enforces catalog == compiler features). So there is no separate "embedded skill" that can drift on its own — a stale catalog means a stale *binary*. And nothing rebuilds `~/.local/bin/machin` after a `git pull` (`make install` is manual), so the `machin` on `PATH` can silently lag source. An agent on an old binary literally gets `unknown command "guide"` (pre-#139) or an old `http_get` signature, and wrongly concludes the capability is missing.

## Change

Adds a short "make sure your `machin` is current" callout to `AGENTS.md`: rebuild/install, then a one-liner that checks `machin guide`'s version against `machinVersion` in `guide.go`, plus a note to delete any stray gitignored `./machin` build artifact (one was sitting in the tree, dated before the guide command existed).

Docs-only; no code/version change. The version-match snippet is tested to pass on a current build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)