### PR TITLE
feat: native math builtins (v0.46.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.46.0
+
+- **Native math builtins.** A floating-point math suite over libm:
+  `sin cos tan asin acos atan atan2 sqrt cbrt pow exp log log2 log10 floor ceil
+  round trunc abs fmod hypot` and `pi()`. Numeric in, `float` out; libm is linked
+  (`-lm`) and the runtime emitted **only when a math builtin is used**, so
+  math-free programs keep their libc-only footprint. An `extern` declaration of
+  the same name still shadows the builtin (so existing `extern "m" { fn sqrt ... }`
+  code is unchanged). Surfaced by [machin-demo-3d](https://github.com/javimosch/machin-demo-3d),
+  which had to reach libm via `extern "m"` for its camera orbit — now `sin`/`cos`
+  are native. The driver for procedural-animation apps.
+
 ## v0.45.0
 
 - **FFI nested cstructs.** A `cstruct` field may now be another declared

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.45.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.46.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.45.0
+Version 0.46.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -255,6 +255,7 @@ throughout the function body).
 | `str` | `(int\|float\|bool\|string) -> string` | format a value: a number, a bool (`"true"`/`"false"`), or a string (identity) |
 | `int` | `(number) -> int` | truncate to int |
 | `float` | `(number) -> float` | `int` → `float` (identity on `float`); there is no implicit `int`→`float`, so a concrete `int` needs this to enter float arithmetic |
+| math | `(number[, number]) -> float` | native libm (linked `-lm` only when used): `sin` `cos` `tan` `asin` `acos` `atan` `atan2` `sqrt` `cbrt` `pow` `exp` `log` `log2` `log10` `floor` `ceil` `round` `trunc` `abs` `fmod` `hypot`, and `pi()`. Numeric in, `float` out. An `extern` of the same name shadows the builtin. |
 | `append` | `([]T, T) -> []T` | grow a slice |
 | `has`, `delete` | `(map, K) -> bool` / `-> ` | membership / removal |
 | `keys` | `(map[K]V) -> []K` | a map's keys |

--- a/build.go
+++ b/build.go
@@ -54,6 +54,10 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 	if strings.Contains(csrc, "mfl_sqlite_") {
 		libs = append(libs, "-lsqlite3")
 	}
+	// native math (sin/cos/sqrt/...) links libm — only when a math builtin is used.
+	if strings.Contains(csrc, "mfl_math_") {
+		libs = append(libs, "-lm")
+	}
 	// crypto builtins (rand/sha/hmac/hkdf/x25519/ed25519/aes) link OpenSSL
 	// libcrypto — only when used. Harmless if -lcrypto is already added for TLS.
 	if strings.Contains(csrc, "mfl_crypto_") {

--- a/codegen.go
+++ b/codegen.go
@@ -67,6 +67,7 @@ type cgen struct {
 	usesSQLite bool  // program calls sqlite_* -> emit SQLite runtime + link -lsqlite3
 	usesCrypto bool  // program calls crypto builtins -> emit crypto runtime + link -lcrypto
 	usesXEdDSA bool  // program calls xeddsa_* -> emit XEdDSA runtime + link -lsodium -lcrypto
+	usesMath  bool   // program calls math builtins (sin/cos/sqrt/...) -> emit math runtime + link -lm
 }
 
 const cRuntime = `#define _GNU_SOURCE
@@ -1485,6 +1486,35 @@ static int64_t mfl_wss_close(int64_t h) {
 }
 `
 
+// mathRuntime is the native floating-point math suite over libm's <math.h>,
+// emitted (and linked -lm) only when a program calls a math builtin. Each is a
+// thin wrapper named mfl_math_<libm-name> on a double; machin's float is double,
+// so signatures line up exactly. _GNU_SOURCE (set in cRuntime) exposes M_PI.
+const mathRuntime = `#include <math.h>
+static double mfl_math_sin(double x){return sin(x);}
+static double mfl_math_cos(double x){return cos(x);}
+static double mfl_math_tan(double x){return tan(x);}
+static double mfl_math_asin(double x){return asin(x);}
+static double mfl_math_acos(double x){return acos(x);}
+static double mfl_math_atan(double x){return atan(x);}
+static double mfl_math_exp(double x){return exp(x);}
+static double mfl_math_log(double x){return log(x);}
+static double mfl_math_log2(double x){return log2(x);}
+static double mfl_math_log10(double x){return log10(x);}
+static double mfl_math_sqrt(double x){return sqrt(x);}
+static double mfl_math_cbrt(double x){return cbrt(x);}
+static double mfl_math_floor(double x){return floor(x);}
+static double mfl_math_ceil(double x){return ceil(x);}
+static double mfl_math_round(double x){return round(x);}
+static double mfl_math_trunc(double x){return trunc(x);}
+static double mfl_math_fabs(double x){return fabs(x);}
+static double mfl_math_pow(double a,double b){return pow(a,b);}
+static double mfl_math_atan2(double a,double b){return atan2(a,b);}
+static double mfl_math_fmod(double a,double b){return fmod(a,b);}
+static double mfl_math_hypot(double a,double b){return hypot(a,b);}
+static double mfl_math_pi(void){return M_PI;}
+`
+
 // regexRuntime is POSIX extended-regex (ERE) support via libc's <regex.h>,
 // emitted only when a program calls regex_*. match/find/groups/replace operate
 // on the subject first (like the other string builtins). A bad pattern fails
@@ -2034,6 +2064,12 @@ func (g *cgen) program(p *Program) (string, error) {
 	}
 	if g.usesWSS {
 		out.WriteString(wssRuntime)
+		out.WriteByte('\n')
+	}
+	if g.usesMath {
+		// native math (libm) — emitted and linked (-lm) only when a program calls a
+		// math builtin, so math-free programs keep machin's libc-only footprint.
+		out.WriteString(mathRuntime)
 		out.WriteByte('\n')
 	}
 	if g.usesRegex {
@@ -3414,6 +3450,30 @@ func (g *cgen) call(ex *Call) (string, error) {
 }
 
 func (g *cgen) callBody(ex *Call, args []string) (string, error) {
+	// An explicit extern declaration shadows a builtin of the same name (matches
+	// the type-checker), so a declared `fn sqrt(float) float` is called, not the
+	// math builtin.
+	if ef := g.c.ExternFn(ex.Callee); ef != nil {
+		parts := make([]string, len(args))
+		for i, a := range args {
+			switch pt := ef.Params[i]; {
+			case pt == "ptr": // MFL int -> opaque void*
+				parts[i] = fmt.Sprintf("(void*)(intptr_t)(%s)", a)
+			case isFFIScalar(pt):
+				parts[i] = fmt.Sprintf("(%s)(%s)", ffiCType(pt), a)
+			default: // a cstruct, marshaled into the C layout
+				parts[i] = fmt.Sprintf("mfl_to_%s(%s)", pt, a)
+			}
+		}
+		call := fmt.Sprintf("%s(%s)", ef.Name, strings.Join(parts, ", "))
+		switch {
+		case ef.Ret == "ptr": // void* -> MFL int
+			return fmt.Sprintf("(int64_t)(intptr_t)(%s)", call), nil
+		case ef.Ret != "" && !isFFIScalar(ef.Ret):
+			return fmt.Sprintf("mfl_from_%s(%s)", ef.Ret, call), nil
+		}
+		return call, nil
+	}
 	switch ex.Callee {
 	case "len":
 		switch g.c.NodeKind(g.curFn, ex.Args[0]) {
@@ -3600,6 +3660,19 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("((int64_t)(%s))", args[0]), nil
 	case "float":
 		return fmt.Sprintf("((double)(%s))", args[0]), nil
+	case "sin", "cos", "tan", "asin", "acos", "atan", "exp", "log", "log2", "log10", "sqrt", "cbrt", "floor", "ceil", "round", "trunc", "abs":
+		g.usesMath = true
+		fn := ex.Callee
+		if fn == "abs" {
+			fn = "fabs"
+		}
+		return fmt.Sprintf("mfl_math_%s((double)(%s))", fn, args[0]), nil
+	case "pow", "atan2", "fmod", "hypot":
+		g.usesMath = true
+		return fmt.Sprintf("mfl_math_%s((double)(%s), (double)(%s))", ex.Callee, args[0], args[1]), nil
+	case "pi":
+		g.usesMath = true
+		return "mfl_math_pi()", nil
 	case "dial":
 		return fmt.Sprintf("mfl_dial(%s, %s)", args[0], args[1]), nil
 	case "listen":
@@ -3671,29 +3744,6 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_wss_close(%s)", args[0]), nil
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
-	}
-	if ef := g.c.ExternFn(ex.Callee); ef != nil {
-		// a foreign C function: cast scalar args to their C type and marshal
-		// struct args into the C layout; marshal a struct return back to MFL.
-		parts := make([]string, len(args))
-		for i, a := range args {
-			switch pt := ef.Params[i]; {
-			case pt == "ptr": // MFL int -> opaque void*
-				parts[i] = fmt.Sprintf("(void*)(intptr_t)(%s)", a)
-			case isFFIScalar(pt):
-				parts[i] = fmt.Sprintf("(%s)(%s)", ffiCType(pt), a)
-			default: // a cstruct, marshaled into the C layout
-				parts[i] = fmt.Sprintf("mfl_to_%s(%s)", pt, a)
-			}
-		}
-		call := fmt.Sprintf("%s(%s)", ef.Name, strings.Join(parts, ", "))
-		switch {
-		case ef.Ret == "ptr": // void* -> MFL int
-			return fmt.Sprintf("(int64_t)(intptr_t)(%s)", call), nil
-		case ef.Ret != "" && !isFFIScalar(ef.Ret):
-			return fmt.Sprintf("mfl_from_%s(%s)", ef.Ret, call), nil
-		}
-		return call, nil
 	}
 	if !g.c.IsTopFunc(ex.Callee) {
 		// a function-valued local variable, called by name

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.45.0"
+const machinVersion = "0.46.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -99,6 +99,20 @@ func machinGuide() guideCatalog {
 			{"int", "(number) -> int", "truncate to int", "convert"},
 			{"float", "(number) -> float", "int -> float (identity on float). MFL has no implicit int->float, so a concrete int (fn return, byte_at, len, ...) needs this to enter float math", "convert"},
 			{"parse_int", "(string) -> int", "parse an integer (0 if non-numeric)", "convert"},
+			// math (libm, linked -lm only when used; numeric in, float out)
+			{"sqrt", "(number) -> float", "square root", "math"},
+			{"cbrt", "(number) -> float", "cube root", "math"},
+			{"pow", "(number, number) -> float", "x raised to y", "math"},
+			{"exp", "(number) -> float", "e^x", "math"},
+			{"log", "(number) -> float", "natural log; also log2, log10", "math"},
+			{"sin", "(number) -> float", "sine (radians); also cos, tan", "math"},
+			{"asin", "(number) -> float", "arcsine; also acos, atan", "math"},
+			{"atan2", "(number, number) -> float", "atan(y/x) with quadrant (y, x)", "math"},
+			{"hypot", "(number, number) -> float", "sqrt(x*x+y*y) without overflow", "math"},
+			{"floor", "(number) -> float", "round toward -inf; also ceil, round, trunc", "math"},
+			{"abs", "(number) -> float", "absolute value (float; fabs)", "math"},
+			{"fmod", "(number, number) -> float", "floating-point remainder of x/y", "math"},
+			{"pi", "() -> float", "the constant pi", "math"},
 			// collections
 			{"len", "(string|slice|map) -> int", "length", "collection"},
 			{"append", "([]T, T) -> []T", "grow a slice", "collection"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -891,6 +891,40 @@ func TestOpaqueHandle(t *testing.T) {
 	}
 }
 
+// Native math builtins (libm), linked -lm only when used; an explicit extern of
+// the same name shadows the builtin.
+func TestMathBuiltins(t *testing.T) {
+	main := `func main() {
+	println(str(sqrt(9.0)) + " " + str(pow(2.0, 8.0)) + " " + str(floor(3.9)) + " " + str(ceil(3.1)))
+	println(str(abs(0.0 - 7.0)) + " " + str(hypot(3.0, 4.0)) + " " + str(round(2.5)))
+	println(str(cos(0.0)) + " " + str(atan2(0.0, 1.0)))
+}`
+	out, _ := buildRun(t, main)
+	want := "3 256 3 4\n7 5 3\n1 0\n"
+	if out != want {
+		t.Fatalf("math: got %q, want %q", out, want)
+	}
+	// gated: a math-free program emits no math runtime (so it never links -lm)
+	plain, err := CompileToC(&Program{Funcs: parseFuncs(t, `func main() { println("hi") }`)}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(plain, "mfl_math_") {
+		t.Fatal("math runtime must not be emitted for a math-free program")
+	}
+	// an explicit extern declaration shadows the builtin of the same name
+	prog, err := ParseProgram([]string{
+		`extern "m" { header "math.h" link "m" fn sqrt(float) float }`,
+		`func main() { println(str(sqrt(1.0, 2.0))) }`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "expected 1 args") {
+		t.Fatalf("extern sqrt should shadow the builtin (arity-checked), got %v", err)
+	}
+}
+
 // Nested cstructs: a cstruct field whose type is another cstruct (by-value
 // struct of by-value structs — e.g. raylib Camera3D holds Vector3s). The MFL
 // wrapper nests the inner mfl_ type and marshaling recurses. Codegen-level.

--- a/types.go
+++ b/types.go
@@ -1594,6 +1594,18 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		argSlots[i] = s
 	}
+	// An explicit extern declaration shadows a builtin of the same name, so a
+	// program that declares e.g. `fn sqrt(float) float` gets its extern rather
+	// than the math builtin.
+	if ef, ok := c.externs[ex.Callee]; ok {
+		if len(argSlots) != len(ef.Params) {
+			return 0, fmt.Errorf("%s: expected %d args, got %d", ef.Name, len(ef.Params), len(argSlots))
+		}
+		for i, pt := range ef.Params {
+			c.addPair(argSlots[i], c.ffiSlot(pt))
+		}
+		return c.ffiSlot(ef.Ret), nil
+	}
 	switch ex.Callee {
 	case "print", "println":
 		return c.cVoid, nil
@@ -1858,6 +1870,25 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], newSlot(c, KNum))
 		return c.cFloat, nil
+	case "sin", "cos", "tan", "asin", "acos", "atan", "exp", "log", "log2", "log10", "sqrt", "cbrt", "floor", "ceil", "round", "trunc", "abs":
+		// native math (libm): numeric in, float out
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("%s: 1 arg", ex.Callee)
+		}
+		c.addPair(argSlots[0], newSlot(c, KNum))
+		return c.cFloat, nil
+	case "pow", "atan2", "fmod", "hypot":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("%s: 2 args", ex.Callee)
+		}
+		c.addPair(argSlots[0], newSlot(c, KNum))
+		c.addPair(argSlots[1], newSlot(c, KNum))
+		return c.cFloat, nil
+	case "pi":
+		if len(argSlots) != 0 {
+			return 0, fmt.Errorf("pi: no args")
+		}
+		return c.cFloat, nil
 	case "listen", "accept":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("%s: 1 arg", ex.Callee)
@@ -2120,16 +2151,6 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		// arg is an fd (int) or a channel — codegen dispatches on its kind. Don't
 		// pin it to int, so close(ch) type-checks.
 		return c.cVoid, nil
-	}
-	if ef, ok := c.externs[ex.Callee]; ok {
-		// a foreign C function: fixed signature, compiled to a direct C call
-		if len(argSlots) != len(ef.Params) {
-			return 0, fmt.Errorf("%s: expected %d args, got %d", ef.Name, len(ef.Params), len(argSlots))
-		}
-		for i, pt := range ef.Params {
-			c.addPair(argSlots[i], c.ffiSlot(pt))
-		}
-		return c.ffiSlot(ef.Ret), nil
 	}
 	if _, isFunc := c.funcs[ex.Callee]; !isFunc {
 		// not a top-level function — maybe a function-valued local variable


### PR DESCRIPTION
## What

A native floating-point math suite over libm: `sin cos tan asin acos atan atan2 sqrt cbrt pow exp log log2 log10 floor ceil round trunc abs fmod hypot` and `pi()`. Numeric in, `float` out.

Surfaced by [machin-demo-3d](https://github.com/javimosch/machin-demo-3d), whose camera orbit had to reach libm via `extern "m"` — now `sin`/`cos` are native. The driver for procedural-animation apps.

## How

- Each builtin is a thin `mfl_math_<libm>` wrapper on a `double` (machin `float` is `double`), in a `mathRuntime` block.
- **Gated:** `usesMath` emits the runtime and links `-lm` **only when a math builtin is used**, so math-free programs keep their libc-only footprint (verified: no `mfl_math_` in a math-free program's C).
- **Extern shadows builtin:** the type-checker and codegen now resolve a declared `extern` fn **before** the builtin switch, so `extern "m" { fn sqrt ... }` (e.g. `examples/complex/ffi_math`) keeps using its extern. This also fixes the precedence generally (explicit declaration wins).

## Changes

- `codegen.go` — `mathRuntime`, `usesMath`, math builtin emission; extern-before-builtin in `callBody`.
- `types.go` — math builtin typing; extern-before-builtin in `genCall`.
- `build.go` — link `-lm` on the `mfl_math_` marker.
- Docs: guide `math` builtins, SPEC §16 table, CHANGELOG v0.46.0.

## Test

`TestMathBuiltins` (values, `-lm` gating, extern-shadow arity check); `ffi_math` example still prints `sqrt(2)=1.41421 / 2^10=1024 / hypot(3,4)=5`; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)