### PR TITLE
agent onboarding: curl|sh installer for the release binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,22 @@ func main(){println(fib(10))}
 
 Why not base64 (the old design)? Measured with [`tools/tokcost.py`](tools/tokcost.py), base64 costs an agent ~2.5× the output tokens to write/edit. A dense `machin pack` form still exists for distribution; `machin run` reads either.
 
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/javimosch/machin/main/install.sh | sh
+machin guide                             # learn the language (version-exact catalog, JSON)
+```
+
+Installs the latest release binary to `~/.local/bin` (override with `MACHIN_INSTALL`).
+machin compiles MFL through C, so building programs needs a **C compiler** (`cc`); the
+`--target wasm` web target additionally needs [`zig`](https://ziglang.org). Building
+web apps? See the [`machin-web` skill](skills/machin-web/SKILL.md).
+
 ## Use
 
 ```bash
-make build                               # → bin/machin   (needs Go 1.22 + a C compiler)
+make build                               # …or build from source (needs Go 1.22 + a C compiler)
 bin/machin run    examples/demo.mfl      # compile to native + execute
 bin/machin build  app.mfl -o app         # standalone native binary
 bin/machin build  app.mfl --emit-c       # print the generated C

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,8 @@ mkdir -p "$dest"
 curl -fSL --progress-bar "$url" -o "$dest/machin"
 chmod +x "$dest/machin"
 
-echo "machin: installed $dest/machin ($("$dest/machin" guide 2>/dev/null | grep -o '\"version\":\"[^\"]*\"' | head -1 | cut -d '\"' -f 4))"
+ver=$("$dest/machin" guide 2>/dev/null | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -1)
+echo "machin: installed $dest/machin ${ver:+(v$ver)}"
 case ":$PATH:" in
   *":$dest:"*) echo "machin: run 'machin guide' to learn the language" ;;
   *) echo "machin: add $dest to your PATH, then run 'machin guide'" ;;

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Install the latest machin compiler binary from GitHub Releases.
+#
+#   curl -fsSL https://raw.githubusercontent.com/javimosch/machin/main/install.sh | sh
+#
+# Installs to $MACHIN_INSTALL (default ~/.local/bin). machin compiles MFL through C,
+# so building programs needs a C compiler (cc/gcc); the wasm target additionally
+# needs `zig`. `machin guide` (the language catalog) needs neither.
+set -eu
+
+repo="javimosch/machin"
+dest="${MACHIN_INSTALL:-$HOME/.local/bin}"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+arch=$(uname -m)
+case "$arch" in
+  x86_64|amd64) arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) echo "machin: unsupported arch '$arch'" >&2; exit 1 ;;
+esac
+case "$os" in
+  linux|darwin) ;;
+  *) echo "machin: unsupported OS '$os' (use the release binaries directly on Windows)" >&2; exit 1 ;;
+esac
+
+tag=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest" \
+        | grep '"tag_name"' | head -1 | cut -d '"' -f 4)
+[ -n "$tag" ] || { echo "machin: could not resolve the latest release tag" >&2; exit 1; }
+
+asset="machin-$tag-$os-$arch"
+url="https://github.com/$repo/releases/download/$tag/$asset"
+
+echo "machin: downloading $tag ($os/$arch) -> $dest/machin"
+mkdir -p "$dest"
+curl -fSL --progress-bar "$url" -o "$dest/machin"
+chmod +x "$dest/machin"
+
+echo "machin: installed $dest/machin ($("$dest/machin" guide 2>/dev/null | grep -o '\"version\":\"[^\"]*\"' | head -1 | cut -d '\"' -f 4))"
+case ":$PATH:" in
+  *":$dest:"*) echo "machin: run 'machin guide' to learn the language" ;;
+  *) echo "machin: add $dest to your PATH, then run 'machin guide'" ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ mkdir -p "$dest"
 curl -fSL --progress-bar "$url" -o "$dest/machin"
 chmod +x "$dest/machin"
 
-ver=$("$dest/machin" guide 2>/dev/null | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -1)
+ver=$("$dest/machin" guide 2>/dev/null | sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' | head -1)
 echo "machin: installed $dest/machin ${ver:+(v$ver)}"
 case ":$PATH:" in
   *":$dest:"*) echo "machin: run 'machin guide' to learn the language" ;;


### PR DESCRIPTION
## What

Adds `install.sh` + a README **Install** section so an agent (or human) arriving at the repo can get the `machin` binary in one line:

```sh
curl -fsSL https://raw.githubusercontent.com/javimosch/machin/main/install.sh | sh
machin guide
```

It detects os/arch (linux/darwin × amd64/arm64), resolves the latest release tag, downloads `machin-v{tag}-{os}-{arch}` into `~/.local/bin` (override with `MACHIN_INSTALL`), and `chmod +x`. The README notes the deps (`cc` to build programs, `zig` for `--target wasm`; `machin guide` needs neither) and links the `machin-web` skill.

## Why

Closes the small but real gap in the agent-discovery flow: to reach `machin guide` (and everything it points to), an agent needed to build from source. Now it's `curl | sh`. Verified end-to-end — the script downloaded a working v0.58.0 binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)