### PR TITLE
feat: pointer/array FFI — raw memory + *T params (v0.47.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.47.0
+
+- **Pointer/array FFI — raw memory + `*T` params.** machin can now build C
+  buffers and structs and hand them to a foreign API:
+  - raw heap memory (pointers are `int`s): `alloc(n)` (zeroed), `free(p)`,
+    `poke_f32`/`poke_i32`/`poke_u8`/`poke_u16`/`poke_ptr(p, byteOffset, v)`,
+    `peek_f32`/`peek_i32(p, byteOffset)`.
+  - a new FFI param convention **`*T`** — the MFL arg is a pointer (`int`); the
+    call dereferences it and passes the pointed-to C struct **by value** (e.g.
+    `fn LoadModelFromMesh(*Mesh) Model`). Pass the pointer itself with `ptr`
+    (`void*` → any `T*`), so an in/out `UploadMesh(Mesh*)` writes back into the
+    buffer.
+  - Also: an explicit `extern` declaration now resolves before the builtin
+    switch (introduced in v0.46.0), so reaching a foreign `fn` of the same name
+    as a builtin still works.
+
+  This is the first FFI tier that hands C **raw pointers/arrays**, unlocking GPU
+  vertex buffers (`UploadMesh`/`LoadModelFromMesh`/`DrawModel`) — a procedurally
+  generated mesh built in MFL and uploaded to VRAM. Surfaced (and verified) by
+  [machin-demo-planet](https://github.com/javimosch/machin-demo-planet). The
+  Tier-2 unlock in the [game-dev north star](docs/NORTH-STAR-GAMEDEV.md).
+
 ## v0.46.1
 
 - **docs:** fix the guide's `ffi-nested-cstruct` gotcha, which still said "no

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.46.1-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.47.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.46.1
+Version 0.47.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -516,7 +516,19 @@ extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) 
   by-value aggregate.)
 - `fn Name(t, ...) ret` — a foreign function. Parameter and return types are FFI
   scalar types, or the name of a declared `cstruct` (numeric or opaque); a
-  missing return type means `void`.
+  missing return type means `void`. A param may also be **`*T`** (`T` a C type
+  from the header): the MFL argument is a pointer (an `int`) and the call
+  **dereferences it, passing the pointed-to `T` by value** — e.g.
+  `fn LoadModelFromMesh(*Mesh) Model`. (To pass the pointer itself, use `ptr`.)
+
+**Raw memory** (pointers are `int`s, like `ptr`) lets MFL build C buffers and
+structs to hand to a foreign function: `alloc(n) -> int` (n **zeroed** bytes),
+`free(p)`, `poke_f32`/`poke_i32`/`poke_u8`/`poke_u16`/`poke_ptr(p, byteOffset, v)`,
+and `peek_f32`/`peek_i32(p, byteOffset)`. The pattern for a GPU mesh: `poke` the
+vertex/colour arrays and a `Mesh` struct into `alloc`'d memory, `UploadMesh(p, ...)`
+(a `ptr` param — `void*` converts to `Mesh*`, and the call writes the VAO/VBO ids
+back), then `LoadModelFromMesh(p)` (a `*Mesh` param). Struct offsets are
+layout-specific — pin the C library version.
 
 **FFI scalar types** → C: `int`/`i64`→`int64_t`, `i32`→`int32_t`, `i16`→`int16_t`,
 `i8`→`int8_t`, `u64`→`uint64_t` … `u8`→`uint8_t`, `float`/`f64`→`double`,

--- a/codegen.go
+++ b/codegen.go
@@ -345,6 +345,18 @@ static char* mfl_str_i(int64_t v) { char* b = mfl_alloc(24); snprintf(b, 24, "%l
 static char* mfl_str_d(double v)  { char* b = mfl_alloc(32); snprintf(b, 32, "%g", v); return b; }
 static char* mfl_str_b(int64_t v) { return v ? "true" : "false"; }
 static char* mfl_dup(const char* s) { size_t n = strlen(s); char* r = mfl_alloc(n+1); memcpy(r, s, n+1); return r; }
+/* raw heap memory: a pointer is an int (intptr_t round-trip), as with the ptr
+   FFI type. alloc() is zeroed (calloc) so building C structs is safe. For
+   filling C buffers (vertex arrays) and structs to hand to a C API. */
+static int64_t mfl_raw_alloc(int64_t n) { return (int64_t)(intptr_t)calloc(1, (size_t)(n > 0 ? n : 0)); }
+static void mfl_raw_free(int64_t p) { free((void*)(intptr_t)p); }
+static void mfl_poke_f32(int64_t p, int64_t o, double v) { *(float*)((char*)(intptr_t)p + o) = (float)v; }
+static void mfl_poke_i32(int64_t p, int64_t o, int64_t v) { *(int32_t*)((char*)(intptr_t)p + o) = (int32_t)v; }
+static void mfl_poke_u8(int64_t p, int64_t o, int64_t v) { *(uint8_t*)((char*)(intptr_t)p + o) = (uint8_t)v; }
+static void mfl_poke_u16(int64_t p, int64_t o, int64_t v) { *(uint16_t*)((char*)(intptr_t)p + o) = (uint16_t)v; }
+static void mfl_poke_ptr(int64_t p, int64_t o, int64_t v) { *(void**)((char*)(intptr_t)p + o) = (void*)(intptr_t)v; }
+static double mfl_peek_f32(int64_t p, int64_t o) { return (double)*(float*)((char*)(intptr_t)p + o); }
+static int64_t mfl_peek_i32(int64_t p, int64_t o) { return (int64_t)*(int32_t*)((char*)(intptr_t)p + o); }
 /* base64 (standard alphabet, padded) over text. */
 static char* mfl_base64_encode(const char* s) {
     static const char t[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -3459,6 +3471,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 			switch pt := ef.Params[i]; {
 			case pt == "ptr": // MFL int -> opaque void*
 				parts[i] = fmt.Sprintf("(void*)(intptr_t)(%s)", a)
+			case strings.HasPrefix(pt, "*"): // *Name: deref an MFL int (ptr) to a C struct, by value
+				parts[i] = fmt.Sprintf("(*(%s*)(intptr_t)(%s))", pt[1:], a)
 			case isFFIScalar(pt):
 				parts[i] = fmt.Sprintf("(%s)(%s)", ffiCType(pt), a)
 			default: // a cstruct, marshaled into the C layout
@@ -3673,6 +3687,14 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "pi":
 		g.usesMath = true
 		return "mfl_math_pi()", nil
+	case "alloc":
+		return fmt.Sprintf("mfl_raw_alloc(%s)", args[0]), nil
+	case "free":
+		return fmt.Sprintf("mfl_raw_free(%s)", args[0]), nil
+	case "poke_f32", "poke_i32", "poke_u8", "poke_u16", "poke_ptr":
+		return fmt.Sprintf("mfl_%s(%s, %s, %s)", ex.Callee, args[0], args[1], args[2]), nil
+	case "peek_f32", "peek_i32":
+		return fmt.Sprintf("mfl_%s(%s, %s)", ex.Callee, args[0], args[1]), nil
 	case "dial":
 		return fmt.Sprintf("mfl_dial(%s, %s)", args[0], args[1]), nil
 	case "listen":

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.46.1"
+const machinVersion = "0.47.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -113,6 +113,14 @@ func machinGuide() guideCatalog {
 			{"abs", "(number) -> float", "absolute value (float; fabs)", "math"},
 			{"fmod", "(number, number) -> float", "floating-point remainder of x/y", "math"},
 			{"pi", "() -> float", "the constant pi", "math"},
+			// raw memory (pointers are ints) — build C buffers/structs for the FFI
+			{"alloc", "(int) -> int", "allocate n zeroed bytes; returns a pointer (as int). For C buffers/structs to hand to an extern fn", "memory"},
+			{"free", "(int) ->", "free a pointer returned by alloc", "memory"},
+			{"poke_f32", "(int, int, number) ->", "write a 32-bit float at ptr+byteoffset", "memory"},
+			{"poke_i32", "(int, int, int) ->", "write a 32-bit int at ptr+byteoffset (also poke_u8, poke_u16)", "memory"},
+			{"poke_ptr", "(int, int, int) ->", "write an 8-byte pointer value at ptr+byteoffset (e.g. a buffer into a struct field)", "memory"},
+			{"peek_f32", "(int, int) -> float", "read a 32-bit float at ptr+byteoffset", "memory"},
+			{"peek_i32", "(int, int) -> int", "read a 32-bit int at ptr+byteoffset", "memory"},
 			// collections
 			{"len", "(string|slice|map) -> int", "length", "collection"},
 			{"append", "([]T, T) -> []T", "grow a slice", "collection"},
@@ -243,6 +251,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"int-float-no-implicit", "There is NO implicit int->float. Only a flexible numeric LITERAL (e.g. 5) promotes against a float; a CONCRETE int — a fn return, byte_at, len, a typed param, or an int-slice element — is a hard `int vs float` mismatch with a float. Wrap it: float(byte_at(b,0)) / 2.0. (int() goes the other way.) This also applies to f32/f64 struct fields in FFI cstructs."},
 			{"ffi-opaque-handle", "For a by-value C struct that contains pointers (raylib Sound/Music/Font/Texture with internals, FILE wrappers, ...), declare an OPAQUE cstruct with an empty body: `cstruct Sound {}`. machin holds the real C struct by value and passes it back to fns without naming its fields — receive it from a fn, store it (incl. []Sound), pass it on; no construct or .field. (A single pointer is simpler: the `ptr` FFI type, held as an int.)"},
 			{"ffi-nested-cstruct", "A cstruct field may be ANOTHER cstruct (by-value struct of structs) — declare the inner one first. e.g. `cstruct Vector3 { x f32 y f32 z f32 }` then `cstruct Camera3D { position Vector3 target Vector3 up Vector3 fovy f32 projection i32 }`; construct with nested literals `Camera3D{Vector3{0,10,10}, Vector3{0,0,0}, Vector3{0,1,0}, 45.0, 0}`. Required for 3D (BeginMode3D) and 2D cameras. (Camera/orbit trig: machin has native sin/cos/sqrt/pi etc. — see the `math` builtins.)"},
+			{"ffi-raw-buffers", "To hand a C API a raw buffer or build a C struct, use raw memory (pointers are ints): `p := alloc(nbytes)` (zeroed), `poke_f32/poke_i32/poke_u8/poke_ptr(p, byteOffset, v)`, `peek_f32/peek_i32`, `free(p)`. Pass the pointer to an extern fn taking `ptr` (becomes void*, implicitly any T*). To pass the *pointed-to struct by value*, declare the param `*Name` — `fn LoadModelFromMesh(*Mesh) Model` emits `*(Mesh*)ptr`. So: build a Mesh in alloc'd memory (poke its fields at known offsets), `UploadMesh(meshPtr, false)` (ptr param, writes back), then `LoadModelFromMesh(meshPtr)` (*Mesh). Offsets are layout-specific — pin the C lib version. (see machin-demo-planet)"},
 			{"eval-order", "Operands and arguments evaluate left-to-right (as in Go), including side effects: `f() + g()` runs f() before g(). Holds for binary ops, call args, slice/struct literals, and multi-return lists."},
 			{"composite-literal", "T{...} literals need T to be a known struct type at parse time. `machin encode` registers all `type` decls first, so this just works in normal builds."},
 			{"stdout-buffering", "libc fully buffers stdout when it's a pipe; a streaming program must call flush() after a write to appear promptly downstream. A TTY is line-buffered."},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -925,6 +925,42 @@ func TestMathBuiltins(t *testing.T) {
 	}
 }
 
+// Raw heap memory: alloc + typed poke/peek round-trip, then free. (Pointers are
+// ints; for building C buffers/structs to hand to a foreign API.)
+func TestRawMemory(t *testing.T) {
+	main := `func main() {
+	p := alloc(32)
+	poke_f32(p, 0, 1.5)
+	poke_i32(p, 8, 7)
+	poke_u8(p, 12, 200)
+	println(str(peek_f32(p, 0)) + " " + str(peek_i32(p, 8)) + " " + str(peek_i32(p, 12)))
+	free(p)
+}`
+	out, _ := buildRun(t, main)
+	if out != "1.5 7 200\n" {
+		t.Fatalf("raw memory: got %q, want %q", out, "1.5 7 200\n")
+	}
+}
+
+// The `*Name` FFI param convention: deref an MFL int (pointer) and pass the
+// pointed-to C struct by value (e.g. LoadModelFromMesh(*Mesh)). Codegen-level.
+func TestFFIDerefParam(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`extern "g" { header "g.h" cstruct Model {} fn LoadFrom(*Thing) Model }`,
+		`func main() { m := LoadFrom(0)  println(str(0)) }`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "(*(Thing*)(intptr_t)") {
+		t.Fatal("*Name param must deref the pointer and pass the C struct by value")
+	}
+}
+
 // Nested cstructs: a cstruct field whose type is another cstruct (by-value
 // struct of by-value structs — e.g. raylib Camera3D holds Vector3s). The MFL
 // wrapper nests the inner mfl_ type and marshaling recurses. Codegen-level.

--- a/parser.go
+++ b/parser.go
@@ -218,11 +218,18 @@ func (p *Parser) parseExternDecl() (*ExternDecl, error) {
 			}
 			var params []string
 			for p.peek().Val != ")" && p.peek().Kind != TEOF {
+				// a leading * means "deref this pointer (an MFL int) and pass the
+				// pointed-to C struct by value" — e.g. fn LoadModelFromMesh(*Mesh).
+				prefix := ""
+				if p.peek().Val == "*" {
+					p.next()
+					prefix = "*"
+				}
 				t := p.next() // a scalar FFI type or a cstruct name; validated by the checker
 				if t.Kind != TIdent {
 					return nil, fmt.Errorf("extern fn %s: expected a parameter type, got %q", name.Val, t.Val)
 				}
-				params = append(params, t.Val)
+				params = append(params, prefix+t.Val)
 				for p.peek().Val == "," {
 					p.next()
 				}

--- a/types.go
+++ b/types.go
@@ -620,6 +620,9 @@ func Check(p *Program) (*Checker, error) {
 		if t == "" || isFFIScalar(t) {
 			return true
 		}
+		if strings.HasPrefix(t, "*") {
+			return true // *Name: deref an MFL int (ptr) to a header C type, by value
+		}
 		_, ok := c.structs[t]
 		return ok
 	}
@@ -1566,6 +1569,9 @@ func (c *Checker) genStructLit(fn *FuncDecl, ex *StructLit) (int, error) {
 // ffiSlot maps an FFI type name to its checker slot: a scalar's shared slot, a
 // fresh struct slot for a cstruct name, or void for "".
 func (c *Checker) ffiSlot(t string) int {
+	if strings.HasPrefix(t, "*") {
+		return c.cInt // *Name: the MFL arg is a pointer held as an int
+	}
 	switch t {
 	case "":
 		return c.cVoid
@@ -1889,6 +1895,50 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("pi: no args")
 		}
 		return c.cFloat, nil
+	// raw heap memory: pointers are ints. For building C buffers/structs to hand
+	// to a foreign API (e.g. a GPU vertex buffer via the FFI).
+	case "alloc":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("alloc: 1 arg (byte count)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cInt, nil
+	case "free":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("free: 1 arg (pointer)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cVoid, nil
+	case "poke_f32":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("poke_f32: 3 args (ptr, byte offset, value)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cInt)
+		c.addPair(argSlots[2], newSlot(c, KNum))
+		return c.cVoid, nil
+	case "poke_i32", "poke_u8", "poke_u16", "poke_ptr":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("%s: 3 args (ptr, byte offset, value)", ex.Callee)
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cInt)
+		c.addPair(argSlots[2], c.cInt)
+		return c.cVoid, nil
+	case "peek_f32":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("peek_f32: 2 args (ptr, byte offset)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cFloat, nil
+	case "peek_i32":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("peek_i32: 2 args (ptr, byte offset)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cInt, nil
 	case "listen", "accept":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("%s: 1 arg", ex.Callee)


### PR DESCRIPTION
## What

The first FFI tier that hands C **raw pointers/arrays** — machin can now build C buffers and structs and pass them to a foreign API. This unlocks GPU vertex buffers: a procedurally generated mesh built in MFL, uploaded to VRAM, and drawn.

- **Raw heap memory** (pointers are `int`s, like `ptr`): `alloc(n)` (zeroed), `free(p)`, `poke_f32`/`poke_i32`/`poke_u8`/`poke_u16`/`poke_ptr(p, byteOffset, v)`, `peek_f32`/`peek_i32(p, byteOffset)`.
- **`*T` FFI param** — the MFL arg is a pointer (`int`); the call dereferences it and passes the pointed-to C struct **by value**: `fn LoadModelFromMesh(*Mesh) Model`. Pass the pointer itself with `ptr` (`void*` → any `T*`), so an in/out `UploadMesh(Mesh*)` writes back into the buffer.

Verified end to end by [machin-demo-planet](https://github.com/javimosch/machin-demo-planet) — `Mesh uploaded successfully to VRAM (GPU)`, a curved planet-surface chunk drawn from a GPU-resident mesh.

## How

- `codegen.go` — `mfl_raw_alloc`/`free`/`poke_*`/`peek_*` C runtime; builtin emission; `*T` arg marshaling `(*(T*)(intptr_t)(arg))`.
- `types.go` — raw-memory builtin typing; `ffiSlot`/`ffiTypeOK` accept `*T` (arg is an int ptr).
- `parser.go` — extern param parsing accepts a leading `*`.
- Docs: guide `memory` builtins + `ffi-raw-buffers` gotcha, SPEC §15, CHANGELOG v0.47.0.

## Test

`TestRawMemory` (alloc/poke/peek round-trip), `TestFFIDerefParam` (the `*T` deref emit); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)