### PR TITLE
docs: game-dev north star + procedural mesh / terrain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ Building a **game** (terminal TUI or raylib GUI/audio)? Read
 [`skills/machin-gamedev/SKILL.md`](skills/machin-gamedev/SKILL.md) first — the
 canonical setup, build-and-verify workflow, raylib FFI surface, and accumulated
 caveats/gotchas (especially MFL's no-implicit-`int`→`float` rule), distilled from
-machin-game-snake / -2048 / -flappy / -simon.
+the game/demo series. Game-dev has become a primary dogfood domain; its direction
+and gap roadmap live in [`docs/NORTH-STAR-GAMEDEV.md`](docs/NORTH-STAR-GAMEDEV.md).
 
 ## What this is
 

--- a/docs/NORTH-STAR-GAMEDEV.md
+++ b/docs/NORTH-STAR-GAMEDEV.md
@@ -1,0 +1,97 @@
+# Game-dev: a north star for the domain
+
+machin is a **backend-first** language — its core target is servers, tools, and
+protocols. But the dogfood loop (build real things; let real use surface gaps)
+keeps producing games, and **game development has emerged as one of machin's
+primary detected domains**. This document is the north star for that domain: it
+is *not* a promise or a committed roadmap — it records the direction so the next
+demo knows which gap is worth driving.
+
+> The overall machin north star is unchanged (backend, machine-first). Game-dev
+> is a **branch** of it: a domain machin is being extended toward, one verified
+> step at a time. Several aspirations below (the combat sim especially) are
+> ideas, not commitments.
+
+## Where it stands today (all shipping, all verified on-screen)
+
+Native binaries through raylib's C FFI (and a terminal track):
+
+| capability | repo | what it proved |
+|---|---|---|
+| terminal real-time game | [machin-game-snake](https://github.com/javimosch/machin-game-snake) | `raw_mode`/`read_key` (v0.41.0) |
+| 2D GUI (shapes+text) | [machin-game-2048](https://github.com/javimosch/machin-game-2048) | scalars + by-value `Color` |
+| sprites / textures | [machin-game-flappy](https://github.com/javimosch/machin-game-flappy) | `f32` structs, struct-return; drove `float()` (v0.43.0) |
+| audio | [machin-game-simon](https://github.com/javimosch/machin-game-simon) | FFI **opaque handles** (v0.44.0) |
+| 3D + per-object rotation | [machin-demo-3d](https://github.com/javimosch/machin-demo-3d) | FFI **nested cstructs** (v0.45.0) → drove **native math** (v0.46.0); rlgl matrix stack |
+| 2D procedural animation | [machin-demo-anim](https://github.com/javimosch/machin-demo-anim) | composition on native math |
+| procedural mesh (immediate mode) | [machin-demo-terrain](https://github.com/javimosch/machin-demo-terrain) | rlgl `rlVertex3f` stream; flat shading in MFL |
+
+The how-to substrate is [`skills/machin-gamedev/SKILL.md`](../skills/machin-gamedev/SKILL.md):
+setup, the FFI surface, the **headerless-extern trick** (reach any scalar/`void`
+`libraylib.a` symbol without its header), and the int/float rules.
+
+So today machin can do: real 2D games (input/sprites/audio), animated 3D scenes
+with cameras and per-object transforms, procedural 2D animation, and procedural
+meshes streamed each frame. That is already a real game-dev surface.
+
+## The vision, in tiers (near → far)
+
+**Tier 1 — solid interactive 3D (mostly here).** Cameras, primitives, per-object
+transforms, immediate-mode procedural geometry, native math. Missing for comfort:
+a small **vector/matrix helper layer** (vec3/mat4 ops as MFL or builtins) and
+**texture-mapped** meshes.
+
+**Tier 2 — real GPU meshes.** Build a mesh once and upload it to a GPU vertex
+buffer (`Mesh` + `UploadMesh`/`DrawMesh`), instead of re-emitting every frame.
+This is the first hard gap: it needs **pointer/array FFI** (raw C `float*`
+buffers, struct-by-pointer). Unlocks large **static** terrain, models, and
+`DrawMeshInstanced` for fields of objects.
+
+**Tier 3 — procedural worlds.**
+- **Planet / terrain generation:** chunked height fields with level-of-detail,
+  biomes, erosion; **scattering** of *flora/fauna* (instanced meshes placed by
+  density functions and noise). Needs Tier-2 meshes + instancing + a real noise
+  primitive (Perlin/Simplex — a candidate native builtin, since layered `sin` only
+  goes so far).
+- **2D & 3D skeleton animation (procedural):** bone hierarchies, forward
+  kinematics, and **IK** (inverse kinematics) for limbs; blending. Mostly MFL math
+  over transforms — but benefits from the vector/matrix layer and, for 3D, skinned
+  meshes (more `Mesh`/`Matrix` FFI).
+
+**Tier 4 — simulation sandbox (aspirational, not set in stone).** A combat-sim in
+the spirit of **ArmA / Armed Assault**: real **ballistics** (drag, gravity, wind,
+penetration), rigid-body **physics**, large streamed worlds, many agents. This is
+a stretch goal that would exercise machin as a *simulation* language as much as a
+rendering one: deterministic fixed-step loops, spatial partitioning, and probably
+a **physics library** via FFI (e.g. an ODE/Bullet-style C lib) rather than
+hand-rolled. Listed as a direction, not a plan.
+
+## The feature roadmap (gaps, in rough dependency order)
+
+Each is a candidate to be *driven by a demo*, not built speculatively:
+
+1. **Pointer / array FFI** — pass raw C buffers (`float*`, `unsigned short*`) and
+   structs **by pointer** (`UploadMesh(Mesh*)`). The single biggest unlock
+   (Tier 2+). Probably a `cbuffer`/`carray` concept + `&struct` marshaling.
+2. **A vector/matrix layer** — vec2/vec3/vec4 + mat4 ops. Could be a vendored MFL
+   module first; promote hot paths to builtins if measured.
+3. **Shaders / uniforms** — `LoadShader`, `SetShaderValue` (needs pointer FFI for
+   uniform arrays); lighting, post-processing.
+4. **A noise builtin** — Perlin/Simplex; the backbone of procedural worlds.
+5. **FFI callbacks (Phase 4)** — C calling back into MFL (custom render/audio
+   callbacks, `SetTraceLogCallback`, GLFW-style input hooks).
+6. **Deterministic fixed-step sim** loop patterns + spatial structures (for Tier 4).
+
+## Method
+
+Same loop as the rest of machin: build a real thing, hit the wall, fill it in the
+language, release, and record it — in the [dogfood table](../skills/machin-gamedev/SKILL.md#each-game-drove-a-feature-the-dogfood-record).
+Be honest about **composition vs. new feature**: per-object rotation, 2D
+procedural animation, and immediate-mode meshes were all *composition* on the
+existing FFI — that the language already reaches them is itself the result. The
+next demo that genuinely *can't* be expressed (real GPU meshes) names the next
+feature (pointer/array FFI).
+
+To contribute a game/demo: build something real, put it in its own public repo
+with a `build.sh`, link the gamedev skill, and add it to
+[awesome-machin](https://github.com/javimosch/awesome-machin).

--- a/skills/machin-gamedev/SKILL.md
+++ b/skills/machin-gamedev/SKILL.md
@@ -8,7 +8,9 @@ description: Build native games and interactive desktop/terminal apps in machin 
 machin (MFL) compiles to a native binary through C, and reaches real games two ways:
 
 - **Terminal (TUI):** ANSI escapes for drawing + `raw_mode`/`read_key` for input. A no-dependency single binary. → [machin-game-snake](https://github.com/javimosch/machin-game-snake) (Snake).
-- **GUI / audio:** [raylib](https://www.raylib.com/) through machin's C **FFI** — a real OpenGL window, textures, sound. Links the system graphics/audio stack, so **not** self-contained. → [machin-game-2048](https://github.com/javimosch/machin-game-2048) (shapes+text), [machin-game-flappy](https://github.com/javimosch/machin-game-flappy) (sprites/textures), [machin-game-simon](https://github.com/javimosch/machin-game-simon) (audio), [machin-demo-3d](https://github.com/javimosch/machin-demo-3d) (3D + per-object rotation), [machin-demo-anim](https://github.com/javimosch/machin-demo-anim) (2D procedural).
+- **GUI / audio:** [raylib](https://www.raylib.com/) through machin's C **FFI** — a real OpenGL window, textures, sound. Links the system graphics/audio stack, so **not** self-contained. → [machin-game-2048](https://github.com/javimosch/machin-game-2048) (shapes+text), [machin-game-flappy](https://github.com/javimosch/machin-game-flappy) (sprites/textures), [machin-game-simon](https://github.com/javimosch/machin-game-simon) (audio), [machin-demo-3d](https://github.com/javimosch/machin-demo-3d) (3D + per-object rotation), [machin-demo-anim](https://github.com/javimosch/machin-demo-anim) (2D procedural), [machin-demo-terrain](https://github.com/javimosch/machin-demo-terrain) (procedural mesh).
+
+Where this domain is heading: [`docs/NORTH-STAR-GAMEDEV.md`](../../docs/NORTH-STAR-GAMEDEV.md) (tiers + the gap roadmap: pointer/array FFI for real GPU meshes, a vector/matrix layer, a noise builtin, shaders, callbacks).
 
 Each game is its own public repo with a `build.sh` (`machin encode src.src > app.mfl && machin build app.mfl -o app`), a `README.md`, a repo-root `SKILL.md`, and committed `assets/`. This skill is the shared substrate; each game's SKILL.md has its specifics.
 
@@ -64,7 +66,9 @@ extern "rlgl" { fn rlPushMatrix() fn rlPopMatrix() fn rlTranslatef(f32,f32,f32) 
 rlPushMatrix()  rlTranslatef(x,y,z)  rlRotatef(deg, 0.0,1.0,0.0)  DrawCube(v3(0.0,0.0,0.0), s,s,s, c)  rlPopMatrix()
 ```
 
-(The same stack works in 2D between `BeginDrawing`/`EndDrawing`. The **headerless-extern** trick is general: any `libraylib.a`/system-lib symbol that's scalar/`void` can be reached this way without its header.) **Math:** machin has **native** math builtins (v0.46.0) — `sin cos tan asin acos atan atan2 sqrt cbrt pow exp log log2 log10 floor ceil round trunc abs fmod hypot` and `pi()` (numeric in, `float` out; `-lm` linked only when used). So an orbit is just `v3(R*cos(a), h, R*sin(a))`. (An `extern "m"` of the same name still shadows the builtin if you want a specific libm signature.)
+(The same stack works in 2D between `BeginDrawing`/`EndDrawing`. The **headerless-extern** trick is general: any `libraylib.a`/system-lib symbol that's scalar/`void` can be reached this way without its header.)
+
+**Procedural meshes (immediate mode)** — see [machin-demo-terrain](https://github.com/javimosch/machin-demo-terrain). Compute geometry in MFL and stream it triangle-by-triangle with rlgl: `extern "rlgl" { fn rlBegin(i32) fn rlEnd() fn rlColor4ub(u8,u8,u8,u8) fn rlVertex3f(f32,f32,f32) fn rlDisableBackfaceCulling() }`; `rlBegin(4)` (= `RL_TRIANGLES`), one `rlColor4ub` then three `rlVertex3f` per triangle, `rlEnd()` — inside `BeginMode3D`. **Flat-shade in MFL** (no light shader otherwise): face normal = cross of two edges, `sh = 0.4 + 0.6*clamp(dot(n_unit, lightDir),0,1)` (`sqrt` to normalize), multiply color by `sh`. `rlDisableBackfaceCulling()` if the surface is seen from both sides (else winding-dependent triangles vanish → thin sliver). ~10–15k `rlVertex3f`/frame is fine. The *static* GPU-VBO path (`Mesh`+`UploadMesh`, `float*` arrays) needs pointer/array FFI machin doesn't have yet — the next real feature; see the north-star doc. **Math:** machin has **native** math builtins (v0.46.0) — `sin cos tan asin acos atan atan2 sqrt cbrt pow exp log log2 log10 floor ceil round trunc abs fmod hypot` and `pi()` (numeric in, `float` out; `-lm` linked only when used). So an orbit is just `v3(R*cos(a), h, R*sin(a))`. (An `extern "m"` of the same name still shadows the builtin if you want a specific libm signature.)
 
 Sprite tricks: a **sprite sheet** is one PNG; pick a frame with a source `Rectangle{float(frame*48), 0, 48, 48}` and rotate via `DrawTexturePro` around `origin = Vector2{w/2, h/2}`. **Flip** with a negative source height (`Rectangle{0,0,88,-600}`) — reuse one texture for both orientations. **Center text** with `MeasureText`.
 
@@ -95,6 +99,7 @@ Rule of thumb: keep each value in one numeric world; cross the boundary explicit
 - **A GUI binary is not self-contained** — it links `libGL`/`libX11`/raylib/audio and needs a display (and an audio device for sound). machin's no-dependency-binary property holds for the headless domain only. Say so in the README.
 - **`str(bool)` works** as of machin **v0.42.0** (`"true"`/`"false"`); on older compilers it was a type error, so keep bools in control flow there.
 - **No slice ranges** (`s[1:]` doesn't parse) — rebuild with a loop (e.g. snake's `drop_first`).
+- **`a < -b` is a lexer trap.** `encode` tightens `< -` to `<-`, which lexes as the channel-receive token (`expected "{", got "<-"`). Write `a < 0.0 - b` or flip the comparison. (Common with negative thresholds: `if h < -0.7` → `if h < 0.0 - 0.7`.)
 - **Random:** there's no PRNG builtin; `byte_at(rand_bytes(1), 0) % N` picks a value (a second byte `< 26` ≈ a 10% branch).
 - **Frame timing:** immediate-mode means never `sleep` mid-game (it freezes the window). Drive animations/state with a per-frame tick counter and `SetTargetFPS`. (Terminal games *do* `sleep(ms)` per tick — they own the loop.)
 - **Mutating shared state:** slices are reference-ish — `f(board)` then `board[i] = v` is visible to the caller (return only summaries). Structs are value types (a copy), so a function can't mutate a caller's struct.
@@ -109,5 +114,6 @@ Rule of thumb: keep each value in one numeric world; cross the boundary explicit
 | simon | audio: pointer-bearing `Sound` by value | FFI **opaque handles** `cstruct Name {}` (v0.44.0) |
 | 3d demo | 3D: `Camera3D` (struct of `Vector3`s); per-object rotation (rlgl matrix stack, headerless extern) | FFI **nested cstructs** (v0.45.0); its libm orbit then drove **native math** builtins (v0.46.0); rotation = composition (no new feature) |
 | anim | 2D procedural flow field (sin/cos/atan2/hypot over time) | composition on native math + 2D FFI (no new feature) |
+| terrain | procedural mesh: per-vertex heights, flat-shaded, streamed via rlgl immediate mode | composition (no new feature); points at the **pointer/array FFI** gap for real GPU VBOs |
 
 When a new game hits a wall, that's the point: fill the gap in the language, release, and note it here.


### PR DESCRIPTION
Adds **docs/NORTH-STAR-GAMEDEV.md** — the north star for game-dev as a primary dogfood domain (backend stays machin's core; game-dev is a branch of it). Current shipped capabilities, a tiered vision (interactive 3D → real GPU meshes → procedural planets / skeleton animation → an aspirational ArmA-like combat sim), and the gap roadmap (pointer/array FFI, vector/matrix layer, noise builtin, shaders, FFI callbacks).

Extends the gamedev skill with the immediate-mode **procedural-mesh** pattern (rlgl `rlBegin`/`rlVertex3f`, flat-shading in MFL, cull-disable), the [machin-demo-terrain](https://github.com/javimosch/machin-demo-terrain) reference + dogfood row, and the **`a < -b`** lexer gotcha. Linked from AGENTS.md. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)