### PR TITLE
v0.52.0: package-level variables (mutable globals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.52.0
+
+- **Package-level variables — `var name = expr` at top level.** A mutable global
+  shared by every function, its type inferred from the initializer (and its uses).
+  Unlike a local it **persists across calls**, so a wasm module's exported
+  functions can finally hold state between host invocations — `var count = 0` +
+  `export func bump(d) { count = count + d }` accumulates across calls. The piece
+  that was missing for a component to own its state in machin (not the JS host).
+  - `=` to a global's name assigns the global; `:=` still introduces (and may
+    shadow with) a local. Globals are visible everywhere, including inside
+    closures — a captured global is referenced directly, not closed over.
+  - Works for any type: scalars, strings, **maps** (`var hits = make(map[string]int)`,
+    then `hits[k] = …`), and **slices** (`var log = []string{}`, then `append`).
+  - Implementation: each global is a C static `mfl_g_<name>`; the initializers run
+    in a `constructor` — before `main` (native) and at `_initialize` (wasm reactor).
+    `encode` keeps a brace-less top-level `var` as its own declaration.
+
 ## v0.51.0
 
 - **Binary HTTP bodies — a machweb server can serve its own wasm (and any binary

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.51.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.52.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.51.0
+Version 0.52.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -160,12 +160,21 @@ sum(xs...)                     // spread: nums = xs
 
 ```go
 x := expr      // declare, type inferred from expr
-var x = expr   // same
+var x = expr   // same (inside a function)
 x = expr       // assign (x must exist; types must match)
 ```
 
 Variables have **function scope** (a name denotes one binding, of one type,
 throughout the function body).
+
+A `var name = expr` written at **top level** (not inside a function) is a
+**package global**: a single mutable binding shared by every function, its type
+inferred from the initializer and uses. Unlike a local it persists for the life
+of the program (and, under the wasm target, across exported-function calls — so a
+component can own its state). `=` to its name assigns the global; `:=` inside a
+function introduces a local that may shadow it. Globals are in scope inside
+closures too (referenced directly, not captured). Their initializers run once at
+startup (before `main`; at `_initialize` for a wasm reactor).
 
 ---
 

--- a/ast.go
+++ b/ast.go
@@ -8,6 +8,16 @@ type Program struct {
 	Types   []*TypeDecl
 	Funcs   []*FuncDecl
 	Externs []*ExternDecl
+	Globals []*GlobalVar
+}
+
+// GlobalVar is a package-level mutable variable: `var name = expr` at top level.
+// It is shared by every function (read and assigned), its type inferred from the
+// initializer (and its uses). Unlike a local, it persists across calls — so a
+// wasm module's exported functions can hold state between host invocations.
+type GlobalVar struct {
+	Name string
+	Init Expr
 }
 
 // ExternDecl declares foreign C functions and how to compile/link against them:

--- a/codegen.go
+++ b/codegen.go
@@ -89,6 +89,7 @@ type cgen struct {
 	usesNet   bool   // program calls dial/listen/accept/read/write/close(fd) -> emit POSIX socket runtime
 	usesTTY   bool   // program calls raw_mode/read_key -> emit termios/select runtime
 	target    string // "" or "native" (default) -> cc; "wasm" -> zig cc, lean runtime, FFI as imports, exports
+	globals   map[string]bool // package-global names (emitted as C statics, mfl_g_<name>)
 }
 
 // build targets.
@@ -2151,6 +2152,12 @@ func cZero(k Kind) string {
 }
 
 func (g *cgen) program(p *Program) (string, error) {
+	// record package-global names so varRef renders them as mfl_g_<name> (this must
+	// be set before any function body is emitted, since bodies may reference them).
+	g.globals = map[string]bool{}
+	for _, name := range g.c.GlobalOrder() {
+		g.globals[name] = true
+	}
 	// emit one function body per instance (monomorphization); this also fills
 	// g.tramp via any go statements.
 	for _, inst := range g.c.Reps() {
@@ -2343,6 +2350,15 @@ func (g *cgen) program(p *Program) (string, error) {
 		out.WriteString(g.jsonFns.String())
 		out.WriteByte('\n')
 	}
+	// package globals: zero-initialized C statics; their MFL initializers run in a
+	// constructor (emitted after the function bodies). Declared here so function
+	// bodies that reference mfl_g_<name> compile.
+	for _, name := range g.c.GlobalOrder() {
+		fmt.Fprintf(&out, "static %s mfl_g_%s;\n", g.c.GlobalCType(name), name)
+	}
+	if len(g.c.GlobalOrder()) > 0 {
+		out.WriteByte('\n')
+	}
 	for _, inst := range g.c.Reps() {
 		// Under wasm, an `export func` is exported to the host under its clean source
 		// name (so JS calls instance.exports.render, not the mangled C symbol). The
@@ -2357,6 +2373,28 @@ func (g *cgen) program(p *Program) (string, error) {
 	out.WriteByte('\n')
 	out.WriteString(g.tramp.String())
 	out.WriteString(g.buf.String())
+	// package-global initializers run in a C constructor — before main (native) and
+	// at _initialize (wasm reactor). Compile each init into a scratch buffer so any
+	// helper statements land inside the constructor, in declaration order.
+	if len(p.Globals) > 0 {
+		g.curFn = "$globals"
+		var ctor strings.Builder
+		for _, gv := range p.Globals {
+			saved := g.buf
+			g.buf = strings.Builder{}
+			e, err := g.expr(gv.Init)
+			if err != nil {
+				return "", err
+			}
+			helpers := g.buf.String()
+			g.buf = saved
+			ctor.WriteString(helpers)
+			fmt.Fprintf(&ctor, "    mfl_g_%s = %s;\n", gv.Name, e)
+		}
+		out.WriteString("__attribute__((constructor)) static void mfl_globals_init(void) {\n")
+		out.WriteString(ctor.String())
+		out.WriteString("}\n")
+	}
 	// Native entry point. The wasm target is a reactor module (no `int main`): the
 	// host drives it through the exported functions, so emit the C main only for
 	// native, and only when the program actually defines an MFL main.
@@ -3260,6 +3298,10 @@ func (g *cgen) isBoxed(name string) bool {
 func (g *cgen) varRef(name string) string {
 	if g.isBoxed(name) {
 		return "(*v_" + name + ")"
+	}
+	// a package global, unless shadowed by a local/param of the current function
+	if g.globals[name] && !g.c.IsLocal(g.curFn, name) {
+		return "mfl_g_" + name
 	}
 	return "v_" + name
 }

--- a/docs/NORTH-STAR-WEB.md
+++ b/docs/NORTH-STAR-WEB.md
@@ -62,12 +62,16 @@ five shipped in **v0.50.0** (`--target wasm`); the rest remain.
 4. ~~**A `machin build --target wasm` driver.**~~ **Done (v0.50.0).** The `zig cc`
    invocation is folded into the compiler (`BuildWasm`), so `app.wasm` falls out of
    one command (`ZIG=` overrides the toolchain).
-5. **Package-level mutable state.** MFL has no top-level `var`; today the JS host
-   owns app state. Either add globals, or settle on a **handle-based** pattern
-   (`alloc` a state struct, return the pointer, pass it back into each call). The
-   next gap to drive.
+5. ~~**Package-level mutable state.**~~ **Done (v0.52.0).** A top-level
+   `var name = expr` is a package global that persists across exported-function
+   calls, so a component owns its state in machin (`var count = 0` +
+   `export func bump(d){count=count+d}`) instead of the JS host holding it. Any
+   type — scalars, strings, make-maps, slices — and visible inside closures.
 6. **String/array marshaling helpers.** A small JS runtime shipped with the
    target (decode/encode strings, pass slices) so apps don't re-roll `readCString`.
+7. **Signals + a patch-list runtime.** Fine-grained reactivity in MFL: state cells
+   (now expressible as globals), derived views, and a diff/patch the JS host
+   applies — the core of the reactive-framework tier.
 
 ## The vision, in tiers (near → far)
 

--- a/globals_test.go
+++ b/globals_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// progFromSrc encodes loose source the way `machin encode` does, then parses.
+func progFromSrc(t *testing.T, src string) *Program {
+	t.Helper()
+	blocks, err := splitFunctions(src)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	var decls []string
+	for _, b := range blocks {
+		decls = append(decls, normalize(b))
+	}
+	prog, err := ParseProgram(decls)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return prog
+}
+
+// A package global holds state across calls: bump accumulates into it.
+func TestGlobalStatePersists(t *testing.T) {
+	prog := progFromSrc(t, `
+var count = 0
+func bump(d) (n) { count = count + d  n = count }
+func main() { println(bump(2))  println(bump(3))  println(bump(0)) }
+`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.Fields(out); len(got) != 3 || got[0] != "2" || got[1] != "5" || got[2] != "5" {
+		t.Fatalf("global did not accumulate: %q (want 2 5 5)", out)
+	}
+}
+
+// `splitFunctions` must keep a brace-less top-level `var` as its own declaration
+// (not merge it into the following function).
+func TestGlobalSplitsStandalone(t *testing.T) {
+	prog := progFromSrc(t, "var a = 1\nvar b = 2\nfunc main() { println(a + b) }")
+	if len(prog.Globals) != 2 {
+		t.Fatalf("got %d globals, want 2", len(prog.Globals))
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(out) != "3" {
+		t.Fatalf("globals not summed: %q", out)
+	}
+}
+
+// A `:=` inside a function shadows a global of the same name; the global is
+// untouched. An `=` assigns the global.
+func TestGlobalShadowing(t *testing.T) {
+	prog := progFromSrc(t, `
+var x = 100
+func shadow() (r) { x := 7  r = x }
+func global() (r) { r = x }
+func main() { println(shadow())  println(global()) }
+`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.Fields(out); len(got) != 2 || got[0] != "7" || got[1] != "100" {
+		t.Fatalf("shadowing wrong: %q (want 7 100)", out)
+	}
+}
+
+// A global is emitted as a C static `mfl_g_<name>` plus a constructor that runs
+// its initializer; references compile to that symbol.
+func TestGlobalCodegenShape(t *testing.T) {
+	prog := progFromSrc(t, "var count = 0\nfunc main() { count = count + 1  println(count) }")
+	csrc, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, want := range []string{"mfl_g_count", "__attribute__((constructor))", "mfl_g_count = "} {
+		if !strings.Contains(csrc, want) {
+			t.Fatalf("emitted C missing %q", want)
+		}
+	}
+}
+
+// Globals close the loop for the wasm target: an exported function can hold state
+// between host calls (the global is a module static, initialized at _initialize).
+func TestGlobalUnderWasmTarget(t *testing.T) {
+	prog := progFromSrc(t, `
+var count = 0
+export func bump(d) (n) { count = count + d  n = count }
+`)
+	csrc, _, err := CompileToCTarget(prog, false, targetWasm)
+	if err != nil {
+		t.Fatalf("compile wasm: %v", err)
+	}
+	if !strings.Contains(csrc, "mfl_g_count") || !strings.Contains(csrc, "__attribute__((constructor))") {
+		t.Fatal("wasm target did not emit the global + its constructor")
+	}
+}

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.51.0"
+const machinVersion = "0.52.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -266,7 +266,8 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"no-tls-without-https", "There is no raw TLS socket; use https_get/https_post (REST) and wss_* (WebSocket). Plain dial/listen are TCP without TLS."},
 			{"floats-over-chan-json", "A slice/map channel element round-trips through JSON, which formats floats with %g (not bit-exact for pathological doubles)."},
 			{"memory", "Per-goroutine arena, reclaimed in bulk when the goroutine returns; wrap a hot allocating loop in `arena { ... }` to keep peak memory flat. Build with --safe for bounds/overflow/div-zero checks."},
-			{"wasm-target", "`machin build app.mfl --target wasm` compiles to a WebAssembly reactor module (needs `zig` as the C->wasm compiler; override with ZIG=). Mark host-callable functions `export func name(...)` — they become wasm exports under their clean name (and are reachability roots, so a wasm module needs no main). A headerless `extern \"env\" { fn dom_set(string) }` becomes a wasm IMPORT the JS host supplies (the `extern \"<lib>\"` name is the import module). Marshaling host-side: machin ints are i64 -> pass/return BigInt; strings are a pointer into the exported `memory` (decode NUL-terminated UTF-8). No package globals yet, so app state lives host-side. See docs/NORTH-STAR-WEB.md."},
+			{"wasm-target", "`machin build app.mfl --target wasm` compiles to a WebAssembly reactor module (needs `zig` as the C->wasm compiler; override with ZIG=). Mark host-callable functions `export func name(...)` — they become wasm exports under their clean name (and are reachability roots, so a wasm module needs no main). A headerless `extern \"env\" { fn dom_set(string) }` becomes a wasm IMPORT the JS host supplies (the `extern \"<lib>\"` name is the import module). Marshaling host-side: machin ints are i64 -> pass/return BigInt; strings are a pointer into the exported `memory` (decode NUL-terminated UTF-8). App state can live in machin via package globals (`var count = 0`), which persist across export calls. See docs/NORTH-STAR-WEB.md."},
+			{"package-globals", "A top-level `var name = expr` is a package GLOBAL: mutable, shared by every function, type inferred from the initializer + uses. It PERSISTS across calls (unlike a local), so a wasm export can hold state between host calls (`var count = 0` + `export func bump(d){count=count+d}`). `=` assigns the global; `:=` makes a local (and may shadow it). Globals work everywhere incl. closures (a captured global is referenced directly), and for any type incl. make-maps and slices. Init runs before main / at wasm `_initialize`."},
 		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -404,8 +404,12 @@ func splitFunctions(src string) ([]string, error) {
 				depth--
 			}
 		}
-		if started && depth == 0 && strings.Contains(cur.String(), "{") {
-			funcs = append(funcs, strings.TrimSpace(cur.String()))
+		// A block is complete when braces balance and it has a body ("{"), OR it is a
+		// brace-less top-level `var` declaration (a package global), which is a single
+		// logical line with no body to wait for.
+		body := strings.TrimSpace(cur.String())
+		if started && depth == 0 && (strings.Contains(body, "{") || strings.HasPrefix(body, "var ")) {
+			funcs = append(funcs, body)
 			cur.Reset()
 			started = false
 		}

--- a/parser.go
+++ b/parser.go
@@ -56,6 +56,7 @@ func ParseProgram(decls []string) (*Program, error) {
 	prog := &Program{}
 	structs := map[string]bool{}
 	var funcSrcs []string
+	var globalSrcs []string
 	for _, src := range decls {
 		toks, err := Lex(src)
 		if err != nil {
@@ -74,6 +75,8 @@ func ParseProgram(decls []string) (*Program, error) {
 				return nil, err
 			}
 			prog.Externs = append(prog.Externs, ed)
+		} else if toks[0].Kind == TKeyword && toks[0].Val == "var" {
+			globalSrcs = append(globalSrcs, src)
 		} else {
 			funcSrcs = append(funcSrcs, src)
 		}
@@ -108,6 +111,13 @@ func ParseProgram(decls []string) (*Program, error) {
 			structs[cs.Name] = true
 		}
 	}
+	for _, src := range globalSrcs {
+		gv, err := ParseGlobalWith(src, structs)
+		if err != nil {
+			return nil, err
+		}
+		prog.Globals = append(prog.Globals, gv)
+	}
 	for _, src := range funcSrcs {
 		fn, err := ParseFuncWith(src, structs)
 		if err != nil {
@@ -117,6 +127,37 @@ func ParseProgram(decls []string) (*Program, error) {
 	}
 	liftClosures(prog) // closure conversion: lift function literals to top level
 	return prog, nil
+}
+
+// ParseGlobal parses a top-level package variable: `var name = expr`.
+func ParseGlobal(src string) (*GlobalVar, error) { return ParseGlobalWith(src, nil) }
+
+// ParseGlobalWith parses a global with the program's struct names in scope, so an
+// initializer may be a struct composite literal (`var cfg = Config{...}`).
+func ParseGlobalWith(src string, structs map[string]bool) (*GlobalVar, error) {
+	toks, err := Lex(src)
+	if err != nil {
+		return nil, err
+	}
+	p := &Parser{toks: toks, structs: structs}
+	if _, err := p.expect(TKeyword, "var"); err != nil {
+		return nil, err
+	}
+	nameTok, err := p.expect(TIdent, "")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TOp, "="); err != nil {
+		return nil, fmt.Errorf("global %q: expected `= <expr>` (a package var needs an initializer)", nameTok.Val)
+	}
+	val, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().Kind != TEOF {
+		return nil, fmt.Errorf("trailing tokens after global %q: %q", nameTok.Val, p.peek().Val)
+	}
+	return &GlobalVar{Name: nameTok.Val, Init: val}, nil
 }
 
 // ParseExtern parses a single extern declaration (foreign C functions).

--- a/types.go
+++ b/types.go
@@ -110,7 +110,28 @@ type Checker struct {
 	reps        []string                          // representative instances (one C function each)
 	exportSrc   map[string]bool                   // source names declared `export func`
 	hasMainFn   bool                              // program defines a main function
+	globalSlot  map[string]int                    // package-global name -> type slot
+	globalOrder []string                          // package globals in declaration order
 }
+
+// IsLocal reports whether name is a parameter or local of the given instance (so
+// codegen can tell a shadowing local from a package global of the same name).
+func (c *Checker) IsLocal(inst, name string) bool {
+	_, ok := c.vars[inst][name]
+	return ok
+}
+
+// IsGlobal reports whether name is a declared package global.
+func (c *Checker) IsGlobal(name string) bool { _, ok := c.globalSlot[name]; return ok }
+
+// GlobalOrder returns the package globals in declaration order.
+func (c *Checker) GlobalOrder() []string { return c.globalOrder }
+
+// GlobalCType returns the C type of a package global.
+func (c *Checker) GlobalCType(name string) string { return c.ctypeSlot(c.globalSlot[name]) }
+
+// GlobalKind returns the inferred kind of a package global (for zero values).
+func (c *Checker) GlobalKind(name string) Kind { return c.kindOf(c.globalSlot[name]) }
 
 // HasMain reports whether the program defines a main function.
 func (c *Checker) HasMain() bool { return c.hasMainFn }
@@ -696,6 +717,30 @@ func Check(p *Program) (*Checker, error) {
 			c.externs[f.Name] = &f
 		}
 	}
+	// 1b. package globals: type each one from its initializer, in declaration order
+	//     (a later global may reference an earlier one). They live in a synthetic
+	//     "$globals" context; references resolve through the globalSlot fallback in
+	//     genExpr/AssignStmt, so functions and globals share the same variables.
+	c.globalSlot = map[string]int{}
+	if len(p.Globals) > 0 {
+		gfn := &FuncDecl{Name: "$globals"}
+		c.vars["$globals"] = map[string]int{}
+		c.nodeSlot["$globals"] = map[Node]int{}
+		c.callInst["$globals"] = map[*Call]string{}
+		c.closureInst["$globals"] = map[*MakeClosure]string{}
+		c.instStack["$globals"] = "$globals"
+		for _, g := range p.Globals {
+			vs, err := c.genExpr(gfn, g.Init)
+			if err != nil {
+				return nil, fmt.Errorf("global %s: %w", g.Name, err)
+			}
+			slot := newSlot(c, KVar)
+			c.addPair(slot, vs)
+			c.globalSlot[g.Name] = slot
+			c.globalOrder = append(c.globalOrder, g.Name)
+		}
+		delete(c.instStack, "$globals")
+	}
 	// 2. instantiate from the roots; every reachable function is specialized per
 	//    concrete call-site type (monomorphization). main is a root when present;
 	//    each `export func` is also a root (kept even if main never calls it), with
@@ -1041,6 +1086,12 @@ func (c *Checker) genStmt(fn *FuncDecl, s Stmt) error {
 		env := c.vars[fn.Name]
 		slot, ok := env[st.Name]
 		if !ok {
+			// `=` to a name that is a package global assigns the global (a local is
+			// only created by `:=`, which may also shadow a global).
+			if gs, isG := c.globalSlot[st.Name]; isG && st.Op == "=" {
+				c.addPair(gs, vs)
+				return nil
+			}
 			slot = newSlot(c, KVar)
 			env[st.Name] = slot
 			c.localOrder[fn.Name] = append(c.localOrder[fn.Name], st.Name)
@@ -1274,6 +1325,9 @@ func (c *Checker) genExprInner(fn *FuncDecl, e Expr) (int, error) {
 		return c.cVoid, nil
 	case *Ident:
 		if s, ok := c.vars[fn.Name][ex.Name]; ok {
+			return s, nil
+		}
+		if s, ok := c.globalSlot[ex.Name]; ok { // a package global, in scope everywhere
 			return s, nil
 		}
 		return 0, fmt.Errorf("%s: undefined variable %q", fn.Name, ex.Name)


### PR DESCRIPTION
## What

A top-level **`var name = expr`** is now a **package global**: mutable, shared by every function, type inferred from its initializer and uses. Unlike a local it **persists across calls** — the missing piece for a component to own its state **in machin** rather than in the JS host.

```go
var count = 0
export func bump(d) (n) { count = count + d  n = count }   // accumulates across wasm export calls
```

## Semantics

- **`=`** to a global's name assigns the global; **`:=`** introduces a local (and may shadow the global).
- Visible **everywhere, including closures** — a captured global is referenced directly, not closed over (lambda-lifting already excludes non-local names from capture).
- **Any type:** scalars, strings, **maps** (`var hits = make(map[string]int)` then `hits[k] = …`), **slices** (`var log = []string{}` then `append`).

## Implementation

- **encode:** `splitFunctions` keeps a brace-less top-level `var` as its own declaration.
- **parser:** top-level `var` → `Program.Globals` (parsed after struct registration, so a struct-literal initializer resolves).
- **checker:** globals typed in a synthetic `$globals` context, in declaration order; `*Ident` reads and `=` assignments fall back to a `globalSlot` map (so functions and globals share variables).
- **codegen:** each global is a C `static mfl_g_<name>`; initializers run in a `__attribute__((constructor))` — before `main` (native) and at `_initialize` (wasm reactor). `varRef` renders `mfl_g_<name>` unless a local of the current function shadows it.

## Verified

- Scalar/string/map/slice globals + a closure reading a global run correctly.
- **wasm state persistence:** an exported `bump` accumulates across host calls (3 → 7 → 17), state held in the module.
- New `globals_test.go` (persistence, standalone split, shadowing, codegen shape, wasm target); full suite green, `go vet` clean.

## Version

Bumps the four synced markers to **v0.52.0** (README badge, SPEC, `guide.go`, CHANGELOG); closes gap #5 in the web north star (toward signals + a reactive runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)