### PR TITLE
v0.58.0: fix calling a captured closure inside a lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.58.0
+
+- **Fix: a captured closure can be CALLED inside a lambda.** `func(){ fn() }` where
+  `fn` is a captured variable now works — previously it failed to compile (`call to
+  undefined function`), because closure conversion's free-variable scan ignored a
+  call's *callee*, so the closure was never captured. This is the higher-order
+  function building block: functions that return closures calling their arguments,
+  and the clean reactive shape `effect(func(){ compute() })` (a stored `func()`
+  thunk that calls a captured compute). Top-level functions/builtins are unaffected
+  (they were never in the enclosing scope, so they're still not captured). One-line
+  fix in `freeIdents`; no regressions.
+
 ## v0.57.0
 
 - **`ptr_str(ptr) -> string` — host→wasm strings (text input / forms).** Reads a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.57.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.58.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.57.0
+Version 0.58.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/closures_test.go
+++ b/closures_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A captured closure variable can now be CALLED inside a lambda — `func(){ fn() }`
+// where fn is captured. Previously the call resolved as a named-function call and
+// failed ("undefined function"), because freeIdents ignored a Call's callee, so the
+// closure was never captured. This is the higher-order-function building block.
+func TestCapturedClosureCalledInLambda(t *testing.T) {
+	cases := []struct{ src, want string }{
+		// return a closure that calls its captured argument
+		{`func wrap(fn) (g) { g = func() { return fn() } }
+		  func main() { h := wrap(func() { return 7 })  println(h()) }`, "7"},
+		// captured closure called with an argument, inside a nested lambda
+		{`func g(h) (r) { r = func() { return h(5) } }
+		  func main() { sq := g(func(x) { return x * x })  println(sq()) }`, "25"},
+		// the reactive shape: a stored func() thunk that calls a captured compute
+		{`var thunks = []func{}
+		  func effect(compute) { thunks = append(thunks, func() { println(compute()) }) }
+		  func main() { a := 3  effect(func() { return a * a })  t := thunks[0]  t()  a = 4  t() }`, "9 16"},
+	}
+	for i, c := range cases {
+		prog := progFromSrc(t, c.src)
+		out, err := RunCaptured(prog)
+		if err != nil {
+			t.Fatalf("case %d run: %v", i, err)
+		}
+		if got := strings.Join(strings.Fields(out), " "); got != c.want {
+			t.Fatalf("case %d = %q, want %q", i, got, c.want)
+		}
+	}
+}

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.57.0"
+const machinVersion = "0.58.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/transform.go
+++ b/transform.go
@@ -233,6 +233,13 @@ func freeIdents(body []Stmt, params []string) map[string]bool {
 			we(ex.L)
 			we(ex.R)
 		case *Call:
+			// The callee may be a captured closure variable (`fn()` where fn is a
+			// captured param/local), not a top-level function — mark it free so it is
+			// captured. Top-level function names and builtins aren't bound in the
+			// enclosing scope either, so this never captures them by mistake.
+			if !bound[ex.Callee] {
+				free[ex.Callee] = true
+			}
 			for _, a := range ex.Args {
 				we(a)
 			}


### PR DESCRIPTION
## What

Fixes a real limitation: **`func(){ fn() }` where `fn` is a captured variable** failed to compile with `call to undefined function "fn"`. The closure was never captured, so by type-check time the lambda had no `fn` in scope.

**Root cause:** closure conversion's free-variable scan (`freeIdents` in `transform.go`) recursed into a `Call`'s **arguments** but ignored its **callee**. So calling a closure-valued variable didn't mark it as free → it wasn't added to the lambda's captures.

**Fix (one line):** in the `*Call` case, mark `ex.Callee` as free when it isn't bound within the lambda. This is safe — top-level function names and builtins aren't bound in the *enclosing* scope either, so the capture filter (`if l.bound[name]`) never picks them up by mistake; only genuine captured variables (params/locals of the enclosing function) are captured.

## Why it matters

It's the higher-order-function building block:

```go
func wrap(fn) (g) { g = func() { return fn() } }        // return a closure calling a captured arg
func g(h) (r) { r = func() { return h(5) } }            // …with an argument
effect(func() { compute() })                            // a stored func() thunk calling a captured compute
```

That last shape is the *clean* reactive model — a single `[]func` of `func()` reactions that capture their own compute closures. The lack of it had forced `framework/reactive.src` into a more verbose typed-per-kind-array design; the runtime can now be simplified (separately).

## Tests

New `closures_test.go` (return-a-closure, closure-with-arg, reactive thunk). Full suite green, `go vet` clean. Four version markers → **v0.58.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a captured closure can now be called inside a lambda expression without causing a compile failure.
  * Improved handling so closures used as call targets are recognized correctly.
* **Tests**
  * Added coverage for calling captured closures inside lambdas across multiple cases.
* **Documentation**
  * Updated version information in the changelog, README, specification, and machine-readable guide to `0.58.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->