### PR TITLE
v0.54.0: reactive computed signals + keyed list reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.54.0
+
+- **`framework/reactive.src` grows computed signals + keyed list reconciliation.**
+  - **`computed(func(){ return … })`** — a memoized derived signal (backed by a
+    real signal, kept current by a reaction); read it with `get` and depend on it
+    like any signal. Transitive: a change recomputes the computed, which updates
+    its own dependents.
+  - **`each(container, keys, item)`** — keyed list reconciliation. `keys()` returns
+    the ordered keys as a CSV string (`func(){ get(ver)  return csv(ids) }`),
+    `item(key)` returns an item's HTML. On a change it emits only the deltas —
+    `list_insert` for new keys (rendered once), `list_remove` for gone keys, and a
+    `list_order` directive — never re-rendering unchanged items. The unified
+    reaction graph means a computed/binding/list all recompute only when a signal
+    they read changes, and only changed text/keys patch.
+- **Defining a function named like a builtin is now a compile error** (it would be
+  silently shadowed by the builtin at call sites — a footgun that bit the reactive
+  runtime three times: `flush`, `keys`, `contains`). Rename it. An `extern` may
+  still shadow a builtin (intentional, for FFI). Drove
+  [machin-web-demo-reactive](https://github.com/javimosch/machin-web-demo-reactive)
+  (now a list + computed demo).
+
 ## v0.53.0
 
 - **Slices of functions — `[]func`.** A slice literal may now have `func` as its

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.53.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.54.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.53.0
+Version 0.54.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/framework/reactive.src
+++ b/framework/reactive.src
@@ -1,98 +1,213 @@
-// reactive.src — a tiny fine-grained reactive runtime for machin web UIs.
-//
-// Compose it ahead of your app and compile to wasm:
-//   machin encode framework/reactive.src yourapp.src > app.mfl
-//   machin build app.mfl --target wasm -o app.wasm
-//
-// The model is signals + a patch list (Solid/Leptos-style fine-grained reactivity):
-//   - a SIGNAL holds a value: `c := signal(0)`, `get(c)`, `set(c, v)`.
-//   - a BINDING is a compute closure tied to a DOM slot: `bind("count", func(){ return str(get(c)) })`.
-//     While it runs the first time, every signal it reads is recorded as a dependency.
-//   - on `set`, only the bindings that READ that signal recompute, and only those
-//     whose rendered TEXT actually changed emit a patch (`dom_patch(slot, value)`).
-// So the host never replaces innerHTML and never diffs a vdom — it sets the text of
-// the handful of slots that changed. State and view logic live entirely in machin.
-//
-// Needs machin v0.53.0+ (slices of functions, `[]func`) and the wasm target.
-// Signals are int-valued; bindings format them to text. The host supplies dom_patch.
-
 extern "env" {
-    fn dom_patch(string, string)   // (slot, value): host sets [data-s=slot]'s text content
+    fn dom_patch(string, string)
+    fn list_insert(string, string, string)
+    fn list_remove(string, string)
+    fn list_order(string, string)
 }
 
-var sig_val = []int{}              // signal values, indexed by signal id
+var sval = []int{}
 var n_sig = 0
 
-var bind_slot = []string{}         // each binding's DOM slot id
-var bind_fn = []func{}             // each binding's compute closure: func() -> string
-var bind_last = []string{}         // last rendered text (for diffing)
-var bind_dirty = []int{}
-var n_bind = 0
+var r_kind = []int{}     // reaction kind: 0 computed, 1 bind, 2 each
+var r_sub = []int{}      // index into the per-kind arrays
+var r_dirty = []int{}
+var n_r = 0
 
-var edge_sig = []int{}             // dependency edges (signal id -> binding id),
-var edge_bind = []int{}            //   recorded while a binding first computes
-var tracking = 0 - 1               // binding id currently computing (auto-tracking), or -1
+var c_fn = []func{}      // computed compute: func() -> int
+var c_sig = []int{}      // its backing signal id
 
-// signal creates a state cell with an initial value and returns its id.
+var b_fn = []func{}      // bind compute: func() -> string
+var b_slot = []string{}
+var b_last = []string{}
+
+var e_kf = []func{}      // each keys: func() -> string (csv of the ordered keys)
+var e_if = []func{}      // each item: func(int) -> string
+var e_cont = []string{}
+var e_old = []string{}   // last key set, csv
+
+var edge_sig = []int{}
+var edge_r = []int{}
+var tracking = 0 - 1
+var flushing = 0
+
 func signal(init) (id) {
     id = n_sig
-    sig_val = append(sig_val, init)
+    sval = append(sval, init)
     n_sig = n_sig + 1
 }
 
-// get reads a signal. If a binding is currently computing, the read is recorded
-// as a dependency edge, so a later set() knows which bindings to recompute.
 func get(id) (v) {
     if tracking >= 0 {
         edge_sig = append(edge_sig, id)
-        edge_bind = append(edge_bind, tracking)
+        edge_r = append(edge_r, tracking)
     }
-    v = sig_val[id]
+    v = sval[id]
 }
 
-// commit recomputes every dirty binding and emits a patch for each whose text
-// actually changed (the minimal patch list).
-func commit() {
+func clear_edges(rid) {
+    ns := []int{}
+    nr := []int{}
     i := 0
-    while i < n_bind {
-        if bind_dirty[i] == 1 {
-            f := bind_fn[i]
-            nv := f()
-            if nv != bind_last[i] {
-                bind_last[i] = nv
-                dom_patch(bind_slot[i], nv)
-            }
-            bind_dirty[i] = 0
+    while i < len(edge_sig) {
+        if edge_r[i] != rid {
+            ns = append(ns, edge_sig[i])
+            nr = append(nr, edge_r[i])
         }
+        i = i + 1
+    }
+    edge_sig = ns
+    edge_r = nr
+}
+
+func in_list(xs, k) (yes) {
+    yes = 0
+    i := 0
+    while i < len(xs) {
+        if xs[i] == k { yes = 1 }
         i = i + 1
     }
 }
 
-// set updates a signal. If the value changed, every binding that depends on it is
-// marked dirty and the dirty set is committed (recomputed + patched).
+func csv(xs) (s) {
+    s = ""
+    i := 0
+    while i < len(xs) {
+        if i > 0 { s = s + "," }
+        s = s + str(xs[i])
+        i = i + 1
+    }
+}
+
+func parse_csv(s) (xs) {
+    xs = []int{}
+    if s == "" { return }
+    parts := split(s, ",")
+    i := 0
+    while i < len(parts) {
+        xs = append(xs, parse_int(parts[i]))
+        i = i + 1
+    }
+}
+
+// A reaction runs its stored compute closure with dependency tracking on, then
+// applies its effect. Each kind has its own runner (one closure signature per
+// function — combining them in one scope confuses inference). run_reaction routes.
+
+func run_computed(s, rid) {
+    prev := tracking
+    tracking = rid
+    cf := c_fn[s]
+    cv := cf()
+    tracking = prev
+    set(c_sig[s], cv)
+}
+
+func run_bind(s, rid) {
+    prev := tracking
+    tracking = rid
+    bf := b_fn[s]
+    bv := bf()
+    tracking = prev
+    if bv != b_last[s] {
+        b_last[s] = bv
+        dom_patch(b_slot[s], bv)
+    }
+}
+
+// A keys closure returns the ordered keys as a CSV STRING (build it with the
+// exported `csv` helper: `func() { get(ver)  return csv(my_ids) }`). Using a
+// string keeps the closure's return type pinned via parse_csv, so an app that
+// registers no list still type-checks (an empty []int closure would not).
+func run_each(s, rid) {
+    prev := tracking
+    tracking = rid
+    kf := e_kf[s]
+    cs := kf()
+    tracking = prev
+    ks := parse_csv(cs)
+    cont := e_cont[s]
+    old := parse_csv(e_old[s])
+    i := 0
+    while i < len(old) {
+        if in_list(ks, old[i]) == 0 { list_remove(cont, str(old[i])) }
+        i = i + 1
+    }
+    itf := e_if[s]
+    i = 0
+    while i < len(ks) {
+        if in_list(old, ks[i]) == 0 { list_insert(cont, str(ks[i]), itf(ks[i])) }
+        i = i + 1
+    }
+    list_order(cont, cs)
+    e_old[s] = cs
+}
+
+func run_reaction(rid) {
+    clear_edges(rid)
+    k := r_kind[rid]
+    s := r_sub[rid]
+    if k == 0 { run_computed(s, rid) }
+    if k == 1 { run_bind(s, rid) }
+    if k == 2 { run_each(s, rid) }
+}
+
+func register(kind, sub) (rid) {
+    rid = n_r
+    r_kind = append(r_kind, kind)
+    r_sub = append(r_sub, sub)
+    r_dirty = append(r_dirty, 0)
+    n_r = n_r + 1
+    run_reaction(rid)
+}
+
+func commit() {
+    if flushing == 1 { return }
+    flushing = 1
+    again := 1
+    while again == 1 {
+        again = 0
+        i := 0
+        while i < n_r {
+            if r_dirty[i] == 1 {
+                r_dirty[i] = 0
+                run_reaction(i)
+                again = 1
+            }
+            i = i + 1
+        }
+    }
+    flushing = 0
+}
+
 func set(id, v) {
-    if sig_val[id] == v { return }
-    sig_val[id] = v
+    if sval[id] == v { return }
+    sval[id] = v
     i := 0
     while i < len(edge_sig) {
-        if edge_sig[i] == id { bind_dirty[edge_bind[i]] = 1 }
+        if edge_sig[i] == id { r_dirty[edge_r[i]] = 1 }
         i = i + 1
     }
     commit()
 }
 
-// bind ties a compute closure to a DOM slot, runs it once (recording its signal
-// dependencies), and paints the initial value.
+func computed(fn) (id) {
+    c_fn = append(c_fn, fn)
+    id = signal(0)
+    c_sig = append(c_sig, id)
+    register(0, len(c_fn) - 1)
+}
+
 func bind(slot, fn) {
-    id := n_bind
-    bind_slot = append(bind_slot, slot)
-    bind_fn = append(bind_fn, fn)
-    bind_last = append(bind_last, "")
-    bind_dirty = append(bind_dirty, 0)
-    n_bind = n_bind + 1
-    tracking = id
-    v := fn()
-    tracking = 0 - 1
-    bind_last[id] = v
-    dom_patch(slot, v)
+    b_fn = append(b_fn, fn)
+    b_slot = append(b_slot, slot)
+    b_last = append(b_last, "")
+    register(1, len(b_fn) - 1)
+}
+
+func each(cont, kf, itf) {
+    e_kf = append(e_kf, kf)
+    e_if = append(e_if, itf)
+    e_cont = append(e_cont, cont)
+    e_old = append(e_old, "")
+    register(2, len(e_kf) - 1)
 }

--- a/func_slice_test.go
+++ b/func_slice_test.go
@@ -55,12 +55,38 @@ func TestReactiveFrameworkCompiles(t *testing.T) {
 		t.Skip("framework/reactive.src not found")
 	}
 	runtime := string(data)
+	// exercise the full surface: a signal, a computed, a binding, and a keyed list.
 	app := `
 var c = 0
-export func start() { c = signal(0)  bind("count", func() { return str(get(c)) }) }
+var dbl = 0
+var ids = []int{}
+export func start() {
+    c = signal(0)
+    dbl = computed(func() { return get(c) * 2 })
+    bind("count", func() { return str(get(c)) })
+    bind("double", func() { return str(get(dbl)) })
+    each("list", func() { get(c)  return csv(ids) }, func(k) { return str(k) })
+}
 export func bump(d) { set(c, get(c) + d) }`
 	prog := progFromSrc(t, runtime+"\n"+app)
 	if _, _, err := CompileToCTarget(prog, false, targetWasm); err != nil {
 		t.Fatalf("reactive runtime failed to compile for wasm: %v", err)
+	}
+}
+
+// The runtime also compiles for an app that uses signals/bindings but NO list —
+// the keys closure's string return keeps `each` type-checkable even when unused.
+func TestReactiveNoListCompiles(t *testing.T) {
+	data, err := os.ReadFile("framework/reactive.src")
+	if err != nil {
+		t.Skip("framework/reactive.src not found")
+	}
+	app := `
+var c = 0
+export func start() { c = signal(0)  bind("count", func() { return str(get(c)) }) }
+export func bump(d) { set(c, get(c) + d) }`
+	prog := progFromSrc(t, string(data)+"\n"+app)
+	if _, _, err := CompileToCTarget(prog, false, targetWasm); err != nil {
+		t.Fatalf("reactive runtime (no list) failed to compile: %v", err)
 	}
 }

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.53.0"
+const machinVersion = "0.54.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -45,6 +45,20 @@ type guideCatalog struct {
 	Builtins []guideBuiltin `json:"builtins"`
 	Idioms   []guideIdiom   `json:"idioms"`
 	Gotchas  []guideNote    `json:"gotchas"`
+}
+
+// builtinNames is the set of builtin function names (from the catalog), memoized.
+// Used to reject a user function that would silently shadow a builtin.
+var builtinNames map[string]bool
+
+func isBuiltinName(n string) bool {
+	if builtinNames == nil {
+		builtinNames = map[string]bool{}
+		for _, b := range machinGuide().Builtins {
+			builtinNames[b.Name] = true
+		}
+	}
+	return builtinNames[n]
 }
 
 func machinGuide() guideCatalog {
@@ -268,7 +282,8 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"memory", "Per-goroutine arena, reclaimed in bulk when the goroutine returns; wrap a hot allocating loop in `arena { ... }` to keep peak memory flat. Build with --safe for bounds/overflow/div-zero checks."},
 			{"wasm-target", "`machin build app.mfl --target wasm` compiles to a WebAssembly reactor module (needs `zig` as the C->wasm compiler; override with ZIG=). Mark host-callable functions `export func name(...)` — they become wasm exports under their clean name (and are reachability roots, so a wasm module needs no main). A headerless `extern \"env\" { fn dom_set(string) }` becomes a wasm IMPORT the JS host supplies (the `extern \"<lib>\"` name is the import module). Marshaling host-side: machin ints are i64 -> pass/return BigInt; strings are a pointer into the exported `memory` (decode NUL-terminated UTF-8). App state can live in machin via package globals (`var count = 0`), which persist across export calls. See docs/NORTH-STAR-WEB.md."},
 			{"package-globals", "A top-level `var name = expr` is a package GLOBAL: mutable, shared by every function, type inferred from the initializer + uses. It PERSISTS across calls (unlike a local), so a wasm export can hold state between host calls (`var count = 0` + `export func bump(d){count=count+d}`). `=` assigns the global; `:=` makes a local (and may shadow it). Globals work everywhere incl. closures (a captured global is referenced directly), and for any type incl. make-maps and slices. Init runs before main / at wasm `_initialize`."},
-			{"lambda-and-builtin-names", "Two footguns when defining functions/closures: (1) a lambda (`func(){...}`) has NO named returns — `func() (s) { s = x }` does NOT parse; use `func() { return x }`. (2) A user function named the same as a builtin (e.g. `flush`, `len`, `str`) is silently SHADOWED by the builtin at call sites — pick a different name (this bit framework/reactive.src, whose internal `flush` was renamed `commit`)."},
+			{"lambda-and-builtin-names", "Two rules when defining functions/closures: (1) a lambda (`func(){...}`) has NO named returns — `func() (s) { s = x }` does NOT parse; use `func() { return x }`. (2) A user function may NOT be named like a builtin (`flush`, `len`, `str`, `keys`, `contains`, ...) — it is a compile error (the builtin would win at call sites, silently ignoring your function). Pick another name. (An `extern` MAY shadow a builtin — that's intentional for FFI.)"},
+			{"reactive-runtime", "`framework/reactive.src` is a fine-grained reactive runtime (signals + a patch list) for wasm UIs. `signal(v)`/`get`/`set`; `computed(func(){ return ... })` is a memoized derived signal; `bind(slot, func(){ return str(...) })` patches a DOM text slot on change; `each(container, func(){ get(ver)  return csv(ids) }, func(k){ return html })` does keyed list reconciliation (keys as a CSV string; emits insert/remove/order). Only reactions that read a changed signal recompute, and only changed text/keys patch. Host supplies dom_patch/list_insert/list_remove/list_order. Drove `[]func` (v0.53.0)."},
 		},
 	}
 }

--- a/reactive_test.go
+++ b/reactive_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A user function that shadows a builtin is rejected (it would be silently ignored
+// at call sites otherwise — the footgun that bit the reactive runtime three times).
+func TestBuiltinShadowingRejected(t *testing.T) {
+	for _, name := range []string{"flush", "keys", "contains", "len", "str"} {
+		src := "func " + name + "() { println(1) }\nfunc main() { " + name + "() }"
+		fn := strings.SplitN(src, "\n", 2)
+		blocks := []string{normalize(fn[0]), normalize(fn[1])}
+		prog, perr := ParseProgram(blocks)
+		if perr != nil {
+			t.Fatalf("%s: parse: %v", name, perr)
+		}
+		if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "shadows the builtin") {
+			t.Fatalf("defining func %q should be rejected as shadowing a builtin, got %v", name, err)
+		}
+	}
+}
+
+// End-to-end behavior: compose the reactive runtime with print-based host functions
+// and a list app, run it natively, and assert the patches are MINIMAL — adding an
+// item inserts only that item, and a reorder emits no item re-render.
+func TestReactiveMinimalPatches(t *testing.T) {
+	data, err := os.ReadFile("framework/reactive.src")
+	if err != nil {
+		t.Skip("framework/reactive.src not found")
+	}
+	// strip the extern block; substitute printing host functions.
+	runtime := regexp.MustCompile(`(?s)extern "env" \{.*?\}\n`).ReplaceAllString(string(data), "")
+	host := `
+func dom_patch(slot, val) { println("patch " + slot + "=" + val) }
+func list_insert(c, k, html) { println("insert " + k) }
+func list_remove(c, k) { println("remove " + k) }
+func list_order(c, ks) { println("order " + ks) }`
+	app := `
+var ver = 0
+var ids = []int{}
+var vals = []int{}
+var n = 0
+var nid = 1
+func total_of() (s) { get(ver)  s = 0  i := 0  while i < n { s = s + vals[i]  i = i + 1 } }
+func add(x) { ids = append(ids, nid)  vals = append(vals, x)  nid = nid + 1  n = n + 1  set(ver, get(ver) + 1) }
+func main() {
+    ver = signal(0)
+    bind("total", func() { return str(total_of()) })
+    each("list", func() { get(ver)  return csv(ids) }, func(k) { return str(k) })
+    println("-- add 10 --")  add(10)
+    println("-- add 20 --")  add(20)
+}`
+	prog, perr := progFromSrcErr(runtime + host + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// after `add 20`, exactly one insert (#2) — item #1 must NOT be re-inserted.
+	after := out[strings.Index(out, "-- add 20 --"):]
+	if strings.Count(after, "insert") != 1 {
+		t.Fatalf("adding a 2nd item should insert only it; got:\n%s", out)
+	}
+	if !strings.Contains(after, "insert 2") || strings.Contains(after, "insert 1") {
+		t.Fatalf("expected only `insert 2` after the 2nd add; got:\n%s", out)
+	}
+	if !strings.Contains(after, "patch total=30") {
+		t.Fatalf("computed total should update to 30; got:\n%s", out)
+	}
+}
+
+// progFromSrcErr is like progFromSrc but returns the error (for table tests).
+func progFromSrcErr(src string) (*Program, error) {
+	blocks, err := splitFunctions(src)
+	if err != nil {
+		return nil, err
+	}
+	var decls []string
+	for _, b := range blocks {
+		decls = append(decls, normalize(b))
+	}
+	return ParseProgram(decls)
+}

--- a/types.go
+++ b/types.go
@@ -654,6 +654,12 @@ func Check(p *Program) (*Checker, error) {
 	var exported []string
 	c.exportSrc = map[string]bool{}
 	for _, fn := range p.Funcs {
+		// A user function may not shadow a builtin: at call sites the builtin wins,
+		// so the function would be silently ignored (a confusing footgun). Externs
+		// may shadow a builtin (intentional — the FFI symbol replaces it).
+		if isBuiltinName(fn.Name) {
+			return nil, fmt.Errorf("function %q shadows the builtin %q — it would be silently ignored at call sites; rename it", fn.Name, fn.Name)
+		}
 		c.funcs[fn.Name] = fn
 		if fn.Exported {
 			exported = append(exported, fn.Name)


### PR DESCRIPTION
## What

Extends `framework/reactive.src` (the signals + patch-list runtime) with the two pieces that make it usable for real components:

### Computed signals
**`computed(func(){ return … })`** — a memoized derived signal, backed by a real signal kept current by a reaction. Read it with `get` and depend on it like any signal. Transitive: a change recomputes the computed, which then updates *its* dependents.

### Keyed list reconciliation
**`each(container, keys, item)`** — `keys()` returns the ordered keys as a CSV string (`func(){ get(ver)  return csv(ids) }`), `item(key)` returns an item's HTML. On a change it emits **only the deltas**: `list_insert` for new keys (rendered once), `list_remove` for gone keys, and a `list_order` directive — **never re-rendering unchanged items**.

The reaction graph is unified: a binding/computed/list recomputes only when a signal it reads changes, and only changed text/keys patch.

**Verified** (native + wasm) on a list+computed app:

| action | patches |
|---|---|
| `add 10` | `total=10, count=1, insert #1, order 1` |
| `add 20` | `total=30, count=2, insert #2, order 1,2`  *(item 1 not re-inserted)* |
| `reverse` | `order 3,2,1`  *(no item re-render)* |
| `remove` | `total=…, remove #k, order …` |

The keys-as-CSV-string design keeps `run_each` type-checkable **even when an app registers no list** (an empty `[]int`-returning closure would default its type and fail).

## Also: builtin shadowing is now a compile error

Defining a function named like a builtin (`flush`, `keys`, `contains`, `len`, …) is now **rejected** — at call sites the builtin wins, so the function was silently ignored (a footgun that bit the reactive runtime *three times*). An `extern` may still shadow a builtin (intentional, for FFI).

## Tests / version

New `reactive_test.go` (minimal-patch behavior end-to-end; shadowing rejected) + `func_slice` tests for the full and no-list runtime. Full suite green, `go vet` clean. Four version markers bumped to **v0.54.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added computed values and keyed list updates for reactive content, improving responsiveness and reducing unnecessary re-renders.
  * Introduced a new release version across the changelog, README, and specification.

* **Bug Fixes**
  * Functions can no longer reuse builtin names, preventing confusing naming conflicts; intentional shadowing remains allowed in external interfaces.
  * Improved reactive updates so list changes are applied incrementally, keeping unchanged items intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->