### PR TITLE
test: solidify the web domain with framework unit tests

### DIFF
--- a/machweb_test.go
+++ b/machweb_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// machwebProg composes framework/machweb.src (the server framework) with a test
+// app and parses it. machweb has no extern block — its net builtins (listen/accept/
+// read/write) compile but are only reached from serve(), which the tests never call,
+// so the pure request/response/router logic runs natively under RunCaptured.
+func machwebProg(t *testing.T, app string) *Program {
+	t.Helper()
+	data, err := os.ReadFile("framework/machweb.src")
+	if err != nil {
+		t.Skip("framework/machweb.src not found")
+	}
+	prog, perr := progFromSrcErr(string(data) + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	return prog
+}
+
+// parse_request must split the request line, extract the body after the blank line,
+// and build a lowercased header map; header() is case-insensitive and "" when absent;
+// param() returns the path segment after a prefix.
+func TestMachwebParseRequest(t *testing.T) {
+	app := `
+func main() {
+    raw := "POST /users/42 HTTP/1.1\r\nHost: ex\r\nContent-Type: application/json\r\nContent-Length: 7\r\n\r\n{\"a\":1}"
+    req := parse_request(raw)
+    println("method=" + req.method)
+    println("path=" + req.path)
+    println("body=" + req.body)
+    println("ctype=" + header(req, "Content-Type"))
+    println("clen=" + header(req, "content-length"))
+    println("host=" + header(req, "HOST"))
+    println("missing=[" + header(req, "X-Nope") + "]")
+    println("param=" + param(req.path, "/users/"))
+    println("noprefix=[" + param(req.path, "/posts/") + "]")
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"method=POST", "path=/users/42", "body={\"a\":1}",
+		"ctype=application/json", // header name is case-insensitive
+		"clen=7",
+		"host=ex",
+		"missing=[]",   // absent header -> ""
+		"param=42",     // segment after the prefix
+		"noprefix=[]",  // prefix that doesn't match -> ""
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// content_length reads the Content-Length value from a header block (and is 0 when
+// the header is absent) — this is what read_request uses to wait for a full body.
+func TestMachwebContentLength(t *testing.T) {
+	app := `
+func main() {
+    println("a=" + str(content_length("GET / HTTP/1.1\r\nContent-Length: 42\r\nHost: x\r\n")))
+    println("b=" + str(content_length("GET / HTTP/1.1\r\nHost: x\r\n")))
+    println("c=" + str(content_length("POST / HTTP/1.1\r\ncontent-length: 5\r\n")))
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"a=42", "b=0", "c=5"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// The response builders set the right status line and content type, and is_bin=0
+// for text bodies (so machweb_handle writes the text path, not the bytes path).
+func TestMachwebResponseBuilders(t *testing.T) {
+	app := `
+func main() {
+    j := ok_json("[]")
+    println("json=" + j.status + "|" + j.ctype + "|" + str(j.is_bin))
+    h := ok_html("<h1>")
+    println("html=" + h.ctype)
+    println("nf=" + not_found().status)
+    b := bad_request("nope")
+    println("bad=" + b.status + "|" + b.body)
+    println("created=" + created("{}").status)
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"json=200 OK|application/json|0",
+		"html=text/html; charset=utf-8",
+		"nf=404 Not Found",
+		"bad=400 Bad Request|nope",
+		"created=201 Created",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// The map-based router dispatches "METHOD PATH" to its handler closure and falls
+// back to 404 for an unregistered route.
+func TestMachwebRouterDispatch(t *testing.T) {
+	app := `
+func mkreq(method, path) (r) { r = Request{method: method, path: path, body: "", headers: make(map[string]string)} }
+func main() {
+    r := new_router()
+    route(r, "GET", "/", func(req) { return ok_text("home") })
+    route(r, "GET", "/users", func(req) { return ok_json("[1,2]") })
+    route(r, "POST", "/users", func(req) { return created("{}") })
+    println("get_root=" + dispatch(r, mkreq("GET", "/")).body)
+    println("get_users=" + dispatch(r, mkreq("GET", "/users")).body)
+    println("post_users=" + dispatch(r, mkreq("POST", "/users")).status)
+    println("unknown=" + dispatch(r, mkreq("DELETE", "/x")).status)
+    println("wrong_method=" + dispatch(r, mkreq("PUT", "/users")).status)
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"get_root=home",
+		"get_users=[1,2]",
+		"post_users=201 Created", // method is part of the key
+		"unknown=404 Not Found",
+		"wrong_method=404 Not Found", // GET /users registered, PUT /users is not
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/reactive_test.go
+++ b/reactive_test.go
@@ -212,6 +212,170 @@ func main() {
 	}
 }
 
+// path_index resolves a path to its registered index (and defaults to 0 for an
+// unknown path); navigate(path_index(p)) is the by-path entry the host uses for
+// link clicks and popstate.
+func TestRouterPathIndex(t *testing.T) {
+	rv, err := os.ReadFile("framework/reactive.src")
+	if err != nil {
+		t.Skip("framework/reactive.src not found")
+	}
+	rt, err := os.ReadFile("framework/router.src")
+	if err != nil {
+		t.Skip("framework/router.src not found")
+	}
+	strip := regexp.MustCompile(`(?s)extern "env" \{.*?\}\n`)
+	runtime := strip.ReplaceAllString(string(rv), "") + strip.ReplaceAllString(string(rt), "")
+	host := `
+func dom_mount(r, h) {}
+func dom_patch(s, v) {}
+func list_insert(c, k, h) {}
+func list_remove(c, k) {}
+func list_order(c, ks) {}
+func dom_html(id, html) { println("OUT " + html) }
+func nav_url(path) { println("URL " + path) }`
+	app := `
+func page() (h) { h = str(current_route()) }
+func main() {
+    router_init(0)
+    route("/")  route("/users")  route("/settings")
+    outlet("outlet", func() { return page() })
+    println("idx /users=" + str(path_index("/users")))
+    println("idx /settings=" + str(path_index("/settings")))
+    println("idx /missing=" + str(path_index("/missing")))
+    navigate(path_index("/settings"))
+    navigate(path_index("/"))
+}`
+	prog, perr := progFromSrcErr(runtime + host + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"idx /users=1",
+		"idx /settings=2",
+		"idx /missing=0", // unknown path defaults to the first route
+		"OUT 2\nURL /settings",
+		"OUT 0\nURL /",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// reactiveProg composes framework/reactive.src (extern block stripped, host funcs
+// substituted) with an app, for the behavioral tests below.
+func reactiveProg(t *testing.T, host, app string) *Program {
+	t.Helper()
+	data, err := os.ReadFile("framework/reactive.src")
+	if err != nil {
+		t.Skip("framework/reactive.src not found")
+	}
+	runtime := regexp.MustCompile(`(?s)extern "env" \{.*?\}\n`).ReplaceAllString(string(data), "")
+	prog, perr := progFromSrcErr(runtime + host + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	return prog
+}
+
+// The three load-bearing reactivity guarantees, in one run:
+//   1. change detection — set(id, sameValue) emits NO patch;
+//   2. dependency isolation — only reactions that READ a signal re-run;
+//   3. computed transitivity — set(base) updates a computed, which patches its slot.
+func TestReactiveChangeAndIsolation(t *testing.T) {
+	host := `func dom_patch(slot, val) { println("patch " + slot + "=" + val) }`
+	app := `
+var a = 0
+var b = 0
+func main() {
+    a = signal(1)
+    b = signal(100)
+    bind("A", func() { return str(get(a)) })
+    bind("B", func() { return str(get(b)) })
+    c := computed(func() { return get(a) * 10 })
+    bind("C", func() { return str(get(c)) })
+    println("-- set a=1 (same) --")  set(a, 1)
+    println("-- set a=2 --")          set(a, 2)
+    println("-- set b=200 --")        set(b, 200)
+}`
+	out, err := RunCaptured(reactiveProg(t, host, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// initial paints
+	for _, want := range []string{"patch A=1", "patch B=100", "patch C=10"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing initial %q in:\n%s", want, out)
+		}
+	}
+	seg := func(from, to string) string {
+		i := strings.Index(out, from)
+		if to == "" {
+			return out[i:]
+		}
+		return out[i:strings.Index(out, to)]
+	}
+	// (1) setting the same value patches nothing
+	if same := seg("-- set a=1 (same) --", "-- set a=2 --"); strings.Contains(same, "patch") {
+		t.Fatalf("set to an equal value must not patch; got:\n%s", same)
+	}
+	// (2)+(3) set a=2 patches A and the computed C, but NOT the independent B
+	a2 := seg("-- set a=2 --", "-- set b=200 --")
+	if !strings.Contains(a2, "patch A=2") || !strings.Contains(a2, "patch C=20") {
+		t.Fatalf("set a=2 should patch A and computed C; got:\n%s", a2)
+	}
+	if strings.Contains(a2, "patch B") {
+		t.Fatalf("set a must not touch B (dependency isolation); got:\n%s", a2)
+	}
+	// setting b touches only B
+	b2 := seg("-- set b=200 --", "")
+	if !strings.Contains(b2, "patch B=200") || strings.Contains(b2, "patch A") || strings.Contains(b2, "patch C") {
+		t.Fatalf("set b should patch only B; got:\n%s", b2)
+	}
+}
+
+// each emits MINIMAL list deltas: a removal is one list_remove (no re-insert), and a
+// pure reorder is a single list_order with no insert/remove at all.
+func TestReactiveEachRemoveReorder(t *testing.T) {
+	host := `
+func list_insert(c, k, h) { println("insert " + k) }
+func list_remove(c, k) { println("remove " + k) }
+func list_order(c, ks) { println("order " + ks) }`
+	app := `
+var ver = 0
+var keys_csv = ""
+func main() {
+    ver = signal(0)
+    each("L", func() { get(ver)  return keys_csv }, func(k) { return str(k) })
+    println("-- 1,2,3 --")       keys_csv = "1,2,3"  set(ver, 1)
+    println("-- remove 2 --")    keys_csv = "1,3"    set(ver, 2)
+    println("-- reorder 3,1 --") keys_csv = "3,1"    set(ver, 3)
+}`
+	out, err := RunCaptured(reactiveProg(t, host, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	rm := out[strings.Index(out, "-- remove 2 --"):strings.Index(out, "-- reorder 3,1 --")]
+	if !strings.Contains(rm, "remove 2") || strings.Contains(rm, "insert") {
+		t.Fatalf("removing a key should emit one remove and no insert; got:\n%s", rm)
+	}
+	if !strings.Contains(rm, "order 1,3") {
+		t.Fatalf("removal should re-order to 1,3; got:\n%s", rm)
+	}
+	ro := out[strings.Index(out, "-- reorder 3,1 --"):]
+	if strings.Contains(ro, "insert") || strings.Contains(ro, "remove") {
+		t.Fatalf("a pure reorder must not insert/remove; got:\n%s", ro)
+	}
+	if !strings.Contains(ro, "order 3,1") {
+		t.Fatalf("reorder should emit order 3,1; got:\n%s", ro)
+	}
+}
+
 // progFromSrcErr is like progFromSrc but returns the error (for table tests).
 func progFromSrcErr(src string) (*Program, error) {
 	blocks, err := splitFunctions(src)


### PR DESCRIPTION
Starts hardening the web domain with MFL-level unit tests for the framework modules.

**machweb** (the server framework) had **zero** MFL-level tests. New `machweb_test.go` composes `framework/machweb.src` with a test app and runs the pure request/response/router logic natively (the net builtins compile but `serve()` is never called):
- `parse_request` — method, path, body, and a lowercased header map; `header()` case-insensitive + `""` when absent.
- `param` (segment after a prefix), `content_length` (incl. absent → 0).
- response builders — status line, content type, `is_bin=0` for text.
- map router `dispatch` — method-aware key, 404 fallback for unknown route **and** wrong method.

**reactive** — pin the load-bearing guarantees that the runtime simplification (v0.59.0) must preserve:
- change detection — `set(id, equalValue)` emits no patch.
- dependency isolation — only reactions that read a signal re-run.
- computed transitivity — `set(base)` updates a computed → patches its slot.
- minimal `each()` deltas — a removal is one `list_remove` (no re-insert); a pure reorder is `list_order` only.

**router** — `path_index` resolution (and default-to-0 for an unknown path) + navigate-by-path.

Tests only; no compiler or framework changes. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)