### PR TITLE
v0.59.0: simplify the reactive runtime + a client-side router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
   API, **byte-identical patch behavior** (verified), ~9 fewer globals, the dispatch
   gone. (Re-confirmed gotcha: a parameter named like a builtin — `keys` — is
   shadowed at call sites; `each`'s param was renamed `keyfn`.)
+- **`framework/router.src` — a client-side router** (composes with reactive, enabled
+  by the cleaner `reaction()` primitive). The active route is a signal (an int
+  index): `route(path)` registers pages, `navigate(i)` / `nav(path)` switch,
+  `link(path, label)` renders an anchor, and `outlet(id, render)` re-renders the
+  active page (a reaction over a new `dom_html` host import) and syncs the address
+  bar (`nav_url`). `nav` takes the path string from the host via `ptr_str`. For
+  multi-page admin apps / SPAs.
 
 ## v0.58.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.59.0
+
+- **Fix: a closure can capture and mutate an aggregate local** (a slice, map, or
+  struct). The heap box for such a captured local is now zeroed via `calloc`;
+  codegen previously emitted `*box = {0}`, invalid C for an aggregate type (it
+  compiled only for scalars). So a closure that captures `xs := []int{}` and
+  `append`s to it across calls now works.
+- **`framework/reactive.src` rewritten on the simpler model** the captured-closure
+  fixes (v0.58.0 + this) unlock: a reaction is now just a **`func()` thunk that
+  captures its own compute closure** and applies its effect, in one `[]func`
+  registry — instead of typed per-kind arrays (`c_fn`/`b_fn`/`e_kf`/…) with a
+  `run_computed`/`run_bind`/`run_each` dispatch. `bind` captures its `last`, `each`
+  its `old` key set, `computed` is a signal kept current by a reaction. Same public
+  API, **byte-identical patch behavior** (verified), ~9 fewer globals, the dispatch
+  gone. (Re-confirmed gotcha: a parameter named like a builtin — `keys` — is
+  shadowed at call sites; `each`'s param was renamed `keyfn`.)
+
 ## v0.58.0
 
 - **Fix: a captured closure can be CALLED inside a lambda.** `func(){ fn() }` where

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.58.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.59.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.58.0
+Version 0.59.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/closures_test.go
+++ b/closures_test.go
@@ -33,3 +33,20 @@ func TestCapturedClosureCalledInLambda(t *testing.T) {
 		}
 	}
 }
+
+// A closure can capture and MUTATE an aggregate local (a slice/map/struct), and the
+// change persists across calls. The heap box for such a local is zeroed via calloc —
+// previously codegen emitted `*box = {0}`, invalid C for a slice. This is what lets
+// the reactive runtime's `each` capture its `old []int` key set.
+func TestCapturedSliceMutation(t *testing.T) {
+	prog := progFromSrc(t, `
+func acc() (push) { xs := []int{}  push = func(v) { xs = append(xs, v)  return len(xs) } }
+func main() { p := acc()  println(p(10))  println(p(20))  println(p(30)) }`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.Join(strings.Fields(out), " "); got != "1 2 3" {
+		t.Fatalf("captured slice mutation = %q, want %q", got, "1 2 3")
+	}
+}

--- a/codegen.go
+++ b/codegen.go
@@ -2468,7 +2468,9 @@ func (g *cgen) function(inst string) error {
 	for _, name := range g.c.Locals(inst) {
 		if fn.Boxed[name] {
 			ct := g.c.VarCType(inst, name)
-			fmt.Fprintf(&g.buf, "    %s* v_%s = mfl_alloc(sizeof(%s)); *v_%s = %s;\n", ct, name, ct, name, cZero(g.c.VarKind(inst, name)))
+			// Zero the heap cell via calloc — the body assigns the real value. (A
+			// `*p = {0}` assignment is invalid C for aggregate types like slices.)
+			fmt.Fprintf(&g.buf, "    %s* v_%s = mfl_calloc(1, sizeof(%s));\n", ct, name, ct)
 			continue
 		}
 		fmt.Fprintf(&g.buf, "    %s v_%s = %s;\n", g.c.VarCType(inst, name), name, cZero(g.c.VarKind(inst, name)))

--- a/framework/reactive.src
+++ b/framework/reactive.src
@@ -6,30 +6,23 @@ extern "env" {
     fn list_order(string, string)
 }
 
+// reactive.src — fine-grained reactivity for machin web UIs (signals + a patch
+// list, the Solid/Leptos model). A REACTION is a func() that reads signals (its
+// dependencies are auto-tracked each run) and applies an effect — patch a DOM slot,
+// set a derived signal, or reconcile a keyed list. On a signal change only the
+// reactions that read it re-run, and only changed text/keys touch the DOM.
+
 var sval = []int{}
 var n_sig = 0
 
-var r_kind = []int{}     // reaction kind: 0 computed, 1 bind, 2 each
-var r_sub = []int{}      // index into the per-kind arrays
+var r_fn = []func{}      // reactions: func()
 var r_dirty = []int{}
 var n_r = 0
 
-var c_fn = []func{}      // computed compute: func() -> int
-var c_sig = []int{}      // its backing signal id
-
-var b_fn = []func{}      // bind compute: func() -> string
-var b_slot = []string{}
-var b_last = []string{}
-
-var e_kf = []func{}      // each keys: func() -> string (csv of the ordered keys)
-var e_if = []func{}      // each item: func(int) -> string
-var e_cont = []string{}
-var e_old = []string{}   // last key set, csv
-
-var edge_sig = []int{}
+var edge_sig = []int{}   // dependency edges (signal id -> reaction id), re-tracked each run
 var edge_r = []int{}
-var tracking = 0 - 1
-var flushing = 0
+var tracking = 0 - 1     // reaction currently running (auto-tracking), or -1
+var flushing = 0         // re-entrancy guard for commit
 
 func signal(init) (id) {
     id = n_sig
@@ -58,6 +51,75 @@ func clear_edges(rid) {
     }
     edge_sig = ns
     edge_r = nr
+}
+
+func run_reaction(rid) {
+    clear_edges(rid)
+    prev := tracking
+    tracking = rid
+    f := r_fn[rid]
+    f()
+    tracking = prev
+}
+
+// reaction registers a func() and runs it once (recording its dependencies).
+func reaction(fn) (rid) {
+    rid = n_r
+    r_fn = append(r_fn, fn)
+    r_dirty = append(r_dirty, 0)
+    n_r = n_r + 1
+    run_reaction(rid)
+}
+
+// commit re-runs dirty reactions to a fixpoint (a computed sets a signal, which
+// may dirty more reactions — keep scanning until none are dirty).
+func commit() {
+    if flushing == 1 { return }
+    flushing = 1
+    again := 1
+    while again == 1 {
+        again = 0
+        i := 0
+        while i < n_r {
+            if r_dirty[i] == 1 {
+                r_dirty[i] = 0
+                run_reaction(i)
+                again = 1
+            }
+            i = i + 1
+        }
+    }
+    flushing = 0
+}
+
+func set(id, v) {
+    if sval[id] == v { return }
+    sval[id] = v
+    i := 0
+    while i < len(edge_sig) {
+        if edge_sig[i] == id { r_dirty[edge_r[i]] = 1 }
+        i = i + 1
+    }
+    commit()
+}
+
+// computed: a memoized derived signal, kept current by a reaction that sets it.
+func computed(fn) (id) {
+    id = signal(0)
+    reaction(func() { set(id, fn()) })
+}
+
+// bind: tie a compute closure (-> string) to a DOM slot; patch only on text change.
+// The reaction captures `last` (boxed), which persists across its re-runs.
+func bind(slot, compute) {
+    last := ""
+    reaction(func() {
+        v := compute()
+        if v != last {
+            last = v
+            dom_patch(slot, v)
+        }
+    })
 }
 
 func in_list(xs, k) (yes) {
@@ -90,127 +152,28 @@ func parse_csv(s) (xs) {
     }
 }
 
-// A reaction runs its stored compute closure with dependency tracking on, then
-// applies its effect. Each kind has its own runner (one closure signature per
-// function — combining them in one scope confuses inference). run_reaction routes.
-
-func run_computed(s, rid) {
-    prev := tracking
-    tracking = rid
-    cf := c_fn[s]
-    cv := cf()
-    tracking = prev
-    set(c_sig[s], cv)
-}
-
-func run_bind(s, rid) {
-    prev := tracking
-    tracking = rid
-    bf := b_fn[s]
-    bv := bf()
-    tracking = prev
-    if bv != b_last[s] {
-        b_last[s] = bv
-        dom_patch(b_slot[s], bv)
-    }
-}
-
-// A keys closure returns the ordered keys as a CSV STRING (build it with the
-// exported `csv` helper: `func() { get(ver)  return csv(my_ids) }`). Using a
-// string keeps the closure's return type pinned via parse_csv, so an app that
-// registers no list still type-checks (an empty []int closure would not).
-func run_each(s, rid) {
-    prev := tracking
-    tracking = rid
-    kf := e_kf[s]
-    cs := kf()
-    tracking = prev
-    ks := parse_csv(cs)
-    cont := e_cont[s]
-    old := parse_csv(e_old[s])
-    i := 0
-    while i < len(old) {
-        if in_list(ks, old[i]) == 0 { list_remove(cont, str(old[i])) }
-        i = i + 1
-    }
-    itf := e_if[s]
-    i = 0
-    while i < len(ks) {
-        if in_list(old, ks[i]) == 0 { list_insert(cont, str(ks[i]), itf(ks[i])) }
-        i = i + 1
-    }
-    list_order(cont, cs)
-    e_old[s] = cs
-}
-
-func run_reaction(rid) {
-    clear_edges(rid)
-    k := r_kind[rid]
-    s := r_sub[rid]
-    if k == 0 { run_computed(s, rid) }
-    if k == 1 { run_bind(s, rid) }
-    if k == 2 { run_each(s, rid) }
-}
-
-func register(kind, sub) (rid) {
-    rid = n_r
-    r_kind = append(r_kind, kind)
-    r_sub = append(r_sub, sub)
-    r_dirty = append(r_dirty, 0)
-    n_r = n_r + 1
-    run_reaction(rid)
-}
-
-func commit() {
-    if flushing == 1 { return }
-    flushing = 1
-    again := 1
-    while again == 1 {
-        again = 0
+// each: keyed list reconciliation. `keys()` returns the ordered keys as a CSV
+// string; `item(key)` returns one item's HTML. The reaction captures `old` (the
+// last key set) and emits only insert/remove/order deltas — never re-rendering an
+// unchanged item. (To update a kept item's content, encode the data in the key.)
+func each(cont, keyfn, item) {
+    old := []int{}
+    reaction(func() {
+        cs := keyfn()
+        ks := parse_csv(cs)
         i := 0
-        while i < n_r {
-            if r_dirty[i] == 1 {
-                r_dirty[i] = 0
-                run_reaction(i)
-                again = 1
-            }
+        while i < len(old) {
+            if in_list(ks, old[i]) == 0 { list_remove(cont, str(old[i])) }
             i = i + 1
         }
-    }
-    flushing = 0
-}
-
-func set(id, v) {
-    if sval[id] == v { return }
-    sval[id] = v
-    i := 0
-    while i < len(edge_sig) {
-        if edge_sig[i] == id { r_dirty[edge_r[i]] = 1 }
-        i = i + 1
-    }
-    commit()
-}
-
-func computed(fn) (id) {
-    c_fn = append(c_fn, fn)
-    id = signal(0)
-    c_sig = append(c_sig, id)
-    register(0, len(c_fn) - 1)
-}
-
-func bind(slot, fn) {
-    b_fn = append(b_fn, fn)
-    b_slot = append(b_slot, slot)
-    b_last = append(b_last, "")
-    register(1, len(b_fn) - 1)
-}
-
-func each(cont, kf, itf) {
-    e_kf = append(e_kf, kf)
-    e_if = append(e_if, itf)
-    e_cont = append(e_cont, cont)
-    e_old = append(e_old, "")
-    register(2, len(e_kf) - 1)
+        i = 0
+        while i < len(ks) {
+            if in_list(old, ks[i]) == 0 { list_insert(cont, str(ks[i]), item(ks[i])) }
+            i = i + 1
+        }
+        list_order(cont, cs)
+        old = ks
+    })
 }
 
 // ---- templating ----
@@ -278,3 +241,4 @@ func mount(root, html) {
     dom_mount(root, html)
     hydrate(html)
 }
+

--- a/framework/router.src
+++ b/framework/router.src
@@ -1,0 +1,83 @@
+// router.src — a tiny client-side router for machin web UIs (composes with
+// reactive.src). The active route is a signal (an int index); navigating updates
+// it, an outlet re-renders the matching page, and the address bar stays in sync.
+//
+//   machin encode framework/reactive.src framework/router.src yourapp.src > app.mfl
+//
+// Usage in a component:
+//   export func start() {
+//       router_init(0)                     // active route is a signal
+//       route("/")  route("/users")        // register paths, in index order
+//       mount("app", nav_bar() + "<div id=outlet></div>")
+//       outlet("outlet", func() { return page() })   // page() switches on current_route()
+//   }
+//   func page() (h) {
+//       r := current_route()
+//       if r == 0 { h = home_html() }
+//       if r == 1 { h = users_html() }
+//   }
+//   func nav_bar() (h) { h = link("/", "home") + link("/users", "users") }
+//
+// The host implements two imports — dom_html(id, html) (set an element's innerHTML)
+// and nav_url(path) (history.pushState + address bar) — and forwards [data-nav]
+// link clicks + popstate to nav() (writing the path string into wasm).
+
+extern "env" {
+    fn dom_html(string, string)
+    fn nav_url(string)
+}
+
+var route_now = 0           // signal id: the active route index
+var route_paths = []string{}
+var route_n = 0
+
+// router_init creates the active-route signal (call first, with the initial index).
+func router_init(initial) {
+    route_now = signal(initial)
+}
+
+// route registers a path and returns its index (call once per page, in order).
+func route(path) (i) {
+    i = route_n
+    route_paths = append(route_paths, path)
+    route_n = route_n + 1
+}
+
+func path_index(path) (i) {
+    i = 0
+    j := 0
+    while j < route_n {
+        if route_paths[j] == path { i = j }
+        j = j + 1
+    }
+}
+
+// current_route returns the active index — read it in your page render so the outlet
+// re-renders on navigation.
+func current_route() (i) { i = get(route_now) }
+
+// navigate switches to a route index and syncs the address bar.
+func navigate(i) {
+    set(route_now, i)
+    nav_url(route_paths[i])
+}
+
+// nav switches by PATH; the host calls it for a link click / popstate, writing the
+// path string into the buffer nav_buf returns.
+export func nav_buf(nbytes) (p) { p = alloc(nbytes + 1) }
+export func nav(p) {
+    path := ptr_str(p)
+    free(p)
+    navigate(path_index(path))
+}
+
+// link renders a navigation anchor; the host intercepts [data-nav] clicks.
+func link(path, label) (h) {
+    h = "<a href=\"" + path + "\" data-nav=\"" + path + "\">" + label + "</a>"
+}
+
+// outlet re-renders the active page into a container whenever the route — or any
+// signal the page reads — changes.
+func outlet(id, render) {
+    reaction(func() { dom_html(id, render()) })
+}

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.58.0"
+const machinVersion = "0.59.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/reactive_test.go
+++ b/reactive_test.go
@@ -168,6 +168,50 @@ func main() {
 	}
 }
 
+// The router (framework/router.src, on top of reactive) switches pages by route
+// index: navigate() re-renders the outlet (via dom_html) and syncs the URL.
+func TestRouter(t *testing.T) {
+	rv, err := os.ReadFile("framework/reactive.src")
+	if err != nil {
+		t.Skip("framework/reactive.src not found")
+	}
+	rt, err := os.ReadFile("framework/router.src")
+	if err != nil {
+		t.Skip("framework/router.src not found")
+	}
+	strip := regexp.MustCompile(`(?s)extern "env" \{.*?\}\n`)
+	runtime := strip.ReplaceAllString(string(rv), "") + strip.ReplaceAllString(string(rt), "")
+	host := `
+func dom_mount(r, h) {}
+func dom_patch(s, v) {}
+func list_insert(c, k, h) {}
+func list_remove(c, k) {}
+func list_order(c, ks) {}
+func dom_html(id, html) { println("OUT " + html) }
+func nav_url(path) { println("URL " + path) }`
+	app := `
+func page() (h) { r := current_route()  h = "?"  if r == 0 { h = "home" }  if r == 1 { h = "users" } }
+func main() {
+    router_init(0)
+    route("/")  route("/users")
+    outlet("outlet", func() { return page() })
+    navigate(1)
+    navigate(0)
+}`
+	prog, perr := progFromSrcErr(runtime + host + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := "OUT home\nOUT users\nURL /users\nOUT home\nURL /\n"
+	if out != want {
+		t.Fatalf("router output:\n%q\nwant:\n%q", out, want)
+	}
+}
+
 // progFromSrcErr is like progFromSrc but returns the error (for table tests).
 func progFromSrcErr(src string) (*Program, error) {
 	blocks, err := splitFunctions(src)


### PR DESCRIPTION
## Two things, one enabling the other

### Fix: closures can capture & mutate an aggregate local
A closure that captures a slice/map/struct local and mutates it failed to compile — the heap box for the captured local was initialized with `*box = {0}`, which is invalid C for an aggregate type (it only compiled for scalars). Now the box is zeroed via `calloc` (the body assigns the real value anyway). So this works:

```go
func acc() (push) { xs := []int{}  push = func(v) { xs = append(xs, v)  return len(xs) } }
// p := acc(); p(10)→1; p(20)→2; p(30)→3
```

### Simplify `framework/reactive.src`
With that fix plus the v0.58.0 captured-closure-**call** fix, the reactive runtime no longer needs its workaround. A **reaction is now just a `func()` thunk that captures its own compute closure** and applies its effect, held in one `[]func` registry:

- `bind(slot, compute)` → a reaction capturing `last` (boxed, persists across runs)
- `each(cont, keyfn, item)` → a reaction capturing `old []int` (the last key set)
- `computed(fn)` → a signal kept current by a reaction

Gone: the typed per-kind arrays (`c_fn`/`c_sig`/`b_fn`/`b_slot`/`b_last`/`e_kf`/`e_if`/`e_cont`/`e_old`) and the `run_computed`/`run_bind`/`run_each` + `r_kind`/`r_sub` dispatch. **~9 fewer globals**, the kind-dispatch removed.

**Same public API**, and **byte-identical patch behavior** — verified `start`/`add`/`sort`/`pop` on the reactive demo produce exactly the same minimal patch list as before (e.g. `sort` → only an `order`, no item re-render).

## Tests / version

New `TestCapturedSliceMutation`; the reactive suite (templating, hydrate, minimal-patches, no-list) still green. `go vet` clean. Four version markers → **v0.59.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)