### PR TITLE
v0.53.0: slices of functions ([]func) + a reactive runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.53.0
+
+- **Slices of functions — `[]func`.** A slice literal may now have `func` as its
+  element type (`fns := []func{}`), so closures can be stored, appended, indexed,
+  and called from a slice — the dispatch-table / callback-list / effect-registry
+  primitive. (Each element is an `mfl_closure`; the slice machinery already handled
+  by-value structs, so this was a one-token parser fix.)
+- **`framework/reactive.src` — a fine-grained reactive runtime for web UIs** (the
+  Solid/Leptos model, in MFL). Built on `[]func` (a binding registry of compute
+  closures) and package globals (the signal store): **signals** hold state
+  (`signal`/`get`/`set`), **bindings** are compute closures tied to a DOM slot
+  (`bind(slot, func(){...})`) whose signal reads are auto-tracked as dependencies,
+  and on `set` only the bindings that read that signal recompute — emitting a
+  **patch** (`dom_patch(slot, value)`) only when the rendered text actually
+  changed. The host sets the text of the handful of changed slots; no innerHTML
+  replacement, no vdom diff. Drove [machin-web-demo-reactive](https://github.com/javimosch/machin-web-demo-reactive).
+  - Gotcha it surfaced: a user function named like a builtin (e.g. `flush`) is
+    silently shadowed by the builtin — the runtime's internal `commit` was renamed
+    to avoid it. Lambda **named returns** aren't supported yet (`func() (s) {…}`);
+    use `func() { return … }`.
+
 ## v0.52.0
 
 - **Package-level variables — `var name = expr` at top level.** A mutable global

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.52.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.53.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.52.0
+Version 0.53.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/framework/reactive.src
+++ b/framework/reactive.src
@@ -1,0 +1,98 @@
+// reactive.src — a tiny fine-grained reactive runtime for machin web UIs.
+//
+// Compose it ahead of your app and compile to wasm:
+//   machin encode framework/reactive.src yourapp.src > app.mfl
+//   machin build app.mfl --target wasm -o app.wasm
+//
+// The model is signals + a patch list (Solid/Leptos-style fine-grained reactivity):
+//   - a SIGNAL holds a value: `c := signal(0)`, `get(c)`, `set(c, v)`.
+//   - a BINDING is a compute closure tied to a DOM slot: `bind("count", func(){ return str(get(c)) })`.
+//     While it runs the first time, every signal it reads is recorded as a dependency.
+//   - on `set`, only the bindings that READ that signal recompute, and only those
+//     whose rendered TEXT actually changed emit a patch (`dom_patch(slot, value)`).
+// So the host never replaces innerHTML and never diffs a vdom — it sets the text of
+// the handful of slots that changed. State and view logic live entirely in machin.
+//
+// Needs machin v0.53.0+ (slices of functions, `[]func`) and the wasm target.
+// Signals are int-valued; bindings format them to text. The host supplies dom_patch.
+
+extern "env" {
+    fn dom_patch(string, string)   // (slot, value): host sets [data-s=slot]'s text content
+}
+
+var sig_val = []int{}              // signal values, indexed by signal id
+var n_sig = 0
+
+var bind_slot = []string{}         // each binding's DOM slot id
+var bind_fn = []func{}             // each binding's compute closure: func() -> string
+var bind_last = []string{}         // last rendered text (for diffing)
+var bind_dirty = []int{}
+var n_bind = 0
+
+var edge_sig = []int{}             // dependency edges (signal id -> binding id),
+var edge_bind = []int{}            //   recorded while a binding first computes
+var tracking = 0 - 1               // binding id currently computing (auto-tracking), or -1
+
+// signal creates a state cell with an initial value and returns its id.
+func signal(init) (id) {
+    id = n_sig
+    sig_val = append(sig_val, init)
+    n_sig = n_sig + 1
+}
+
+// get reads a signal. If a binding is currently computing, the read is recorded
+// as a dependency edge, so a later set() knows which bindings to recompute.
+func get(id) (v) {
+    if tracking >= 0 {
+        edge_sig = append(edge_sig, id)
+        edge_bind = append(edge_bind, tracking)
+    }
+    v = sig_val[id]
+}
+
+// commit recomputes every dirty binding and emits a patch for each whose text
+// actually changed (the minimal patch list).
+func commit() {
+    i := 0
+    while i < n_bind {
+        if bind_dirty[i] == 1 {
+            f := bind_fn[i]
+            nv := f()
+            if nv != bind_last[i] {
+                bind_last[i] = nv
+                dom_patch(bind_slot[i], nv)
+            }
+            bind_dirty[i] = 0
+        }
+        i = i + 1
+    }
+}
+
+// set updates a signal. If the value changed, every binding that depends on it is
+// marked dirty and the dirty set is committed (recomputed + patched).
+func set(id, v) {
+    if sig_val[id] == v { return }
+    sig_val[id] = v
+    i := 0
+    while i < len(edge_sig) {
+        if edge_sig[i] == id { bind_dirty[edge_bind[i]] = 1 }
+        i = i + 1
+    }
+    commit()
+}
+
+// bind ties a compute closure to a DOM slot, runs it once (recording its signal
+// dependencies), and paints the initial value.
+func bind(slot, fn) {
+    id := n_bind
+    bind_slot = append(bind_slot, slot)
+    bind_fn = append(bind_fn, fn)
+    bind_last = append(bind_last, "")
+    bind_dirty = append(bind_dirty, 0)
+    n_bind = n_bind + 1
+    tracking = id
+    v := fn()
+    tracking = 0 - 1
+    bind_last[id] = v
+    dom_patch(slot, v)
+}

--- a/func_slice_test.go
+++ b/func_slice_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// A slice of functions — `[]func{}` — can be built, appended to, indexed, and its
+// elements called. This is the dispatch-table / effect-list primitive (it drove
+// the reactive runtime in framework/reactive.src).
+func TestFuncSliceStoreAndCall(t *testing.T) {
+	prog := progFromSrc(t, `
+func add_to(fns, f) (out) { out = append(fns, f) }
+func main() {
+    a := 3
+    b := 10
+    fns := []func{}
+    fns = append(fns, func() { return str(a * a) })
+    fns = add_to(fns, func() { return str(b + 1) })
+    i := 0
+    while i < len(fns) {
+        f := fns[i]
+        println(f())
+        i = i + 1
+    }
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.Fields(out); len(got) != 2 || got[0] != "9" || got[1] != "11" {
+		t.Fatalf("func slice calls = %q (want 9 11)", out)
+	}
+}
+
+// `[]func` is a slice of closures (mfl_closure elements), passed by value like any
+// slice — the element type resolves to mfl_closure in the emitted C.
+func TestFuncSliceCodegen(t *testing.T) {
+	prog := progFromSrc(t, "func main() { fns := []func{}  fns = append(fns, func() { return 1 })  f := fns[0]  println(f()) }")
+	csrc, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(csrc, "mfl_closure") {
+		t.Fatal("func slice did not lower to mfl_closure elements")
+	}
+}
+
+// The reactive runtime module composes and type-checks (its signal/get/set/bind
+// over a []func binding registry is the headline use of func slices).
+func TestReactiveFrameworkCompiles(t *testing.T) {
+	data, err := os.ReadFile("framework/reactive.src")
+	if err != nil {
+		t.Skip("framework/reactive.src not found")
+	}
+	runtime := string(data)
+	app := `
+var c = 0
+export func start() { c = signal(0)  bind("count", func() { return str(get(c)) }) }
+export func bump(d) { set(c, get(c) + d) }`
+	prog := progFromSrc(t, runtime+"\n"+app)
+	if _, _, err := CompileToCTarget(prog, false, targetWasm); err != nil {
+		t.Fatalf("reactive runtime failed to compile for wasm: %v", err)
+	}
+}

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.52.0"
+const machinVersion = "0.53.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -63,7 +63,7 @@ func machinGuide() guideCatalog {
 			{"bool", "true/false"},
 			{"string", "immutable UTF-8 bytes; zero value \"\""},
 			{"bytes", "NUL-safe binary buffer (ptr+len); from bytes()/from_hex(); inspect with len/byte_at/to_hex. For binary protocols & crypto (strings truncate at NUL)"},
-			{"[]T", "slice (append to grow); for i, v := range"},
+			{"[]T", "slice (append to grow); for i, v := range. T can be a struct, another slice, or `func` (`[]func{}` — a slice of closures, for dispatch tables / effect lists)"},
 			{"map[K]V", "K is int or string; make(map[K]V); has/delete/keys"},
 			{"struct", "type T struct { f T ... }; value semantics; T{f: v}"},
 			{"chan T", "make(chan T); ch <- v; <-ch; close; for v := range ch; v, ok := <-ch"},
@@ -268,6 +268,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"memory", "Per-goroutine arena, reclaimed in bulk when the goroutine returns; wrap a hot allocating loop in `arena { ... }` to keep peak memory flat. Build with --safe for bounds/overflow/div-zero checks."},
 			{"wasm-target", "`machin build app.mfl --target wasm` compiles to a WebAssembly reactor module (needs `zig` as the C->wasm compiler; override with ZIG=). Mark host-callable functions `export func name(...)` — they become wasm exports under their clean name (and are reachability roots, so a wasm module needs no main). A headerless `extern \"env\" { fn dom_set(string) }` becomes a wasm IMPORT the JS host supplies (the `extern \"<lib>\"` name is the import module). Marshaling host-side: machin ints are i64 -> pass/return BigInt; strings are a pointer into the exported `memory` (decode NUL-terminated UTF-8). App state can live in machin via package globals (`var count = 0`), which persist across export calls. See docs/NORTH-STAR-WEB.md."},
 			{"package-globals", "A top-level `var name = expr` is a package GLOBAL: mutable, shared by every function, type inferred from the initializer + uses. It PERSISTS across calls (unlike a local), so a wasm export can hold state between host calls (`var count = 0` + `export func bump(d){count=count+d}`). `=` assigns the global; `:=` makes a local (and may shadow it). Globals work everywhere incl. closures (a captured global is referenced directly), and for any type incl. make-maps and slices. Init runs before main / at wasm `_initialize`."},
+			{"lambda-and-builtin-names", "Two footguns when defining functions/closures: (1) a lambda (`func(){...}`) has NO named returns — `func() (s) { s = x }` does NOT parse; use `func() { return x }`. (2) A user function named the same as a builtin (e.g. `flush`, `len`, `str`) is silently SHADOWED by the builtin at call sites — pick a different name (this bit framework/reactive.src, whose internal `flush` was renamed `commit`)."},
 		},
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -1113,8 +1113,8 @@ func (p *Parser) parseSliceLit() (Expr, error) {
 	if _, err := p.expect(TPunct, "]"); err != nil {
 		return nil, err
 	}
-	elemTok := p.next() // element type name
-	if elemTok.Kind != TIdent {
+	elemTok := p.next() // element type name (an identifier, or the `func` keyword)
+	if elemTok.Kind != TIdent && !(elemTok.Kind == TKeyword && elemTok.Val == "func") {
 		return nil, fmt.Errorf("slice element type must be a name, got %q", elemTok.Val)
 	}
 	if _, err := p.expect(TPunct, "{"); err != nil {


### PR DESCRIPTION
## What

Two things, one driving the other:

### `[]func` — slices of functions
A slice literal may now use **`func`** as its element type (`fns := []func{}`), so closures can be stored, appended, indexed, and **called from a slice** — the dispatch-table / callback-list / effect-registry primitive. Each element is an `mfl_closure`; the slice machinery already passed by-value structs around, so this was a **one-token parser fix** (allow the `func` keyword where a slice element type is expected).

### `framework/reactive.src` — fine-grained reactivity in MFL
A small reactive runtime (the Solid/Leptos model) built on `[]func` (a binding registry of compute closures) and **package globals** (v0.52.0, the signal store):

- **signals** hold state — `c := signal(0)`, `get(c)`, `set(c, v)`.
- **bindings** are compute closures tied to a DOM slot — `bind("count", func(){ return str(get(c)) })`. While a binding first runs, every signal it reads is **auto-tracked** as a dependency.
- on `set`, **only the bindings that read that signal** recompute, and only those whose rendered **text actually changed** emit `dom_patch(slot, value)`.

The host sets the text of the handful of changed slots — **no `innerHTML` replacement, no vdom diff**. State and view logic live entirely in machin.

## Verified — minimal patches

A counter with slots `count`, `sq` (n²), `fib`, and an independent `step` signal, in both native and wasm:

| action | patches emitted |
|---|---|
| `start` | count=0, sq=0, fib=0, step=1 |
| `bump +1` | count=1, sq=1, fib=1  *(step untouched)* |
| `bump +1` | count=2, sq=4  *(fib **not** patched — fib(2)=fib(1)=1)* |
| `set_step 5` | step=5  *(only step)* |
| `bump +5` | count=7, sq=49, fib=13 |

## Footguns it surfaced (now in `machin guide`)

- A **lambda has no named returns** (`func() (s){…}` doesn't parse) — use `func() { return … }`.
- A user function named like a **builtin** (`flush`, `len`, …) is silently shadowed by the builtin — the runtime's internal `flush` was renamed `commit`.

## Tests / version

New `func_slice_test.go` (store/call, codegen lowers to `mfl_closure`, the reactive runtime compiles for wasm); full suite green, `go vet` clean. Four version markers bumped to **v0.53.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)