### PR TITLE
feat: FFI nested cstructs (v0.45.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.45.0
+
+- **FFI nested cstructs.** A `cstruct` field may now be another declared
+  `cstruct`, not just a numeric scalar — a by-value struct of by-value structs.
+  The synthesized MFL struct nests the inner `mfl_` type and the boundary
+  marshaling recurses (`mfl_from_`/`mfl_to_` per field). This unblocks **3D**:
+  raylib's `Camera3D` is three `Vector3`s + scalars, so it couldn't be expressed
+  before; now `Camera3D{Vector3{...}, Vector3{...}, Vector3{...}, 45.0, 0}`
+  constructs and passes by value to `BeginMode3D`. Surfaced building
+  [machin-demo-3d](https://github.com/javimosch/machin-demo-3d). (Also unlocks 2D
+  cameras and any struct-of-structs C API.) Note the orbit math there still goes
+  through libm via `extern "m"` — machin has no native `sin`/`cos`/`sqrt` yet,
+  the next gap.
+
 ## v0.44.0
 
 - **FFI opaque handles — `cstruct Name {}`.** An empty-body `cstruct` declares a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.44.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.45.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.44.0
+Version 0.45.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -501,7 +501,10 @@ extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) 
 - `cstruct Name { field ctype ... }` — declares a C struct's layout (Phase 2).
   machin synthesizes a matching MFL struct `Name` (so MFL can construct and
   field-access it) and marshals between the MFL value and the C struct by value
-  at the boundary. Field types are sized C scalars (below).
+  at the boundary. Field types are sized C scalars (below) **or another declared
+  `cstruct`** — nested by-value structs marshal recursively, so e.g. raylib's
+  `Camera3D` (three `Vector3`s + scalars) is expressible and constructible
+  (`Camera3D{Vector3{...}, ...}`).
 - `cstruct Name {}` — an **opaque handle** (Phase 3): an empty body declares a
   by-value C type (from the `header`) that machin holds and passes back **without
   naming its fields**. This is for by-value structs that contain pointers and so

--- a/codegen.go
+++ b/codegen.go
@@ -2101,7 +2101,14 @@ func (g *cgen) program(p *Program) (string, error) {
 		fmt.Fprintf(&out, " } mfl_%s;\n", td.Name)
 	}
 	// FFI struct marshaling: convert each cstruct between its MFL value (mfl_Name,
-	// with int64/double fields) and the C layout (Name) at the boundary.
+	// with int64/double/nested mfl_ fields) and the C layout (Name) at the
+	// boundary. A nested cstruct field recurses through its own mfl_from_/mfl_to_.
+	cstructNames := map[string]bool{}
+	for _, ed := range p.Externs {
+		for _, cs := range ed.Structs {
+			cstructNames[cs.Name] = true
+		}
+	}
 	for _, ed := range p.Externs {
 		for _, cs := range ed.Structs {
 			if cs.Opaque {
@@ -2112,12 +2119,20 @@ func (g *cgen) program(p *Program) (string, error) {
 			}
 			fmt.Fprintf(&out, "static mfl_%s mfl_from_%s(%s c) { return (mfl_%s){", cs.Name, cs.Name, cs.Name, cs.Name)
 			for _, f := range cs.Fields {
-				fmt.Fprintf(&out, " .f_%s = c.%s,", f.Name, f.Name)
+				if cstructNames[f.CType] {
+					fmt.Fprintf(&out, " .f_%s = mfl_from_%s(c.%s),", f.Name, f.CType, f.Name)
+				} else {
+					fmt.Fprintf(&out, " .f_%s = c.%s,", f.Name, f.Name)
+				}
 			}
 			out.WriteString(" }; }\n")
 			fmt.Fprintf(&out, "static %s mfl_to_%s(mfl_%s m) { return (%s){", cs.Name, cs.Name, cs.Name, cs.Name)
 			for _, f := range cs.Fields {
-				fmt.Fprintf(&out, " .%s = (%s)m.f_%s,", f.Name, ffiCType(f.CType), f.Name)
+				if cstructNames[f.CType] {
+					fmt.Fprintf(&out, " .%s = mfl_to_%s(m.f_%s),", f.Name, f.CType, f.Name)
+				} else {
+					fmt.Fprintf(&out, " .%s = (%s)m.f_%s,", f.Name, ffiCType(f.CType), f.Name)
+				}
 			}
 			out.WriteString(" }; }\n")
 		}

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.44.0"
+const machinVersion = "0.45.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -228,6 +228,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"multi-assign-only", "http_get and json_get return multiple values; use `a, b, c := http_get(u)`. Calling them as a single value is a compile error."},
 			{"int-float-no-implicit", "There is NO implicit int->float. Only a flexible numeric LITERAL (e.g. 5) promotes against a float; a CONCRETE int — a fn return, byte_at, len, a typed param, or an int-slice element — is a hard `int vs float` mismatch with a float. Wrap it: float(byte_at(b,0)) / 2.0. (int() goes the other way.) This also applies to f32/f64 struct fields in FFI cstructs."},
 			{"ffi-opaque-handle", "For a by-value C struct that contains pointers (raylib Sound/Music/Font/Texture with internals, FILE wrappers, ...), declare an OPAQUE cstruct with an empty body: `cstruct Sound {}`. machin holds the real C struct by value and passes it back to fns without naming its fields — receive it from a fn, store it (incl. []Sound), pass it on; no construct or .field. (A single pointer is simpler: the `ptr` FFI type, held as an int.)"},
+			{"ffi-nested-cstruct", "A cstruct field may be ANOTHER cstruct (by-value struct of structs) — declare the inner one first. e.g. `cstruct Vector3 { x f32 y f32 z f32 }` then `cstruct Camera3D { position Vector3 target Vector3 up Vector3 fovy f32 projection i32 }`; construct with nested literals `Camera3D{Vector3{0,10,10}, Vector3{0,0,0}, Vector3{0,1,0}, 45.0, 0}`. Required for 3D (BeginMode3D) and 2D cameras. (No native sin/cos/sqrt yet — reach libm via `extern \"m\" { header \"math.h\" link \"m\" fn sin(float) float ... }`.)"},
 			{"eval-order", "Operands and arguments evaluate left-to-right (as in Go), including side effects: `f() + g()` runs f() before g(). Holds for binary ops, call args, slice/struct literals, and multi-return lists."},
 			{"composite-literal", "T{...} literals need T to be a known struct type at parse time. `machin encode` registers all `type` decls first, so this just works in normal builds."},
 			{"stdout-buffering", "libc fully buffers stdout when it's a pipe; a streaming program must call flush() after a write to appear promptly downstream. A TTY is line-buffered."},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -891,6 +891,30 @@ func TestOpaqueHandle(t *testing.T) {
 	}
 }
 
+// Nested cstructs: a cstruct field whose type is another cstruct (by-value
+// struct of by-value structs — e.g. raylib Camera3D holds Vector3s). The MFL
+// wrapper nests the inner mfl_ type and marshaling recurses. Codegen-level.
+func TestNestedCStruct(t *testing.T) {
+	src := []string{
+		`extern "g" { header "g.h" cstruct V3 { x f32 y f32 z f32 } cstruct Cam { pos V3 fovy f32 } fn Begin(Cam) }`,
+		`func main() { c := Cam{V3{1.0, 2.0, 3.0}, 45.0}  Begin(c) }`,
+	}
+	prog, err := ParseProgram(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_V3 f_pos;") {
+		t.Fatal("nested cstruct field must be the inner mfl_ type")
+	}
+	if !strings.Contains(c, "mfl_from_V3(c.pos)") || !strings.Contains(c, "mfl_to_V3(m.f_pos)") {
+		t.Fatal("nested cstruct field must marshal recursively")
+	}
+}
+
 // float() lifts a concrete int into float arithmetic (the counterpart to int()).
 // MFL has no implicit int->float, so a value typed int (a function return,
 // byte_at, len, ...) can't mix with a float without this.

--- a/parser.go
+++ b/parser.go
@@ -80,6 +80,12 @@ func ParseProgram(decls []string) (*Program, error) {
 	}
 	// a cstruct is also a first-class MFL struct (int/float fields); synthesize
 	// its TypeDecl so MFL code can construct and field-access it.
+	cstructNames := map[string]bool{}
+	for _, ed := range prog.Externs {
+		for _, cs := range ed.Structs {
+			cstructNames[cs.Name] = true
+		}
+	}
 	for _, ed := range prog.Externs {
 		for _, cs := range ed.Structs {
 			if cs.Opaque {
@@ -91,7 +97,12 @@ func ParseProgram(decls []string) (*Program, error) {
 			}
 			fields := make([]Field, len(cs.Fields))
 			for i, f := range cs.Fields {
-				fields[i] = Field{Name: f.Name, Type: ffiMFLType(f.CType)}
+				// a cstruct field may be another cstruct (nested by-value struct)
+				if cstructNames[f.CType] {
+					fields[i] = Field{Name: f.Name, Type: f.CType}
+				} else {
+					fields[i] = Field{Name: f.Name, Type: ffiMFLType(f.CType)}
+				}
 			}
 			prog.Types = append(prog.Types, &TypeDecl{Name: cs.Name, Fields: fields})
 			structs[cs.Name] = true

--- a/types.go
+++ b/types.go
@@ -623,11 +623,19 @@ func Check(p *Program) (*Checker, error) {
 		_, ok := c.structs[t]
 		return ok
 	}
+	// the set of all declared cstruct names, so a cstruct field may be another
+	// cstruct (nested by-value structs — e.g. raylib Camera3D holds Vector3s)
+	cstructNames := map[string]bool{}
+	for _, ed := range p.Externs {
+		for _, cs := range ed.Structs {
+			cstructNames[cs.Name] = true
+		}
+	}
 	for _, ed := range p.Externs {
 		for _, cs := range ed.Structs {
 			for _, f := range cs.Fields {
-				if !isFFINumeric(f.CType) {
-					return nil, fmt.Errorf("cstruct %s field %s: %q is not a numeric C type", cs.Name, f.Name, f.CType)
+				if !isFFINumeric(f.CType) && !cstructNames[f.CType] {
+					return nil, fmt.Errorf("cstruct %s field %s: %q is not a numeric C type or a declared cstruct", cs.Name, f.Name, f.CType)
 				}
 			}
 		}


### PR DESCRIPTION
## What

A `cstruct` field may now be **another declared `cstruct`** — a by-value struct of by-value structs, not just numeric scalars.

This unblocks **3D**: raylib's `Camera3D` is three `Vector3`s + scalars, so it couldn't be expressed before. Now:

```
cstruct Vector3 { x f32 y f32 z f32 }
cstruct Camera3D { position Vector3 target Vector3 up Vector3 fovy f32 projection i32 }
fn BeginMode3D(Camera3D)
...
cam := Camera3D{Vector3{12.0,7.0,0.0}, Vector3{0.0,1.5,0.0}, Vector3{0.0,1.0,0.0}, 45.0, 0}
BeginMode3D(cam)
```

(Also unlocks 2D cameras and any struct-of-structs C API.)

## How

`cstruct` field validation now accepts a declared cstruct name (not only numeric scalars). The synthesized MFL struct gets a field of the inner `mfl_<T>` type (via `cTypeName`, which already maps struct names), and the boundary marshaling recurses: `mfl_from_<Outer>` calls `mfl_from_<Inner>(c.field)` and `mfl_to_<Outer>` calls `mfl_to_<Inner>(m.f_field)`. Declare the inner struct first so its marshalers are emitted first.

## Changes

- `types.go` — field validation accepts nested cstruct names.
- `parser.go` — synth maps a cstruct-typed field to the struct type.
- `codegen.go` — recursive marshaling for nested-struct fields.
- Docs: SPEC §15, a guide `ffi-nested-cstruct` gotcha, CHANGELOG v0.45.0.

## Test

`TestNestedCStruct` (nested `mfl_` field + recursive marshal in the generated C); full suite green. Verified live: [machin-demo-3d](https://github.com/javimosch/machin-demo-3d) renders an orbiting-camera 3D scene through `Camera3D`.

Note: the demo's orbit math goes through libm via `extern "m"` — machin still has no native `sin`/`cos`/`sqrt`, the next gap (a procedural-animation app would drive it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.45.0

* **New Features**
  * FFI `cstruct` fields can now contain nested `cstruct` types (struct-of-structs), rather than only numeric scalars. Generated code recursively marshals nested structures, enabling use cases like 3D camera support.

* **Documentation**
  * Updated language specification to describe nested `cstruct` marshaling behavior.
  * Enhanced toolchain guide with nested struct examples and declaration ordering guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->