### PR TITLE
docs: router in the web skill + north star

### DIFF
--- a/docs/NORTH-STAR-WEB.md
+++ b/docs/NORTH-STAR-WEB.md
@@ -49,6 +49,7 @@ north star is to make it first-class.
 | **fine-grained reactivity** | [machin-web-demo-reactive](https://github.com/javimosch/machin-web-demo-reactive) · [`framework/reactive.src`](../framework) | signals + a patch list (Solid/Leptos model) in MFL: auto-tracked deps, only changed bindings recompute, only changed text patches — drove `[]func` (v0.53.0), computed + keyed lists (v0.54.0), templating (v0.55.0) |
 | **reactive forms (text input)** | [machin-web-demo-todo](https://github.com/javimosch/machin-web-demo-todo) | a todo app — typed text flows into wasm via `ptr_str` (v0.57.0); signals + computed + keyed list + templating |
 | **CRUD back-office** | [machin-web-demo-users](https://github.com/javimosch/machin-web-demo-users) | one binary = CLI + HTTP server + **SQLite** JSON API + reactive view; `sqlite_query`→JSON + `json_get` + `ptr_str` |
+| **multi-page SPA / routing** | [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router) · [`framework/router.src`](../framework) | client-side router (the active route is a signal); no-reload nav, back/forward, deep-links; built on the `reaction()` primitive (v0.59.0) |
 | **isomorphic app boilerplate** | [boilerplate-cli-ui-machin-isomorphic](https://github.com/javimosch/boilerplate-cli-ui-machin-isomorphic) | one binary = CLI + HTTP server + JSON API + reactive wasm UI; SSR + hydrate (v0.56.0); shared `models.src` |
 | backend web framework | [`framework/machweb.src`](../framework) | `serve(port, handler)` → self-contained native server |
 

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -87,6 +87,16 @@ the DOM (no `innerHTML` churn, no vdom diff).
 | `mount(root, html)` | set the root's innerHTML once, then activate the queued slots/lists (client-side render) |
 | `hydrate(html)` | activate them against an **already-SSR'd DOM** (no re-render) — for isomorphic pages |
 
+**Multi-page (`framework/router.src`).** For an admin app with several pages, compose
+the router too. The active route is a signal (an int index): `router_init(0)`,
+`route(path)` registers pages in order, `link(path, label)` renders a nav anchor,
+`current_route()` reads the active index, and `outlet(id, render)` re-renders the
+active page (a reaction over a `dom_html` host import) and syncs the address bar.
+`page()` switches on `current_route()` and must be a **pure render** (read signals,
+never `set` — that loops). The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
+clicks to `nav(path)` (path in via `ptr_str`) + `popstate`, and a catch-all server
+serves the shell for any path (deep-links). See [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router).
+
 A whole component is one expression:
 
 ```go
@@ -184,7 +194,7 @@ reactive over the API. One binary, one language.
 
 ## Pointers
 
-- Frameworks: [`framework/machweb.src`](../../framework) · `reactive.src` · `flags.src`.
+- Frameworks: [`framework/machweb.src`](../../framework) · `reactive.src` · `router.src` · `flags.src`.
 - Boilerplate: [boilerplate-cli-ui-machin-isomorphic](https://github.com/javimosch/boilerplate-cli-ui-machin-isomorphic).
 - Focused demos: [machin-web-demo-wasm](https://github.com/javimosch/machin-web-demo-wasm) (the bridge) · [machin-web-demo-ssr](https://github.com/javimosch/machin-web-demo-ssr) (isomorphic SSR) · [machin-web-demo-reactive](https://github.com/javimosch/machin-web-demo-reactive) (signals/computed/lists/templating) · [machin-web-demo-todo](https://github.com/javimosch/machin-web-demo-todo) (forms / text input).
 - Direction & the dogfood record: [`docs/NORTH-STAR-WEB.md`](../../docs/NORTH-STAR-WEB.md).


### PR DESCRIPTION
Documents framework/router.src (the client-side SPA router, v0.59.0) in the `machin-web` skill (a multi-page section + the pointers list) and the web north-star table, pointing at [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for multi-page routing and deep links in the client framework overview.
  * Expanded the capability table to show that multi-page SPA routing is supported.
  * Clarified how routes, links, active page rendering, and server-side fallback behavior work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->