### PR TITLE
v0.50.0: --target wasm — compile machin to WebAssembly (frontend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.50.0
+
+- **`--target wasm` — machin compiles to WebAssembly (frontend / in-browser).**
+  `machin build app.mfl --target wasm` cross-compiles the emitted C to a
+  `wasm32-wasi` **reactor** module via `zig cc` (zig bundles clang + a wasi-libc,
+  so it is a single-binary C→wasm toolchain — no emscripten/wasi-sdk; override
+  with `ZIG=`). The module loads in a bare browser; the bridge is machin's own
+  **FFI, both ways**:
+  - **`export func name(...)`** — a new keyword that marks a function as a wasm
+    **export** (and a reachability root, kept even if `main` never calls it). The
+    host calls `instance.exports.name(...)`; the export carries an `export_name`
+    attribute so JS sees the clean source name, not the mangled C symbol. A wasm
+    module needs **no `main`** — an export is its own entry point.
+  - **`extern "env" { fn set_html(string) }`** — under the wasm target a headerless
+    extern becomes a wasm **import** (`import_module`/`import_name`) the host (JS)
+    supplies, e.g. a DOM call. The `extern "<lib>"` name is the import module
+    (default `env`).
+  - Marshaling: machin ints are i64 ⇒ `BigInt` across the boundary; strings cross
+    as a pointer into the exported `memory` (decode NUL-terminated UTF-8 host-side).
+- **The POSIX socket/tty runtime is now pay-as-you-go.** The networking
+  (`listen`/`accept`/`dial`/`read`/`write`/`close`) and terminal
+  (`raw_mode`/`read_key`) runtimes are split out of the always-on core. The
+  **native** target is unchanged (it always carries them, and still emits `int
+  main`); the **wasm** target emits each only when the program actually uses it,
+  so a frontend module references no `socket()`/`termios` symbols (which wasi-libc
+  doesn't fully provide) and compiles clean — the same `usesX` gating machin
+  already does for TLS/WebSocket/regex/math/SQLite. Drove
+  [machin-demo-wasm](https://github.com/javimosch/machin-demo-wasm); see
+  `docs/NORTH-STAR-WEB.md`. Still ahead for a richer frontend: package-level
+  globals (state lives host-side today) and a shipped JS string/array runtime.
+
 ## v0.49.0
 
 - **`noise2` / `noise3` — native Perlin gradient noise.** Deterministic, ~`[-1,1]`,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.49.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.50.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.49.0
+Version 0.50.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -80,7 +80,7 @@ The decoded text of a declaration is tokenized as follows.
 - **Float literals.** digits with a `.`, e.g. `3.14`, `0.5`.
 - **String literals.** `"..."` with escapes `\n \t \r \" \\`.
 - **Keywords.** `func return if else while for range true false nil var go type
-  struct chan make map arena extern break continue select`.
+  struct chan make map arena extern export break continue select`.
 - **Operators and punctuation.** `+ - * / % & | ^ << >> == != < <= > >= && || ! = := <- .
   : , ; ( ) { } [ ]`.
 
@@ -439,19 +439,30 @@ id(42); id("hi"); id(3.14)   // → three native functions
 
 ```
 .mfl (canonical text) ──▶ parse ──▶ lambda-lift ──▶ infer + monomorphize ──▶ emit C ──▶ cc -O2 ──▶ native binary
+                                                                                   └──▶ zig cc (wasm32-wasi) ──▶ .wasm
 ```
 
 - **Inference** is unification over a union-find; deferred resolution handles
   `x[i]`, `x.f`, and `range` once the base type is known.
-- **Monomorphization** instantiates the reachable call graph from `main`,
-  specializing each function per concrete type and deduplicating identical
-  instances.
+- **Monomorphization** instantiates the reachable call graph from `main` and from
+  every `export func` root, specializing each function per concrete type and
+  deduplicating identical instances.
 - **Codegen** emits one C function per instance with unboxed value types, plus a
   small C runtime (slices, maps, channels, closures, sockets, JSON, strings).
   `https_get`/`https_post` and `wss_open`/`wss_send`/`wss_recv`/`wss_close`
   additionally emit a TLS runtime (HTTPS and/or RFC 6455 WebSocket framing over a
   shared TLS core) and link OpenSSL (`-lssl -lcrypto`) — but only when used, so
   programs that touch neither stay libc-only.
+- **Targets.** The default target is a native binary via `cc -O2`. `machin build
+  --target wasm` instead emits a WebAssembly module (`wasm32-wasi`, reactor model)
+  via `zig cc` — zig bundles clang + a wasi-libc, so it is a single-binary C→wasm
+  toolchain (override with `ZIG=`). For the wasm target: each `export func`
+  becomes a wasm export (under its source name, via an `export_name` attribute)
+  and a reachability root, so a module needs no `main`; a headerless `extern
+  "<mod>"` becomes a wasm import the host supplies (`import_module`/`import_name`);
+  and the POSIX socket/tty runtime is emitted only when used (so a frontend module
+  references no `socket()`/`termios`). machin ints are i64 (`BigInt` across the JS
+  boundary); strings are pointers into the exported `memory`.
 
 ---
 

--- a/ast.go
+++ b/ast.go
@@ -305,6 +305,10 @@ type FuncDecl struct {
 	// Variadic marks the last parameter as variadic: it collects trailing call
 	// arguments into a slice.
 	Variadic bool
+	// Exported marks a function declared `export func ...`: it is a reachability
+	// root (kept even if main never calls it) and, under the wasm target, becomes
+	// a WebAssembly export the host (JS) can call. A no-op for the native target.
+	Exported bool
 	// IsLambda marks a lifted lambda: it is always invoked via the closure
 	// convention (a leading void* env), and its first NumCaptures params are
 	// captured variables, supplied at runtime from that heap environment.

--- a/build.go
+++ b/build.go
@@ -78,6 +78,51 @@ func BuildBinary(prog *Program, outPath string, safe bool) error {
 	return nil
 }
 
+// zigPath is the C->wasm cross compiler. zig ships clang + a wasi-libc, so it is
+// a single-binary toolchain (no emscripten / wasi-sdk needed). Override with ZIG.
+func zigPath() string {
+	if z := os.Getenv("ZIG"); z != "" {
+		return z
+	}
+	return "zig"
+}
+
+// BuildWasm compiles the program to a WebAssembly module at outPath, targeting
+// wasm32-wasi in *reactor* model (no _start: the host drives it through the
+// exported functions). The emitted C tags FFI imports as wasm imports and omits
+// the POSIX socket/tty runtime unless used, so a frontend module loads in a bare
+// browser with only its `extern "env"` host functions as imports. Each `export
+// func` is handed to the linker as a wasm export.
+func BuildWasm(prog *Program, outPath string, safe bool) error {
+	csrc, exports, err := CompileToCTarget(prog, safe, targetWasm)
+	if err != nil {
+		return err
+	}
+	if len(exports) == 0 {
+		return fmt.Errorf("wasm target: no exported functions — mark at least one with `export func`")
+	}
+	tmp, err := os.CreateTemp("", "mfl-*.c")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(csrc); err != nil {
+		return err
+	}
+	tmp.Close()
+
+	// Each exported function carries an export_name attribute (emitted by codegen),
+	// which forces its export under the clean source name — so no --export flags.
+	_ = exports
+	args := []string{"cc", "-target", "wasm32-wasi", "-mexec-model=reactor", "-O2", "-std=c11", "-o", outPath, tmp.Name()}
+
+	cmd := exec.Command(zigPath(), args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s failed: %v\n%s", zigPath(), err, out)
+	}
+	return nil
+}
+
 // RunCaptured builds the program to a temp binary, runs it, and returns stdout.
 func RunCaptured(prog *Program) (string, error) {
 	bin, err := os.CreateTemp("", "mfl-bin-*")

--- a/codegen.go
+++ b/codegen.go
@@ -10,13 +10,30 @@ import (
 // `cc -O2`, so MFL's runtime cost is whatever the C compiler's optimizer
 // produces — native, on par with C/Rust/Zig for scalar code.
 func CompileToC(p *Program, safe bool) (string, error) {
+	src, _, err := CompileToCTarget(p, safe, targetNative)
+	return src, err
+}
+
+// CompileToCTarget compiles to C for a given target ("native" or "wasm"). For
+// the wasm target it also returns the C names of the program's `export func`s
+// (the symbols the wasm linker exports). The emitted C differs by target: a wasm
+// build tags FFI imports with wasm import attributes, omits the POSIX socket/tty
+// runtime unless used, and omits the native `int main` entry point.
+func CompileToCTarget(p *Program, safe bool, target string) (string, []string, error) {
+	if target == "" {
+		target = targetNative
+	}
 	liftClosures(p) // idempotent: a no-op once literals are already lifted
 	c, err := Check(p)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	g := &cgen{c: c, safe: safe, jsonMemo: map[string]string{}, parseMemo: map[string]string{}, chanJSONMemo: map[string][2]string{}}
-	return g.program(p)
+	g := &cgen{c: c, safe: safe, target: target, jsonMemo: map[string]string{}, parseMemo: map[string]string{}, chanJSONMemo: map[string][2]string{}}
+	src, err := g.program(p)
+	if err != nil {
+		return "", nil, err
+	}
+	return src, c.ExportNames(), nil
 }
 
 // cTypeName renders a declared type string (int, float, bool, string, []elem,
@@ -69,7 +86,18 @@ type cgen struct {
 	usesXEdDSA bool  // program calls xeddsa_* -> emit XEdDSA runtime + link -lsodium -lcrypto
 	usesMath  bool   // program calls math builtins (sin/cos/sqrt/...) -> emit math runtime + link -lm
 	usesNoise bool   // program calls noise2/noise3 -> emit Perlin noise runtime + link -lm
+	usesNet   bool   // program calls dial/listen/accept/read/write/close(fd) -> emit POSIX socket runtime
+	usesTTY   bool   // program calls raw_mode/read_key -> emit termios/select runtime
+	target    string // "" or "native" (default) -> cc; "wasm" -> zig cc, lean runtime, FFI as imports, exports
 }
+
+// build targets.
+const (
+	targetNative = "native"
+	targetWasm   = "wasm"
+)
+
+func (g *cgen) wasm() bool { return g.target == targetWasm }
 
 const cRuntime = `#define _GNU_SOURCE
 #include <stdio.h>
@@ -690,45 +718,6 @@ static char* mfl_join(mfl_slice xs, const char* sep) {
     return r;
 }
 
-/* networking: the low-level shape of Go's net package */
-static int64_t mfl_listen(int64_t port) {
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
-    int opt = 1; setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-    struct sockaddr_in a; memset(&a, 0, sizeof(a));
-    a.sin_family = AF_INET; a.sin_addr.s_addr = INADDR_ANY; a.sin_port = htons((uint16_t)port);
-    if (bind(fd, (struct sockaddr*)&a, sizeof(a)) < 0) { perror("bind"); exit(1); }
-    if (listen(fd, 64) < 0) { perror("listen"); exit(1); }
-    return fd;
-}
-static int64_t mfl_accept(int64_t fd) { return accept((int)fd, NULL, NULL); }
-/* dial: connect a TCP socket to host:port, returning an fd (-1 on failure).
-   The fd is used with the same read/write/close as an accepted connection. */
-static int64_t mfl_dial(const char* host, int64_t port) {
-    struct addrinfo hints, *res, *rp;
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC; hints.ai_socktype = SOCK_STREAM;
-    char ps[16]; snprintf(ps, sizeof(ps), "%lld", (long long)port);
-    if (getaddrinfo(host, ps, &hints, &res) != 0) return -1;
-    int fd = -1;
-    for (rp = res; rp; rp = rp->ai_next) {
-        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-        if (fd < 0) continue;
-        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) break;
-        close(fd); fd = -1;
-    }
-    freeaddrinfo(res);
-    return fd;
-}
-static char* mfl_read(int64_t fd) {
-    char* buf = mfl_alloc(65536);
-    ssize_t n = read((int)fd, buf, 65535);
-    if (n < 0) n = 0;
-    buf[n] = 0;
-    return buf;
-}
-static int64_t mfl_write(int64_t fd, const char* s) { return (int64_t)write((int)fd, s, strlen(s)); }
-static void mfl_close(int64_t fd) { close((int)fd); }
-
 /* read one line from stdin (without the trailing newline); "" at EOF */
 static char* mfl_input(void) {
     size_t cap = 128, len = 0;
@@ -739,47 +728,6 @@ static char* mfl_input(void) {
         buf[len++] = (char)c;
     }
     buf[len] = 0;
-    return buf;
-}
-/* terminal raw mode + non-blocking single-key read (for TUIs and games).
-   raw_mode(1) puts the tty in cbreak + no-echo with VMIN=0/VTIME=0 so reads
-   never block; raw_mode(0) restores the saved settings. */
-static struct termios mfl_tty_saved;
-static int mfl_tty_raw = 0;
-static int64_t mfl_raw_mode(int64_t on) {
-    if (on) {
-        if (mfl_tty_raw) return 0;
-        struct termios t;
-        if (tcgetattr(STDIN_FILENO, &t) != 0) return -1;
-        mfl_tty_saved = t;
-        t.c_lflag &= ~(ICANON | ECHO);
-        t.c_cc[VMIN] = 0;
-        t.c_cc[VTIME] = 0;
-        if (tcsetattr(STDIN_FILENO, TCSANOW, &t) != 0) return -1;
-        mfl_tty_raw = 1;
-    } else {
-        if (!mfl_tty_raw) return 0;
-        tcsetattr(STDIN_FILENO, TCSANOW, &mfl_tty_saved);
-        mfl_tty_raw = 0;
-    }
-    return 0;
-}
-/* non-blocking read of one key; a 1-char string, or "" if nothing is waiting.
-   In raw mode VMIN=0 already makes read() return immediately; otherwise poll
-   with select() so we never block. */
-static char* mfl_read_key(void) {
-    char* buf = mfl_alloc(2);
-    buf[0] = 0; buf[1] = 0;
-    unsigned char c = 0;
-    if (mfl_tty_raw) {
-        if (read(STDIN_FILENO, &c, 1) == 1) buf[0] = (char)c;
-    } else {
-        fd_set fds; FD_ZERO(&fds); FD_SET(STDIN_FILENO, &fds);
-        struct timeval tv; tv.tv_sec = 0; tv.tv_usec = 0;
-        if (select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv) > 0) {
-            if (read(STDIN_FILENO, &c, 1) == 1) buf[0] = (char)c;
-        }
-    }
     return buf;
 }
 /* read all of stdin verbatim until EOF (no line splitting). Exact for text;
@@ -1020,6 +968,97 @@ static mfl_json_result mfl_json_get(const char* json, const char* path) {
     if (!end) { R.err = mfl_dup_arena("parse", 5); return R; }
     R.value = mfl_dup_arena(cur, (size_t)(end - cur));
     return R;
+}
+`
+
+// netRuntime is the POSIX socket layer (Go's net package, low-level): listen/
+// accept/dial/read/write/close over TCP fds. Part of the always-on runtime for
+// the native target; under the wasm target it is emitted only when the program
+// actually calls one of these builtins (a frontend app that touches no sockets
+// then references no POSIX networking symbols at all).
+const netRuntime = `/* networking: the low-level shape of Go's net package */
+static int64_t mfl_listen(int64_t port) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    int opt = 1; setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    struct sockaddr_in a; memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET; a.sin_addr.s_addr = INADDR_ANY; a.sin_port = htons((uint16_t)port);
+    if (bind(fd, (struct sockaddr*)&a, sizeof(a)) < 0) { perror("bind"); exit(1); }
+    if (listen(fd, 64) < 0) { perror("listen"); exit(1); }
+    return fd;
+}
+static int64_t mfl_accept(int64_t fd) { return accept((int)fd, NULL, NULL); }
+/* dial: connect a TCP socket to host:port, returning an fd (-1 on failure).
+   The fd is used with the same read/write/close as an accepted connection. */
+static int64_t mfl_dial(const char* host, int64_t port) {
+    struct addrinfo hints, *res, *rp;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC; hints.ai_socktype = SOCK_STREAM;
+    char ps[16]; snprintf(ps, sizeof(ps), "%lld", (long long)port);
+    if (getaddrinfo(host, ps, &hints, &res) != 0) return -1;
+    int fd = -1;
+    for (rp = res; rp; rp = rp->ai_next) {
+        fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) continue;
+        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) break;
+        close(fd); fd = -1;
+    }
+    freeaddrinfo(res);
+    return fd;
+}
+static char* mfl_read(int64_t fd) {
+    char* buf = mfl_alloc(65536);
+    ssize_t n = read((int)fd, buf, 65535);
+    if (n < 0) n = 0;
+    buf[n] = 0;
+    return buf;
+}
+static int64_t mfl_write(int64_t fd, const char* s) { return (int64_t)write((int)fd, s, strlen(s)); }
+static void mfl_close(int64_t fd) { close((int)fd); }
+`
+
+// ttyRuntime is terminal raw mode + non-blocking single-key reads (termios +
+// select), for TUIs and terminal games. Always-on for native; under wasm emitted
+// only when raw_mode/read_key is used (a browser app references neither).
+const ttyRuntime = `/* terminal raw mode + non-blocking single-key read (for TUIs and games).
+   raw_mode(1) puts the tty in cbreak + no-echo with VMIN=0/VTIME=0 so reads
+   never block; raw_mode(0) restores the saved settings. */
+static struct termios mfl_tty_saved;
+static int mfl_tty_raw = 0;
+static int64_t mfl_raw_mode(int64_t on) {
+    if (on) {
+        if (mfl_tty_raw) return 0;
+        struct termios t;
+        if (tcgetattr(STDIN_FILENO, &t) != 0) return -1;
+        mfl_tty_saved = t;
+        t.c_lflag &= ~(ICANON | ECHO);
+        t.c_cc[VMIN] = 0;
+        t.c_cc[VTIME] = 0;
+        if (tcsetattr(STDIN_FILENO, TCSANOW, &t) != 0) return -1;
+        mfl_tty_raw = 1;
+    } else {
+        if (!mfl_tty_raw) return 0;
+        tcsetattr(STDIN_FILENO, TCSANOW, &mfl_tty_saved);
+        mfl_tty_raw = 0;
+    }
+    return 0;
+}
+/* non-blocking read of one key; a 1-char string, or "" if nothing is waiting.
+   In raw mode VMIN=0 already makes read() return immediately; otherwise poll
+   with select() so we never block. */
+static char* mfl_read_key(void) {
+    char* buf = mfl_alloc(2);
+    buf[0] = 0; buf[1] = 0;
+    unsigned char c = 0;
+    if (mfl_tty_raw) {
+        if (read(STDIN_FILENO, &c, 1) == 1) buf[0] = (char)c;
+    } else {
+        fd_set fds; FD_ZERO(&fds); FD_SET(STDIN_FILENO, &fds);
+        struct timeval tv; tv.tv_sec = 0; tv.tv_usec = 0;
+        if (select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv) > 0) {
+            if (read(STDIN_FILENO, &c, 1) == 1) buf[0] = (char)c;
+        }
+    }
+    return buf;
 }
 `
 
@@ -2099,6 +2138,17 @@ func (g *cgen) program(p *Program) (string, error) {
 	var out strings.Builder
 	out.WriteString(cRuntime)
 	out.WriteByte('\n')
+	// POSIX socket + tty runtimes: always present for the native target; for the
+	// wasm target emitted only when actually used, so a browser app pulls in no
+	// socket/termios symbols (which wasi-libc does not fully provide).
+	if !g.wasm() || g.usesNet {
+		out.WriteString(netRuntime)
+		out.WriteByte('\n')
+	}
+	if !g.wasm() || g.usesTTY {
+		out.WriteString(ttyRuntime)
+		out.WriteByte('\n')
+	}
 	if g.usesTLS || g.usesWSS {
 		// OpenSSL plumbing — emitted (and linked) only when a program uses native
 		// TLS (https_* or wss_*), so TLS-free programs stay libc-only.
@@ -2172,7 +2222,18 @@ func (g *cgen) program(p *Program) (string, error) {
 			if ps == "" {
 				ps = "void"
 			}
-			fmt.Fprintf(&out, "extern %s %s(%s);\n", externCType(ef.Ret), ef.Name, ps)
+			// Under the wasm target a headerless extern is a host (JS) function: tag
+			// it as a wasm import so the linker leaves it undefined for the host to
+			// supply. The `extern "<lib>"` name is the import module (default "env").
+			var attr string
+			if g.wasm() && ed.Header == "" {
+				mod := ed.Lib
+				if mod == "" {
+					mod = "env"
+				}
+				attr = fmt.Sprintf("__attribute__((import_module(%q), import_name(%q))) ", mod, ef.Name)
+			}
+			fmt.Fprintf(&out, "%sextern %s %s(%s);\n", attr, externCType(ef.Ret), ef.Name, ps)
 		}
 	}
 	// struct typedefs, in declaration order (a struct may reference earlier ones)
@@ -2260,12 +2321,25 @@ func (g *cgen) program(p *Program) (string, error) {
 		out.WriteByte('\n')
 	}
 	for _, inst := range g.c.Reps() {
+		// Under wasm, an `export func` is exported to the host under its clean source
+		// name (so JS calls instance.exports.render, not the mangled C symbol). The
+		// attribute on the prototype also forces the export — no linker flag needed.
+		if g.wasm() {
+			if src := g.c.SrcFunc(inst); g.c.exportSrc[src.Name] {
+				fmt.Fprintf(&out, "__attribute__((export_name(%q))) ", src.Name)
+			}
+		}
 		out.WriteString(g.signature(inst) + ";\n")
 	}
 	out.WriteByte('\n')
 	out.WriteString(g.tramp.String())
 	out.WriteString(g.buf.String())
-	out.WriteString("int main(int argc, char** argv) { mfl_argc = argc; mfl_argv = argv; mfl_main(); return 0; }\n")
+	// Native entry point. The wasm target is a reactor module (no `int main`): the
+	// host drives it through the exported functions, so emit the C main only for
+	// native, and only when the program actually defines an MFL main.
+	if !g.wasm() && g.c.HasMain() {
+		out.WriteString("int main(int argc, char** argv) { mfl_argc = argc; mfl_argv = argv; mfl_main(); return 0; }\n")
+	}
 	return out.String(), nil
 }
 
@@ -3674,8 +3748,10 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "flush":
 		return "mfl_flush()", nil
 	case "raw_mode":
+		g.usesTTY = true
 		return fmt.Sprintf("mfl_raw_mode(%s)", args[0]), nil
 	case "read_key":
+		g.usesTTY = true
 		return "mfl_read_key()", nil
 	case "base64_encode":
 		return fmt.Sprintf("mfl_base64_encode(%s)", args[0]), nil
@@ -3761,19 +3837,25 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "peek_f32", "peek_i32":
 		return fmt.Sprintf("mfl_%s(%s, %s)", ex.Callee, args[0], args[1]), nil
 	case "dial":
+		g.usesNet = true
 		return fmt.Sprintf("mfl_dial(%s, %s)", args[0], args[1]), nil
 	case "listen":
+		g.usesNet = true
 		return fmt.Sprintf("mfl_listen(%s)", args[0]), nil
 	case "accept":
+		g.usesNet = true
 		return fmt.Sprintf("mfl_accept(%s)", args[0]), nil
 	case "read":
+		g.usesNet = true
 		return fmt.Sprintf("mfl_read(%s)", args[0]), nil
 	case "write":
+		g.usesNet = true
 		return fmt.Sprintf("mfl_write(%s, %s)", args[0], args[1]), nil
 	case "close":
 		if g.c.NodeKind(g.curFn, ex.Args[0]) == KChan {
 			return fmt.Sprintf("mfl_chan_close(%s)", args[0]), nil
 		}
+		g.usesNet = true
 		return fmt.Sprintf("mfl_close(%s)", args[0]), nil
 	case "input":
 		return "mfl_input()", nil

--- a/docs/NORTH-STAR-WEB.md
+++ b/docs/NORTH-STAR-WEB.md
@@ -37,32 +37,34 @@ north star is to make it first-class.
 
 | capability | repo | what it proved |
 |---|---|---|
-| **MFL in the browser** | [machin-demo-wasm](https://github.com/javimosch/machin-demo-wasm) | MFL → C → `zig cc` wasm; FFI-as-import DOM bridge; string marshaling; verified on-screen in Chrome |
+| **`--target wasm` (first-class, v0.50.0)** | this repo | `machin build --target wasm` → a `wasm32-wasi` reactor module via `zig cc`; `export func` + FFI-as-import bridge built into codegen; lean pay-as-you-go runtime |
+| **MFL in the browser** | [machin-demo-wasm](https://github.com/javimosch/machin-demo-wasm) | MFL → C → wasm; FFI-as-import DOM bridge; string marshaling; verified on-screen in Chrome |
 | backend web framework | [`framework/machweb.src`](../framework) | `serve(port, handler)` → self-contained native server |
 
 ## The feature roadmap (gaps, in rough dependency order)
 
-Each is a candidate to be *driven by a demo*, not built speculatively. The demo
-above already names the first four — its `build.sh` papers over each:
+Each is a candidate to be *driven by a demo*, not built speculatively. The first
+five shipped in **v0.50.0** (`--target wasm`); the rest remain.
 
-1. **A `--target wasm` codegen mode.** The core C runtime unconditionally
-   references POSIX **networking/tty** symbols (`socket`, `SO_REUSEADDR`,
-   `termios`, pthreads). A frontend app calls none of them. Make that runtime
-   **pay-as-you-go** — machin already gates `usesWSS` / `usesRegex` / `usesMath` /
-   `usesNoise` / `usesSQLite` this way, so the same pattern applied to
-   networking/tty/goroutines yields a lean, freestanding-friendly emit. This is
-   the keystone; everything else is small.
-2. **Emit wasm-import attributes.** Under the wasm target, an FFI `extern` should
-   emit `__attribute__((import_module("env"), import_name("...")))` instead of a
-   bare prototype, so host functions become proper wasm imports automatically.
-3. **An `export` annotation.** Mark which MFL functions are wasm exports (and keep
-   them through tree-shaking) without needing a dummy `main` to reference them.
-4. **Package-level mutable state.** MFL has no top-level `var`; today the JS host
+1. ~~**A `--target wasm` codegen mode.**~~ **Done (v0.50.0).** The POSIX
+   networking (`listen`/`accept`/`dial`/`read`/`write`/`close`) and tty
+   (`raw_mode`/`read_key`) runtimes are split out of the always-on core and made
+   **pay-as-you-go** — the same `usesX` gating used for TLS/WSS/regex/math/SQLite.
+   Native is unchanged; a wasm build references no `socket()`/`termios`, so it
+   links clean. The keystone.
+2. ~~**Emit wasm-import attributes.**~~ **Done (v0.50.0).** Under the wasm target a
+   headerless `extern "<mod>"` emits `__attribute__((import_module, import_name))`,
+   so host functions are proper wasm imports automatically.
+3. ~~**An `export` annotation.**~~ **Done (v0.50.0).** `export func` marks a wasm
+   export (under its clean source name via `export_name`) and a reachability root,
+   so a module needs no dummy `main`.
+4. ~~**A `machin build --target wasm` driver.**~~ **Done (v0.50.0).** The `zig cc`
+   invocation is folded into the compiler (`BuildWasm`), so `app.wasm` falls out of
+   one command (`ZIG=` overrides the toolchain).
+5. **Package-level mutable state.** MFL has no top-level `var`; today the JS host
    owns app state. Either add globals, or settle on a **handle-based** pattern
-   (`alloc` a state struct, return the pointer, pass it back into each call).
-5. **A `machin build --target wasm` driver.** Fold the `zig cc` invocation into
-   the compiler (like `BuildBinary` does for native), auto-detecting/honoring a
-   `zig`/wasi toolchain, so `app.wasm` falls out of one command.
+   (`alloc` a state struct, return the pointer, pass it back into each call). The
+   next gap to drive.
 6. **String/array marshaling helpers.** A small JS runtime shipped with the
    target (decode/encode strings, pass slices) so apps don't re-roll `readCString`.
 
@@ -92,8 +94,10 @@ is written once. A stretch goal, listed as a direction, not a plan.
 ## Method
 
 Same loop as the rest of machin: build a real thing, hit the wall, fill it in the
-language, release, record. The frontend's first wall is already standing and
-named — the unconditionally-POSIX core runtime (gap #1). Be honest about
+language, release, record. The frontend's first wall — the unconditionally-POSIX
+core runtime — was hit by [machin-demo-wasm](https://github.com/javimosch/machin-demo-wasm)
+and filled in **v0.50.0** (`--target wasm`); the next wall is package-level state
+(gap #5), to be named by the next demo. Be honest about
 **composition vs. new feature**: that the FFI *already* doubles as the wasm
 import/export bridge is composition, and itself the headline result — machin
 reaches the browser with no new language primitive, only a leaner emit.

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.49.0"
+const machinVersion = "0.50.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -55,7 +55,7 @@ func machinGuide() guideCatalog {
 		Keywords: []string{
 			"func", "return", "if", "else", "while", "for", "range", "break", "continue",
 			"select", "go", "chan", "make", "map", "struct", "type", "var", "arena",
-			"extern", "true", "false", "nil",
+			"extern", "export", "true", "false", "nil",
 		},
 		Types: []guideNote{
 			{"int", "64-bit signed"},
@@ -264,6 +264,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"no-tls-without-https", "There is no raw TLS socket; use https_get/https_post (REST) and wss_* (WebSocket). Plain dial/listen are TCP without TLS."},
 			{"floats-over-chan-json", "A slice/map channel element round-trips through JSON, which formats floats with %g (not bit-exact for pathological doubles)."},
 			{"memory", "Per-goroutine arena, reclaimed in bulk when the goroutine returns; wrap a hot allocating loop in `arena { ... }` to keep peak memory flat. Build with --safe for bounds/overflow/div-zero checks."},
+			{"wasm-target", "`machin build app.mfl --target wasm` compiles to a WebAssembly reactor module (needs `zig` as the C->wasm compiler; override with ZIG=). Mark host-callable functions `export func name(...)` — they become wasm exports under their clean name (and are reachability roots, so a wasm module needs no main). A headerless `extern \"env\" { fn dom_set(string) }` becomes a wasm IMPORT the JS host supplies (the `extern \"<lib>\"` name is the import module). Marshaling host-side: machin ints are i64 -> pass/return BigInt; strings are a pointer into the exported `memory` (decode NUL-terminated UTF-8). No package globals yet, so app state lives host-side. See docs/NORTH-STAR-WEB.md."},
 		},
 	}
 }

--- a/lexer.go
+++ b/lexer.go
@@ -29,7 +29,7 @@ var keywords = map[string]bool{
 	"while": true, "for": true, "true": true, "false": true,
 	"nil": true, "var": true, "go": true, "type": true, "struct": true,
 	"chan": true, "make": true, "map": true, "range": true,
-	"arena": true, "extern": true,
+	"arena": true, "extern": true, "export": true,
 	"break": true, "continue": true, "select": true,
 }
 

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func usage() {
 usage:
   machin run   <file.mfl>            compile to native + execute
   machin build <file.mfl> [-o out]   compile to a native binary
+  machin build <file.mfl> --target wasm  compile to a WebAssembly module (needs zig; mark exports with export func)
   machin build <file.mfl> --emit-c   print the generated C and stop
   machin build|run <file.mfl> --safe  insert bounds / div-zero / overflow checks
   machin encode <src>                mint canonical MFL from loose Go-like text
@@ -154,7 +155,7 @@ func cmdRun(args []string) error {
 }
 
 func cmdBuild(args []string) error {
-	var src, out string
+	var src, out, target string
 	emitC, safe := false, false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -164,6 +165,12 @@ func cmdBuild(args []string) error {
 			}
 			i++
 			out = args[i]
+		case "--target":
+			if i+1 >= len(args) {
+				return fmt.Errorf("build: --target needs a value (native|wasm)")
+			}
+			i++
+			target = args[i]
 		case "--emit-c":
 			emitC = true
 		case "--safe":
@@ -175,16 +182,33 @@ func cmdBuild(args []string) error {
 	if src == "" {
 		return fmt.Errorf("build: need a .mfl file")
 	}
+	switch target {
+	case "", "native":
+		target = "native"
+	case "wasm":
+	default:
+		return fmt.Errorf("build: unknown --target %q (want native or wasm)", target)
+	}
 	prog, err := loadMFL(src)
 	if err != nil {
 		return err
 	}
 	if emitC {
-		c, err := CompileToC(prog, safe)
+		c, _, err := CompileToCTarget(prog, safe, target)
 		if err != nil {
 			return err
 		}
 		fmt.Print(c)
+		return nil
+	}
+	if target == "wasm" {
+		if out == "" {
+			out = strings.TrimSuffix(filepath.Base(src), filepath.Ext(src)) + ".wasm"
+		}
+		if err := BuildWasm(prog, out, safe); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "built %s (wasm)\n", out)
 		return nil
 	}
 	if out == "" {

--- a/parser.go
+++ b/parser.go
@@ -367,6 +367,11 @@ func (p *Parser) parseTypeName() (string, error) {
 }
 
 func (p *Parser) parseFuncDecl() (*FuncDecl, error) {
+	exported := false
+	if p.peek().Kind == TKeyword && p.peek().Val == "export" {
+		p.next()
+		exported = true
+	}
 	if _, err := p.expect(TKeyword, "func"); err != nil {
 		return nil, err
 	}
@@ -423,7 +428,7 @@ func (p *Parser) parseFuncDecl() (*FuncDecl, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FuncDecl{Name: nameTok.Val, Params: params, Returns: returns, Variadic: variadic, Body: body}, nil
+	return &FuncDecl{Name: nameTok.Val, Params: params, Returns: returns, Variadic: variadic, Body: body, Exported: exported}, nil
 }
 
 func (p *Parser) parseBlock() ([]Stmt, error) {

--- a/types.go
+++ b/types.go
@@ -108,6 +108,27 @@ type Checker struct {
 	closureInst map[string]map[*MakeClosure]string // enclosing instance -> closure node -> lambda instance
 	cnameOf     map[string]string                 // instance -> C function name (deduped)
 	reps        []string                          // representative instances (one C function each)
+	exportSrc   map[string]bool                   // source names declared `export func`
+	hasMainFn   bool                              // program defines a main function
+}
+
+// HasMain reports whether the program defines a main function.
+func (c *Checker) HasMain() bool { return c.hasMainFn }
+
+// ExportNames returns the source names of every `export func` that survived to a
+// representative instance — the names a wasm build exports to the host (each C
+// function carries an export_name attribute, so JS sees the clean name).
+func (c *Checker) ExportNames() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, inst := range c.reps {
+		src := c.instFn[inst].Name
+		if c.exportSrc[src] && !seen[src] {
+			seen[src] = true
+			out = append(out, src)
+		}
+	}
+	return out
 }
 
 // rangeUse defers a for-range: once base resolves, key/val are bound to the
@@ -609,11 +630,21 @@ func Check(p *Program) (*Checker, error) {
 	}
 
 	// 1. register functions
+	var exported []string
+	c.exportSrc = map[string]bool{}
 	for _, fn := range p.Funcs {
 		c.funcs[fn.Name] = fn
+		if fn.Exported {
+			exported = append(exported, fn.Name)
+			c.exportSrc[fn.Name] = true
+		}
 	}
-	if _, ok := c.funcs["main"]; !ok {
-		return nil, fmt.Errorf("no main function defined")
+	_, hasMain := c.funcs["main"]
+	c.hasMainFn = hasMain
+	// A program needs an entry point: a main, or — for a library target (wasm) —
+	// at least one `export func`. Exported functions are reachability roots too.
+	if !hasMain && len(exported) == 0 {
+		return nil, fmt.Errorf("no main function defined (and no exported functions)")
 	}
 	// register foreign (extern) functions; their signatures are fixed, not inferred
 	ffiTypeOK := func(t string) bool {
@@ -665,10 +696,19 @@ func Check(p *Program) (*Checker, error) {
 			c.externs[f.Name] = &f
 		}
 	}
-	// 2. instantiate from main; every reachable function is specialized per
-	//    concrete call-site type (monomorphization).
-	if _, err := c.instantiate("main"); err != nil {
-		return nil, err
+	// 2. instantiate from the roots; every reachable function is specialized per
+	//    concrete call-site type (monomorphization). main is a root when present;
+	//    each `export func` is also a root (kept even if main never calls it), with
+	//    its parameter types inferred from the function body.
+	if hasMain {
+		if _, err := c.instantiate("main"); err != nil {
+			return nil, err
+		}
+	}
+	for _, name := range exported {
+		if _, err := c.instantiate(name); err != nil {
+			return nil, err
+		}
 	}
 	// 3. solve
 	if err := c.solve(); err != nil {

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// compileWasm is a tiny helper: encode loose source, parse, and compile for the
+// wasm target, returning the emitted C and the exported names.
+func compileWasm(t *testing.T, srcs ...string) (string, []string) {
+	t.Helper()
+	var decls []string
+	for _, s := range srcs {
+		blocks, err := splitFunctions(s)
+		if err != nil {
+			t.Fatalf("split: %v", err)
+		}
+		for _, b := range blocks {
+			decls = append(decls, normalize(b))
+		}
+	}
+	prog, err := ParseProgram(decls)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	csrc, exports, err := CompileToCTarget(prog, false, targetWasm)
+	if err != nil {
+		t.Fatalf("compile wasm: %v", err)
+	}
+	return csrc, exports
+}
+
+const wasmApp = `
+extern "env" {
+    fn set_html(string)
+}
+func view(n) (s) { s = "n=" + str(n * n) }
+export func render(n) { set_html(view(n)) }
+`
+
+// A wasm module needs no main: an export func is its own reachability root, and
+// the host drives the module through it. The native C entry point is omitted.
+func TestWasmExportRootsWithoutMain(t *testing.T) {
+	csrc, exports := compileWasm(t, wasmApp)
+	if len(exports) != 1 || exports[0] != "render" {
+		t.Fatalf("exports = %v, want [render]", exports)
+	}
+	if !strings.Contains(csrc, "mfl_render") {
+		t.Fatal("render was tree-shaken despite being exported")
+	}
+	if !strings.Contains(csrc, "mfl_view") {
+		t.Fatal("view (reachable from the export) was not emitted")
+	}
+	if strings.Contains(csrc, "int main(int argc") {
+		t.Fatal("wasm target should not emit a native int main entry point")
+	}
+}
+
+// FFI imports become wasm imports (import_module/import_name) so the host (JS)
+// supplies them; exports carry export_name so the host sees the clean name.
+func TestWasmImportAndExportAttributes(t *testing.T) {
+	csrc, _ := compileWasm(t, wasmApp)
+	if !strings.Contains(csrc, `import_module("env")`) || !strings.Contains(csrc, `import_name("set_html")`) {
+		t.Fatal("FFI extern was not tagged as a wasm import")
+	}
+	if !strings.Contains(csrc, `export_name("render")`) {
+		t.Fatal("exported function was not tagged with export_name")
+	}
+}
+
+// The POSIX socket/tty runtime is pay-as-you-go under wasm: a frontend module
+// that touches neither pulls in no socket()/termios symbols.
+func TestWasmOmitsUnusedPosixRuntime(t *testing.T) {
+	csrc, _ := compileWasm(t, wasmApp)
+	for _, sym := range []string{"socket(", "SO_REUSEADDR", "mfl_listen", "mfl_dial", "tcsetattr", "mfl_raw_mode"} {
+		if strings.Contains(csrc, sym) {
+			t.Fatalf("wasm module pulled in unused POSIX symbol %q", sym)
+		}
+	}
+}
+
+// But when the program does use sockets, the net runtime is emitted (so a wasm
+// program that genuinely dials is still well-formed C).
+func TestWasmKeepsUsedNetRuntime(t *testing.T) {
+	csrc, _ := compileWasm(t, `
+extern "env" { fn log_i(i32) }
+export func ping() { fd := dial("host", 80)  log_i(int(fd)) }
+`)
+	if !strings.Contains(csrc, "mfl_dial") {
+		t.Fatal("net runtime omitted despite dial() being called")
+	}
+}
+
+// The native target is unchanged: it always carries the POSIX runtime and emits
+// the int main entry point, and FFI externs stay plain (no wasm attributes).
+func TestNativeTargetUnchanged(t *testing.T) {
+	prog, err := ParseProgram([]string{normalize("func main() { println(1) }")})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	csrc, exports, err := CompileToCTarget(prog, false, targetNative)
+	if err != nil {
+		t.Fatalf("compile native: %v", err)
+	}
+	if len(exports) != 0 {
+		t.Fatalf("native exports = %v, want none", exports)
+	}
+	if !strings.Contains(csrc, "mfl_listen") || !strings.Contains(csrc, "mfl_raw_mode") {
+		t.Fatal("native target should always carry the full POSIX runtime")
+	}
+	if !strings.Contains(csrc, "int main(int argc") {
+		t.Fatal("native target must emit int main")
+	}
+	if strings.Contains(csrc, "import_module") {
+		t.Fatal("native target must not emit wasm import attributes")
+	}
+}


### PR DESCRIPTION
## What

Adds a **`--target wasm`** build mode so machin reaches the **browser frontend** — the Rust/Yew/Leptos move, here **MFL → C → wasm**, reusing the existing C backend. `machin build app.mfl --target wasm` cross-compiles the emitted C to a `wasm32-wasi` **reactor** module via `zig cc` (zig bundles clang + wasi-libc — a single-binary C→wasm toolchain, no emscripten/wasi-sdk; override with `ZIG=`).

## The bridge is machin's own FFI, both ways

- **`export func name(...)`** — new keyword. Marks a wasm **export** (callable as `instance.exports.name`, via an `export_name` attribute so JS sees the clean source name) and a **reachability root**, so a wasm module needs **no `main`**.
- **`extern "env" { fn set_html(string) }`** — under wasm a headerless extern becomes a wasm **import** the JS host supplies (`import_module`/`import_name`; the `extern "<lib>"` name is the module, default `env`).
- Marshaling host-side: machin ints are i64 ⇒ `BigInt`; strings are pointers into the exported `memory` (decode NUL-terminated UTF-8).

## Lean runtime (the keystone)

The POSIX socket (`listen`/`accept`/`dial`/`read`/`write`/`close`) and tty (`raw_mode`/`read_key`) runtimes are split out of the always-on core and made **pay-as-you-go** — the same `usesX` gating machin already does for TLS/WSS/regex/math/SQLite:

- **Native is unchanged**: always carries them, still emits `int main`. (Test: `TestNativeTargetUnchanged`.)
- **Wasm** emits each only when used, so a frontend module references no `socket()`/`termios` (which wasi-libc doesn't fully provide) and links clean with no workaround flags.

## Verified

- Full suite green; `go vet` clean. New `wasm_test.go`: export-roots-without-main, import/export attributes, lean-runtime omission, used-net retention, native-unchanged.
- End-to-end on-screen: an MFL counter (view logic + recursive `fib` in machin) built with one command, `fib(12)=144` rendered live in headless Chrome. Drove [machin-demo-wasm](https://github.com/javimosch/machin-demo-wasm); see `docs/NORTH-STAR-WEB.md`.

## Still ahead (documented, not in this PR)

Package-level globals (app state lives host-side today) and a shipped JS string/array runtime → toward a reactive DOM framework (the Leptos/Yew analog).

## Version

Bumps the four synced markers to **v0.50.0** (README badge, SPEC, `guide.go`, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)