### PR TITLE
feat: noise2/noise3 — native Perlin gradient noise (v0.49.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.49.0
+
+- **`noise2` / `noise3` — native Perlin gradient noise.** Deterministic, ~`[-1,1]`,
+  smooth/continuous; 2D and 3D. The backbone of procedural worlds — layer it (fbm,
+  in MFL) for terrain, animate 2D noise over time with `noise3`. Pure C + libm's
+  `floor`; the runtime is emitted and `-lm` linked only when used. Drove a full
+  procedural planet ([machin-demo-cyberpunk](https://github.com/javimosch/machin-demo-cyberpunk)):
+  infinite chunk-streamed terrain + procedurally placed buildings, all from noise.
+
 ## v0.48.0
 
 - **Pointer-bearing `cstruct` fields + inout `T*` params.** Two follow-ups to the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.48.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.49.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.48.0
+Version 0.49.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -256,6 +256,7 @@ throughout the function body).
 | `int` | `(number) -> int` | truncate to int |
 | `float` | `(number) -> float` | `int` → `float` (identity on `float`); there is no implicit `int`→`float`, so a concrete `int` needs this to enter float arithmetic |
 | math | `(number[, number]) -> float` | native libm (linked `-lm` only when used): `sin` `cos` `tan` `asin` `acos` `atan` `atan2` `sqrt` `cbrt` `pow` `exp` `log` `log2` `log10` `floor` `ceil` `round` `trunc` `abs` `fmod` `hypot`, and `pi()`. Numeric in, `float` out. An `extern` of the same name shadows the builtin. |
+| `noise2`/`noise3` | `(number, ...) -> float` | Perlin gradient noise (2D / 3D), deterministic, ~`[-1,1]`, smooth. Layer it (fbm) for procedural terrain. Links `-lm`; emitted only when used. |
 | `append` | `([]T, T) -> []T` | grow a slice |
 | `has`, `delete` | `(map, K) -> bool` / `-> ` | membership / removal |
 | `keys` | `(map[K]V) -> []K` | a map's keys |

--- a/build.go
+++ b/build.go
@@ -54,8 +54,8 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 	if strings.Contains(csrc, "mfl_sqlite_") {
 		libs = append(libs, "-lsqlite3")
 	}
-	// native math (sin/cos/sqrt/...) links libm — only when a math builtin is used.
-	if strings.Contains(csrc, "mfl_math_") {
+	// native math (sin/cos/sqrt/...) and Perlin noise both link libm — only when used.
+	if strings.Contains(csrc, "mfl_math_") || strings.Contains(csrc, "mfl_noise") {
 		libs = append(libs, "-lm")
 	}
 	// crypto builtins (rand/sha/hmac/hkdf/x25519/ed25519/aes) link OpenSSL

--- a/codegen.go
+++ b/codegen.go
@@ -68,6 +68,7 @@ type cgen struct {
 	usesCrypto bool  // program calls crypto builtins -> emit crypto runtime + link -lcrypto
 	usesXEdDSA bool  // program calls xeddsa_* -> emit XEdDSA runtime + link -lsodium -lcrypto
 	usesMath  bool   // program calls math builtins (sin/cos/sqrt/...) -> emit math runtime + link -lm
+	usesNoise bool   // program calls noise2/noise3 -> emit Perlin noise runtime + link -lm
 }
 
 const cRuntime = `#define _GNU_SOURCE
@@ -1498,6 +1499,40 @@ static int64_t mfl_wss_close(int64_t h) {
 }
 `
 
+// noiseRuntime is Ken Perlin's improved gradient noise (3D; noise2 is the z=0
+// slice), emitted (and linked -lm for floor) only when a program calls noise*.
+// Deterministic — a fixed permutation. Range ~[-1, 1]. Layer it (fbm) in MFL.
+const noiseRuntime = `#include <math.h>
+static int mfl_nperm[512];
+static int mfl_nperm_done = 0;
+static void mfl_noise_init(void) {
+    static const int p[256] = {151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180};
+    for (int i = 0; i < 256; i++) { mfl_nperm[i] = p[i]; mfl_nperm[256 + i] = p[i]; }
+    mfl_nperm_done = 1;
+}
+static double mfl_nfade(double t) { return t * t * t * (t * (t * 6 - 15) + 10); }
+static double mfl_nlerp(double t, double a, double b) { return a + t * (b - a); }
+static double mfl_ngrad(int hash, double x, double y, double z) {
+    int h = hash & 15;
+    double u = h < 8 ? x : y;
+    double v = h < 4 ? y : (h == 12 || h == 14 ? x : z);
+    return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
+}
+static double mfl_noise3(double x, double y, double z) {
+    if (!mfl_nperm_done) mfl_noise_init();
+    int X = (int)floor(x) & 255, Y = (int)floor(y) & 255, Z = (int)floor(z) & 255;
+    x -= floor(x); y -= floor(y); z -= floor(z);
+    double u = mfl_nfade(x), v = mfl_nfade(y), w = mfl_nfade(z);
+    int A = mfl_nperm[X] + Y, AA = mfl_nperm[A] + Z, AB = mfl_nperm[A + 1] + Z;
+    int B = mfl_nperm[X + 1] + Y, BA = mfl_nperm[B] + Z, BB = mfl_nperm[B + 1] + Z;
+    return mfl_nlerp(w, mfl_nlerp(v, mfl_nlerp(u, mfl_ngrad(mfl_nperm[AA], x, y, z), mfl_ngrad(mfl_nperm[BA], x - 1, y, z)),
+                                     mfl_nlerp(u, mfl_ngrad(mfl_nperm[AB], x, y - 1, z), mfl_ngrad(mfl_nperm[BB], x - 1, y - 1, z))),
+                        mfl_nlerp(v, mfl_nlerp(u, mfl_ngrad(mfl_nperm[AA + 1], x, y, z - 1), mfl_ngrad(mfl_nperm[BA + 1], x - 1, y, z - 1)),
+                                     mfl_nlerp(u, mfl_ngrad(mfl_nperm[AB + 1], x, y - 1, z - 1), mfl_ngrad(mfl_nperm[BB + 1], x - 1, y - 1, z - 1))));
+}
+static double mfl_noise2(double x, double y) { return mfl_noise3(x, y, 0.0); }
+`
+
 // mathRuntime is the native floating-point math suite over libm's <math.h>,
 // emitted (and linked -lm) only when a program calls a math builtin. Each is a
 // thin wrapper named mfl_math_<libm-name> on a double; machin's float is double,
@@ -2082,6 +2117,11 @@ func (g *cgen) program(p *Program) (string, error) {
 		// native math (libm) — emitted and linked (-lm) only when a program calls a
 		// math builtin, so math-free programs keep machin's libc-only footprint.
 		out.WriteString(mathRuntime)
+		out.WriteByte('\n')
+	}
+	if g.usesNoise {
+		// Perlin noise (libm for floor) — emitted only when noise2/noise3 is used.
+		out.WriteString(noiseRuntime)
 		out.WriteByte('\n')
 	}
 	if g.usesRegex {
@@ -3706,6 +3746,12 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "pi":
 		g.usesMath = true
 		return "mfl_math_pi()", nil
+	case "noise2":
+		g.usesNoise = true
+		return fmt.Sprintf("mfl_noise2((double)(%s), (double)(%s))", args[0], args[1]), nil
+	case "noise3":
+		g.usesNoise = true
+		return fmt.Sprintf("mfl_noise3((double)(%s), (double)(%s), (double)(%s))", args[0], args[1], args[2]), nil
 	case "alloc":
 		return fmt.Sprintf("mfl_raw_alloc(%s)", args[0]), nil
 	case "free":

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.48.0"
+const machinVersion = "0.49.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -113,6 +113,8 @@ func machinGuide() guideCatalog {
 			{"abs", "(number) -> float", "absolute value (float; fabs)", "math"},
 			{"fmod", "(number, number) -> float", "floating-point remainder of x/y", "math"},
 			{"pi", "() -> float", "the constant pi", "math"},
+			{"noise2", "(number, number) -> float", "Perlin gradient noise (2D), deterministic, ~[-1,1], smooth. Layer it (fbm) by summing octaves at scaled freq/amp", "math"},
+			{"noise3", "(number, number, number) -> float", "Perlin gradient noise (3D) — animate 2D noise over time, or volumetric", "math"},
 			// raw memory (pointers are ints) — build C buffers/structs for the FFI
 			{"alloc", "(int) -> int", "allocate n zeroed bytes; returns a pointer (as int). For C buffers/structs to hand to an extern fn", "memory"},
 			{"free", "(int) ->", "free a pointer returned by alloc", "memory"},
@@ -209,6 +211,8 @@ func machinGuide() guideCatalog {
 			{"bytes", `func main() { b := from_hex("deadbeef")  b = bytes_concat(b, bytes("!"))  println(to_hex(b) + " len=" + str(len(b)) + " b0=" + str(byte_at(b, 0))) }`},
 			{"bitwise", `func main() { x := 0xa5  println(str(x >> 4 & 0x0f) + " " + str(x | 0x100) + " " + str(^x & 0xff)) }`},
 			{"terminal-input", `func main() { raw_mode(1)  esc := bytes_str(from_hex("1b"))  k := read_key()  if k == "q" { print(esc + "[2J") }  raw_mode(0) }`},
+			{"fbm-noise", `func fbm(x, y) (s) { s = 0.0  amp := 1.0  fr := 1.0  o := 0  while o < 5 { s = s + amp * noise2(x * fr, y * fr)  amp = amp * 0.5  fr = fr * 2.0  o = o + 1 } }
+func main() { println(str(fbm(1.5, 2.5))) }`},
 			{"types", `type P struct { name string  age int }
 func main() { p := P{name: "ada", age: 36}  xs := []int{1, 2, 3}  m := make(map[string]int)  m["k"] = 1  println(p.name + " " + str(len(xs)) + " " + str(m["k"])) }`},
 			{"goroutine-channel", `func work(ch) { ch <- 42 }

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -1023,6 +1023,32 @@ func TestNestedCStruct(t *testing.T) {
 	}
 }
 
+// Perlin noise builtins: deterministic, in ~[-1,1], continuous; gated (-lm only
+// when used).
+func TestNoise(t *testing.T) {
+	main := `func main() {
+	a := noise2(3.5, 1.2)
+	b := noise2(3.5, 1.2)
+	ok := "no"  if a == b { ok = "yes" }
+	inr := "no"  if a > 0.0 - 1.0 { if a < 1.0 { inr = "yes" } }
+	near := "no"  d := noise2(3.5, 1.2) - noise2(3.51, 1.2)  if d < 0.2 { if d > 0.0 - 0.2 { near = "yes" } }
+	println(ok + " " + inr + " " + near + " " + str(noise3(0.0, 0.0, 0.0)))
+}`
+	out, _ := buildRun(t, main)
+	// deterministic, in range, continuous; noise3 at the origin is ~0
+	if !strings.HasPrefix(out, "yes yes yes ") {
+		t.Fatalf("noise: got %q", out)
+	}
+	// gated: a noise-free program emits no noise runtime
+	plain, err := CompileToC(&Program{Funcs: parseFuncs(t, `func main() { println("hi") }`)}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(plain, "mfl_noise") {
+		t.Fatal("noise runtime must not be emitted for a noise-free program")
+	}
+}
+
 // float() lifts a concrete int into float arithmetic (the counterpart to int()).
 // MFL has no implicit int->float, so a value typed int (a function return,
 // byte_at, len, ...) can't mix with a float without this.

--- a/types.go
+++ b/types.go
@@ -1902,6 +1902,21 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, fmt.Errorf("pi: no args")
 		}
 		return c.cFloat, nil
+	case "noise2":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("noise2: 2 args (x, y)")
+		}
+		c.addPair(argSlots[0], newSlot(c, KNum))
+		c.addPair(argSlots[1], newSlot(c, KNum))
+		return c.cFloat, nil
+	case "noise3":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("noise3: 3 args (x, y, z)")
+		}
+		c.addPair(argSlots[0], newSlot(c, KNum))
+		c.addPair(argSlots[1], newSlot(c, KNum))
+		c.addPair(argSlots[2], newSlot(c, KNum))
+		return c.cFloat, nil
 	// raw heap memory: pointers are ints. For building C buffers/structs to hand
 	// to a foreign API (e.g. a GPU vertex buffer via the FFI).
 	case "alloc":


### PR DESCRIPTION
## What

Native **Perlin gradient noise**: `noise2(x, y)` and `noise3(x, y, z)` — deterministic, ~`[-1,1]`, smooth/continuous. The backbone of procedural worlds: layer it (fbm) in MFL for terrain; animate 2D noise over time with `noise3`.

## How

Ken Perlin's improved-noise (3D; `noise2` is the `z=0` slice), a fixed permutation. Pure C + libm's `floor`; the `noiseRuntime` block and `-lm` are emitted **only when `noise2`/`noise3` is used** (verified: noise-free programs emit no `mfl_noise`).

## Changes

- `codegen.go` — `noiseRuntime`, `usesNoise`, builtin emission.
- `types.go` — `noise2`/`noise3` typing (numeric in, float out).
- `build.go` — link `-lm` on the `mfl_noise` marker.
- Docs: guide `noise2`/`noise3` builtins + an `fbm-noise` idiom, SPEC math table, CHANGELOG v0.49.0.

## Test

`TestNoise` (determinism, in-range, continuity, gating); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)