### PR TITLE
docs: gamedev skill — per-object transforms (rlgl) + anim demo

### DIFF
--- a/skills/machin-gamedev/SKILL.md
+++ b/skills/machin-gamedev/SKILL.md
@@ -8,7 +8,7 @@ description: Build native games and interactive desktop/terminal apps in machin 
 machin (MFL) compiles to a native binary through C, and reaches real games two ways:
 
 - **Terminal (TUI):** ANSI escapes for drawing + `raw_mode`/`read_key` for input. A no-dependency single binary. → [machin-game-snake](https://github.com/javimosch/machin-game-snake) (Snake).
-- **GUI / audio:** [raylib](https://www.raylib.com/) through machin's C **FFI** — a real OpenGL window, textures, sound. Links the system graphics/audio stack, so **not** self-contained. → [machin-game-2048](https://github.com/javimosch/machin-game-2048) (shapes+text), [machin-game-flappy](https://github.com/javimosch/machin-game-flappy) (sprites/textures), [machin-game-simon](https://github.com/javimosch/machin-game-simon) (audio), [machin-demo-3d](https://github.com/javimosch/machin-demo-3d) (3D).
+- **GUI / audio:** [raylib](https://www.raylib.com/) through machin's C **FFI** — a real OpenGL window, textures, sound. Links the system graphics/audio stack, so **not** self-contained. → [machin-game-2048](https://github.com/javimosch/machin-game-2048) (shapes+text), [machin-game-flappy](https://github.com/javimosch/machin-game-flappy) (sprites/textures), [machin-game-simon](https://github.com/javimosch/machin-game-simon) (audio), [machin-demo-3d](https://github.com/javimosch/machin-demo-3d) (3D + per-object rotation), [machin-demo-anim](https://github.com/javimosch/machin-demo-anim) (2D procedural).
 
 Each game is its own public repo with a `build.sh` (`machin encode src.src > app.mfl && machin build app.mfl -o app`), a `README.md`, a repo-root `SKILL.md`, and committed `assets/`. This skill is the shared substrate; each game's SKILL.md has its specifics.
 
@@ -54,7 +54,17 @@ FFI tiers, all verified working:
 - **Opaque handles** (`cstruct Sound {}`, machin **v0.44.0**) — a by-value C struct that contains pointers (`Sound`/`Music`/`Font`). machin holds the real C struct and passes it back to fns without naming its fields. Receive it from a fn, store it (a var **or** `[]Sound`), pass it on; **no** construct or `.field`. (A single pointer is simpler: the `ptr` FFI type, an `int`.)
 - **Nested cstructs** (machin **v0.45.0**) — a `cstruct` field may be another `cstruct`, marshaled recursively. Declare the inner one **first**. Required for **3D** and 2D cameras: `cstruct Vector3 { x f32 y f32 z f32 }` then `cstruct Camera3D { position Vector3 target Vector3 up Vector3 fovy f32 projection i32 }`; construct with nested literals `Camera3D{Vector3{12.0,7.0,0.0}, Vector3{0.0,1.5,0.0}, Vector3{0.0,1.0,0.0}, 45.0, 0}` and pass by value to `BeginMode3D`.
 
-**3D** (see [machin-demo-3d](https://github.com/javimosch/machin-demo-3d)): bracket 3D draws with `BeginMode3D(cam)` / `EndMode3D()`; `DrawCube(Vector3, f32,f32,f32, Color)`, `DrawCubeWires`, `DrawSphere(Vector3, f32, Color)`, `DrawGrid(i32, f32)`; any `DrawText` after `EndMode3D` is screen-space. Rebuild the `Camera3D` each frame rather than mutating it. `projection` `0` = `CAMERA_PERSPECTIVE`. **Math:** machin has **native** math builtins (v0.46.0) — `sin cos tan asin acos atan atan2 sqrt cbrt pow exp log log2 log10 floor ceil round trunc abs fmod hypot` and `pi()` (numeric in, `float` out; `-lm` linked only when used). So an orbit is just `v3(R*cos(a), h, R*sin(a))`. (An `extern "m"` of the same name still shadows the builtin if you want a specific libm signature.)
+**3D** (see [machin-demo-3d](https://github.com/javimosch/machin-demo-3d)): bracket 3D draws with `BeginMode3D(cam)` / `EndMode3D()`; `DrawCube(Vector3, f32,f32,f32, Color)`, `DrawCubeWires`, `DrawSphere(Vector3, f32, Color)`, `DrawGrid(i32, f32)`; any `DrawText` after `EndMode3D` is screen-space. Rebuild the `Camera3D` each frame rather than mutating it. `projection` `0` = `CAMERA_PERSPECTIVE`.
+
+**Per-object transforms (rotation/scale).** `DrawCube`/`DrawSphere` only translate (axis-aligned). To rotate or scale an object, use raylib's immediate-mode matrix stack from **rlgl**: `rlPushMatrix` → `rlTranslatef(x,y,z)` → `rlRotatef(deg, ax,ay,az)` / `rlScalef(x,y,z)` → draw at the **local origin** → `rlPopMatrix`. Those functions live in `rlgl.h`, **not** `raylib.h` — but their symbols are in `libraylib.a`, so declare them in a **headerless extern block** (machin emits the prototypes itself; symbols link from the raylib block's libs). No new machin feature — the existing scalar/`void` FFI carries it:
+
+```
+extern "rlgl" { fn rlPushMatrix() fn rlPopMatrix() fn rlTranslatef(f32,f32,f32) fn rlRotatef(f32,f32,f32,f32) fn rlScalef(f32,f32,f32) }
+// spin a cube in place:
+rlPushMatrix()  rlTranslatef(x,y,z)  rlRotatef(deg, 0.0,1.0,0.0)  DrawCube(v3(0.0,0.0,0.0), s,s,s, c)  rlPopMatrix()
+```
+
+(The same stack works in 2D between `BeginDrawing`/`EndDrawing`. The **headerless-extern** trick is general: any `libraylib.a`/system-lib symbol that's scalar/`void` can be reached this way without its header.) **Math:** machin has **native** math builtins (v0.46.0) — `sin cos tan asin acos atan atan2 sqrt cbrt pow exp log log2 log10 floor ceil round trunc abs fmod hypot` and `pi()` (numeric in, `float` out; `-lm` linked only when used). So an orbit is just `v3(R*cos(a), h, R*sin(a))`. (An `extern "m"` of the same name still shadows the builtin if you want a specific libm signature.)
 
 Sprite tricks: a **sprite sheet** is one PNG; pick a frame with a source `Rectangle{float(frame*48), 0, 48, 48}` and rotate via `DrawTexturePro` around `origin = Vector2{w/2, h/2}`. **Flip** with a negative source height (`Rectangle{0,0,88,-600}`) — reuse one texture for both orientations. **Center text** with `MeasureText`.
 
@@ -97,6 +107,7 @@ Rule of thumb: keep each value in one numeric world; cross the boundary explicit
 | 2048 | raylib FFI: scalars + `Color` | (composed; no new builtin) |
 | flappy | textures/sprites, `f32` structs, struct-return | `float()` int→float (v0.43.0) |
 | simon | audio: pointer-bearing `Sound` by value | FFI **opaque handles** `cstruct Name {}` (v0.44.0) |
-| 3d demo | 3D: `Camera3D` (struct of `Vector3`s) | FFI **nested cstructs** (v0.45.0); its libm orbit then drove **native math** builtins (v0.46.0) |
+| 3d demo | 3D: `Camera3D` (struct of `Vector3`s); per-object rotation (rlgl matrix stack, headerless extern) | FFI **nested cstructs** (v0.45.0); its libm orbit then drove **native math** builtins (v0.46.0); rotation = composition (no new feature) |
+| anim | 2D procedural flow field (sin/cos/atan2/hypot over time) | composition on native math + 2D FFI (no new feature) |
 
 When a new game hits a wall, that's the point: fill the gap in the language, release, and note it here.


### PR DESCRIPTION
Adds the per-object rotation/scale pattern to the canonical game-dev skill: raylib's rlgl immediate-mode matrix stack (`rlPushMatrix`/`rlTranslatef`/`rlRotatef`/`rlScalef`/`rlPopMatrix`) reached via a **headerless extern block** — those symbols live in `rlgl.h` but are in `libraylib.a`, so machin emits the prototypes and the existing scalar/void FFI carries it (no new feature). Generalizes the headerless-extern trick, and adds machin-demo-anim to the intro list + dogfood record. Docs-only.

Verified live in [machin-demo-3d](https://github.com/javimosch/machin-demo-3d) — cubes now spin on their own axes while orbiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded game development guidance with more examples, including 3D and 2D procedural demos.
  * Added clearer notes for 3D rendering workflows, including world-space vs. screen-space drawing and object rotation/scale techniques.
  * Improved examples showing how math utilities can support orbit-style 3D calculations.
  * Updated the game feature table to reflect the new 3D rendering approach and procedural flow-field usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->