### PR TITLE
v0.57.0: ptr_str builtin — host→wasm strings (text input)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.57.0
+
+- **`ptr_str(ptr) -> string` — host→wasm strings (text input / forms).** Reads a
+  NUL-terminated string out of raw memory into an MFL (arena) string. This is the
+  missing **into-wasm** string direction: the JS host writes UTF-8 + a NUL into the
+  module's memory at a pointer the program `alloc`'d, then calls an export passing
+  that pointer, and the program reads it with `ptr_str`. (Strings already flowed
+  *out* of wasm as a memory pointer the host decodes; ints flow both ways.) Pairs
+  with `alloc`/`free`. Verified round-trip incl. multi-byte UTF-8 (accents, emoji).
+  Unblocks forms — an `<input>`'s text can now reach a machin component.
+
+  ```go
+  export func input_buf(n) (p) { p = alloc(n + 1) }     // host writes n bytes + NUL here
+  export func submit(p) { add_todo(ptr_str(p))  free(p) }
+  ```
+
 ## v0.56.0
 
 - **`framework/reactive.src`: `hydrate` + a value-embedding `slot` — isomorphic

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.56.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.57.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.56.0
+Version 0.57.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/bytes_io_test.go
+++ b/bytes_io_test.go
@@ -5,6 +5,42 @@ import (
 	"testing"
 )
 
+// ptr_str reads a NUL-terminated string out of raw memory — the host->wasm string
+// direction. Poke bytes into an alloc'd buffer, then read them back as a string.
+func TestPtrStrRoundTrip(t *testing.T) {
+	src := `func main() {
+		p := alloc(4)
+		poke_u8(p, 0, 72)  poke_u8(p, 1, 105)  poke_u8(p, 2, 0)
+		s := ptr_str(p)
+		println(s + "/" + str(len(s)))
+		free(p)
+	}`
+	fn, err := ParseFunc(normalize(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := RunCaptured(&Program{Funcs: []*FuncDecl{fn}})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(out) != "Hi/2" {
+		t.Fatalf("ptr_str round-trip = %q, want %q", strings.TrimSpace(out), "Hi/2")
+	}
+}
+
+// ptr_str returns a string; passing it where a string is needed type-checks, and
+// its argument is an int pointer.
+func TestPtrStrTypes(t *testing.T) {
+	fn, _ := ParseFunc(normalize(`func main() { s := ptr_str(alloc(2))  println(s) }`))
+	if _, err := Check(&Program{Funcs: []*FuncDecl{fn}}); err != nil {
+		t.Fatalf("ptr_str should type-check (int -> string): %v", err)
+	}
+	bad, _ := ParseFunc(normalize(`func main() { println(ptr_str("not a pointer")) }`))
+	if _, err := Check(&Program{Funcs: []*FuncDecl{bad}}); err == nil {
+		t.Fatal("ptr_str on a string arg should be a type error")
+	}
+}
+
 // read_file_bytes returns bytes (NUL-safe), and write_bytes takes (fd, bytes) ->
 // int — the pair that lets a server read a binary asset and write it to a socket
 // without a C-string body truncating it at the first NUL.

--- a/codegen.go
+++ b/codegen.go
@@ -380,6 +380,10 @@ static char* mfl_dup(const char* s) { size_t n = strlen(s); char* r = mfl_alloc(
    filling C buffers (vertex arrays) and structs to hand to a C API. */
 static int64_t mfl_raw_alloc(int64_t n) { return (int64_t)(intptr_t)calloc(1, (size_t)(n > 0 ? n : 0)); }
 static void mfl_raw_free(int64_t p) { free((void*)(intptr_t)p); }
+/* read a NUL-terminated string from a raw pointer into an MFL (arena) string — the
+   host->wasm direction: the JS host writes UTF-8 + a NUL into wasm memory at a
+   pointer the program alloc'd, then passes it here. */
+static char* mfl_ptr_str(int64_t p) { return p ? mfl_dup((const char*)(intptr_t)p) : mfl_dup(""); }
 static void mfl_poke_f32(int64_t p, int64_t o, double v) { *(float*)((char*)(intptr_t)p + o) = (float)v; }
 static void mfl_poke_i32(int64_t p, int64_t o, int64_t v) { *(int32_t*)((char*)(intptr_t)p + o) = (int32_t)v; }
 static void mfl_poke_u8(int64_t p, int64_t o, int64_t v) { *(uint8_t*)((char*)(intptr_t)p + o) = (uint8_t)v; }
@@ -3901,6 +3905,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_%s(%s, %s, %s)", ex.Callee, args[0], args[1], args[2]), nil
 	case "peek_f32", "peek_i32":
 		return fmt.Sprintf("mfl_%s(%s, %s)", ex.Callee, args[0], args[1]), nil
+	case "ptr_str":
+		return fmt.Sprintf("mfl_ptr_str(%s)", args[0]), nil
 	case "dial":
 		g.usesNet = true
 		return fmt.Sprintf("mfl_dial(%s, %s)", args[0], args[1]), nil

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.56.0"
+const machinVersion = "0.57.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -138,6 +138,7 @@ func machinGuide() guideCatalog {
 			{"poke_ptr", "(int, int, int) ->", "write an 8-byte pointer value at ptr+byteoffset (e.g. a buffer into a struct field)", "memory"},
 			{"peek_f32", "(int, int) -> float", "read a 32-bit float at ptr+byteoffset", "memory"},
 			{"peek_i32", "(int, int) -> int", "read a 32-bit int at ptr+byteoffset", "memory"},
+			{"ptr_str", "(int) -> string", "read a NUL-terminated string from a raw pointer into an MFL string — the host->wasm string direction (host writes UTF-8+NUL into wasm memory at an alloc'd ptr, passes it to an export). Pairs with alloc/free.", "memory"},
 			// collections
 			{"len", "(string|slice|map) -> int", "length", "collection"},
 			{"append", "([]T, T) -> []T", "grow a slice", "collection"},

--- a/types.go
+++ b/types.go
@@ -2061,6 +2061,12 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cInt)
 		c.addPair(argSlots[1], c.cInt)
 		return c.cInt, nil
+	case "ptr_str":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("ptr_str: 1 arg (pointer to NUL-terminated bytes)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cString, nil
 	case "listen", "accept":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("%s: 1 arg", ex.Callee)


### PR DESCRIPTION
## What

Adds **`ptr_str(ptr) -> string`** — reads a NUL-terminated string out of raw memory into an MFL (arena) string. This is the missing **into-wasm** string direction.

Strings already flowed *out* of wasm (machin returns a memory pointer the host decodes), and ints flow both ways. Now text can flow *in*: the JS host writes UTF-8 + a NUL into the module's `memory` at a pointer the program `alloc`'d, then calls an export passing that pointer, and the program reads it:

```go
export func input_buf(n) (p) { p = alloc(n + 1) }      // host writes n bytes + NUL here
export func submit(p) { add_todo(ptr_str(p))  free(p) }
```

```js
const bytes = new TextEncoder().encode(inputEl.value);
const p = Number(instance.exports.input_buf(BigInt(bytes.length)));
new Uint8Array(memory.buffer).set(bytes, p);
instance.exports.submit(BigInt(p));
```

**Unblocks forms** — an `<input>`'s text can finally reach a machin component (the gap that kept the isomorphic boilerplate to preset options).

## Verified

- wasm round-trip with multi-byte UTF-8: JS wrote `"héllo from JS 🎉 — user input!"` into wasm memory, machin read it back byte-perfect via `ptr_str`.
- Native poke→`ptr_str` round-trip.
- New `TestPtrStrRoundTrip` / `TestPtrStrTypes`; full suite green, `go vet` clean. Four version markers → **v0.57.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)