### PR TITLE
release: v0.59.1 — agent-discovery friction fixes (dogfooded)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,14 @@ add it to [awesome-machin](https://github.com/javimosch/awesome-machin)** (the
 curated ecosystem list). Each app is its own public repo under `javimosch` with
 a `build.sh` (`machin encode src/*.src > app.mfl && machin build app.mfl`).
 
+Building a **web app** (HTTP server, JSON API, SSR, a reactive wasm UI, or a
+CRUD back-office)? Read [`skills/machin-web/SKILL.md`](skills/machin-web/SKILL.md)
+first — the machweb/reactive/router frameworks, the wasm bridge + host↔wasm
+marshaling, the SQLite data layer (`parse(rows, []T{})` to decode rows), build-and-
+verify, and the gotchas. A runnable data-layer reference is
+[`examples/complex/sqlite_crud.mfl`](examples/complex/sqlite_crud.mfl); direction
+and gap roadmap live in [`docs/NORTH-STAR-WEB.md`](docs/NORTH-STAR-WEB.md).
+
 Building a **game** (terminal TUI or raylib GUI/audio)? Read
 [`skills/machin-gamedev/SKILL.md`](skills/machin-gamedev/SKILL.md) first — the
 canonical setup, build-and-verify workflow, raylib FFI surface, and accumulated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.59.1
+
+Agent-discovery polish — fixes surfaced by dogfooding the north-star flow ("learn
+machin and build a users back-office" from a cold start). No language changes.
+
+- **`machin guide` clarified** where a fresh agent silently shipped a bug:
+  `json_get` now states it returns the **raw JSON token** (a string field comes
+  back **quoted**); `parse` documents its **slice witness** (`parse(jsonArray,
+  []T{}) -> []T`); `sqlite_query` points at `parse(rows, []T{})` as the
+  row-iteration idiom; a new `sqlite-rows-decode` gotcha ties it together.
+- **`skills/machin-web/SKILL.md`**: fixed the wrong `sqlite_query -> []string`
+  signature (it returns a JSON-array string); led the CRUD recipe with
+  `parse(rows, []User{})`; documented the form-encoded POST-body path (use the
+  `url_decode` builtin + a `form_field` helper — don't hand-roll `url_decode`,
+  it's a builtin and shadowing it is a compile error).
+- **New runnable example** `examples/complex/sqlite_crud.mfl` — the SQLite data
+  layer end to end (the repo had no in-tree SQLite example before).
+- **`AGENTS.md`** dogfood section now points web-building agents at the
+  `machin-web` skill (previously only game-dev was signposted).
+
 ## v0.59.0
 
 - **Fix: a closure can capture and mutate an aggregate local** (a slice, map, or

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.59.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.59.1-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.59.0
+Version 0.59.1
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/examples/complex/sqlite_crud.mfl
+++ b/examples/complex/sqlite_crud.mfl
@@ -1,0 +1,8 @@
+type User struct{id int  name string  email string}
+
+func render_row(u)(h){h=str(u.id)+" | "+u.name+" | "+u.email}
+
+func list_users(db)(us){rows:=sqlite_query(db,"SELECT id, name, email FROM users ORDER BY id")us=parse(rows,[]User{})}
+
+func main(){db:=sqlite_open(":memory:")sqlite_exec(db,"CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)")sqlite_exec(db,"INSERT INTO users (name, email) VALUES (?, ?)",[]string{"Ada Lovelace","ada@example.com"})sqlite_exec(db,"INSERT INTO users (name, email) VALUES (?, ?)",[]string{"Alan Turing","alan@example.com"})us:=list_users(db)println("-- users --")i:=0 while i<len(us){println(render_row(us[i]))i=i+1}println("json: "+json(us))name,_:=json_get(sqlite_query(db,"SELECT name FROM users WHERE id = ?",[]string{"1"}),"[0].name")println("json_get name (raw token, quoted): "+name)sqlite_exec(db,"UPDATE users SET email = ? WHERE id = ?",[]string{"ada@machin.dev","1"})sqlite_exec(db,"DELETE FROM users WHERE id = ?",[]string{"2"})after:=list_users(db)println("-- after update+delete --")j:=0 while j<len(after){println(render_row(after[j]))j=j+1}sqlite_close(db)}
+

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.59.0"
+const machinVersion = "0.59.1"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -191,7 +191,7 @@ func machinGuide() guideCatalog {
 			// sqlite (libsqlite3, linked only when used)
 			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
 			{"sqlite_exec", "(int, string[, []string]) -> int", "run SQL with no result; optional []string binds the ? params (injection-safe); 0 ok", "db"},
-			{"sqlite_query", "(int, string[, []string]) -> string", "run a SELECT -> JSON array of rows; optional []string binds the ? params; composes with json_get", "db"},
+			{"sqlite_query", "(int, string[, []string]) -> string", "run a SELECT -> a JSON-array-of-rows STRING; optional []string binds the ? params. Decode N rows with parse(rows, []T{}) for a typed slice; json_get for one field", "db"},
 			{"sqlite_close", "(int) -> int", "close the database", "db"},
 			// regex (POSIX extended)
 			{"regex_match", "(string, string) -> bool", "does the ERE pattern match anywhere in s", "regex"},
@@ -200,8 +200,8 @@ func machinGuide() guideCatalog {
 			{"regex_replace", "(string, string, string) -> string", "replace all ERE matches in s with repl", "regex"},
 			// json
 			{"json", "(any) -> string", "serialize a value to JSON", "json"},
-			{"parse", "(string, T{}) -> T", "parse JSON into T (T{} is a type witness)", "json"},
-			{"json_get", "(string, string) -> (string, string)", "jq-style path -> (value, err); err \"\"/notfound/path/parse. MULTI-ASSIGN ONLY", "json"},
+			{"parse", "(string, T{}) -> T", "parse JSON into T (T{} is a type witness); accepts a SLICE witness: parse(jsonArray, []T{}) -> []T (decode whole rows/arrays)", "json"},
+			{"json_get", "(string, string) -> (string, string)", "jq-style path -> (value, err); err \"\"/notfound/path/parse. Returns the RAW JSON token: a string value comes back QUOTED (\"Ada\") — strip the quotes, or prefer parse() for whole objects. MULTI-ASSIGN ONLY", "json"},
 			{"http_body", "(string) -> string", "body of a raw HTTP message", "json"},
 			// net
 			{"dial", "(string, int) -> int", "TCP connect host:port -> fd (-1 on fail)", "net"},
@@ -267,7 +267,8 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"build", "Author loose Go-like .src, then `machin encode a.src > a.mfl` and `machin build a.mfl -o app`. The .mfl is canonical plain text (one decl/line)."},
 			{"struct-value-semantics", "Structs are VALUE types: passing or assigning one copies it, so a function cannot mutate a caller's struct (and a builder must return the updated struct). For shared mutable state use a map — a reference type, so m[k]=v survives the holder being passed by value (see framework/flags.src)."},
 			{"map-comma-ok", "There is no map comma-ok: `v, ok := m[k]` does NOT compile. A read of an absent key returns the value type's zero value; use has(m, k) to test presence. (comma-ok is for channel receives: `v, ok := <-ch`.)"},
-			{"parse-witness", "parse(s, T{}) needs a value of T as a type witness, e.g. `u := parse(body, User{})`. For schemaless extraction use json_get(s, path); json(x) serializes any value."},
+			{"parse-witness", "parse(s, T{}) needs a value of T as a type witness, e.g. `u := parse(body, User{})`. A SLICE witness decodes an array: `parse(jsonArray, []T{}) -> []T`. For schemaless extraction use json_get(s, path); json(x) serializes any value."},
+			{"sqlite-rows-decode", "sqlite_query returns a JSON-array-of-rows STRING — decode the whole result with parse(rows, []T{}) to get a typed []T you can range over (this is the row-iteration idiom; columns map to struct fields by name). Reach for json_get only to pull ONE field, and remember json_get returns the raw JSON token: a string field comes back QUOTED. Always use parameterized sqlite_exec/query (?, []string{...}) — never string-concat user input into SQL."},
 			{"multi-assign-only", "http_get and json_get return multiple values; use `a, b, c := http_get(u)`. Calling them as a single value is a compile error."},
 			{"int-float-no-implicit", "There is NO implicit int->float. Only a flexible numeric LITERAL (e.g. 5) promotes against a float; a CONCRETE int — a fn return, byte_at, len, a typed param, or an int-slice element — is a hard `int vs float` mismatch with a float. Wrap it: float(byte_at(b,0)) / 2.0. (int() goes the other way.) This also applies to f32/f64 struct fields in FFI cstructs."},
 			{"ffi-opaque-handle", "For a by-value C struct that contains pointers (raylib Sound/Music/Font/Texture with internals, FILE wrappers, ...), declare an OPAQUE cstruct with an empty body: `cstruct Sound {}`. machin holds the real C struct by value and passes it back to fns without naming its fields — receive it from a fn, store it (incl. []Sound), pass it on; no construct or .field. (A single pointer is simpler: the `ptr` FFI type, held as an int.)"},

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -66,8 +66,18 @@ func main() { serve(48080, func(req) { return handle(req) }) }
   is NUL-safe (a `.wasm` has NUL bytes a string body would truncate).
 - **A database:** machin has SQLite builtins — `sqlite_open(path)` / `sqlite_exec(db,
   sql)` / `sqlite_exec(db, sql, []string params)` (`?`-bind, injection-safe) /
-  `sqlite_query(db, sql[, params]) -> []string` rows / `sqlite_close(db)`. Perfect
-  for a users table behind a JSON API.
+  `sqlite_query(db, sql[, params]) -> string` (a **JSON-array-of-rows string**) /
+  `sqlite_close(db)`. Perfect for a users table behind a JSON API. **Decode rows with
+  `parse`, not `json_get`:**
+  ```go
+  type User struct { id int  name string  email string }
+  rows  := sqlite_query(db, "SELECT id, name, email FROM users ORDER BY id")
+  users := parse(rows, []User{})            // a typed []User to range over — values decoded
+  ```
+  A **slice witness** (`[]User{}`) is the row-iteration idiom. Reach for `json_get(rows,
+  "[0].name")` only to pull ONE field — and note **it returns the raw JSON token, so a
+  string comes back quoted** (`"Ada"`); strip the quotes (`substr(s, 1, len(s)-1)`) or
+  just use `parse`. Always parameterize (`?`, `[]string{...}`); never concat user input.
 - **A CLI:** compose `framework/flags.src` — `new_flags` / `flag_int` / `flag_str` /
   `flag_bool` / `parse_flags(fs, args())` / `flag_int_val` / `flag_on(fs,"help")`
   (auto `--help`).
@@ -178,8 +188,22 @@ instance.exports.start();
 2. **Server** (`server.src`): `sqlite_open("users.db")`, create the table; routes —
    `GET /` SSR-renders the user list (matching `data-s` names so the client
    hydrates), `GET /app.wasm` serves the client, `GET /api/users` returns rows as
-   JSON, `POST /api/users` inserts (parse the body), `DELETE`/`POST /api/users/del`
+   JSON (`ok_json(json(parse(sqlite_query(...), []User{})))` or just the raw query
+   string), `POST /api/users` inserts (parse the body), `DELETE`/`POST /api/users/del`
    removes. Use parameterized `sqlite_exec(db, sql, params)` — never string-concat SQL.
+   - **The POST body shape depends on the sender.** A `fetch` with a JSON body →
+     `parse(req.body, User{})` or `json_get`. A browser `<form>` (non-JS fallback, or
+     `Content-Type: application/x-www-form-urlencoded`) → the body is `name=Ada&email=a%40b`;
+     decode each field with the **`url_decode` builtin** (don't hand-roll it — a function
+     named `url_decode` is a compile error, it shadows the builtin). A tiny helper:
+     ```go
+     func form_field(body, key) (v) {           // body: "a=1&b=2"; key: "a"
+         for _, kv := range split(body, "&") {
+             eq := index(kv, "=")
+             if eq > 0 && substr(kv, 0, eq) == key { v = url_decode(substr(kv, eq+1, len(kv))) }
+         }
+     }
+     ```
 3. **Client** (`client.src`): signals hold the rows; `each` renders the table
    (re-key on any mutable field); a **form** (`<input>` + `ptr_str`) adds a user and
    `POST`s; row buttons toggle/delete and call the API. A `computed` shows the count.
@@ -194,6 +218,7 @@ reactive over the API. One binary, one language.
 
 ## Pointers
 
+- Runnable in-tree: [`examples/complex/sqlite_crud.mfl`](../../examples/complex/sqlite_crud.mfl) — the SQLite data layer end to end (open → parameterized insert → `parse([]User{})` → update/delete → JSON), no server, runs under `machin run`.
 - Frameworks: [`framework/machweb.src`](../../framework) · `reactive.src` · `router.src` · `flags.src`.
 - Boilerplate: [boilerplate-cli-ui-machin-isomorphic](https://github.com/javimosch/boilerplate-cli-ui-machin-isomorphic).
 - Focused demos: [machin-web-demo-wasm](https://github.com/javimosch/machin-web-demo-wasm) (the bridge) · [machin-web-demo-ssr](https://github.com/javimosch/machin-web-demo-ssr) (isomorphic SSR) · [machin-web-demo-reactive](https://github.com/javimosch/machin-web-demo-reactive) (signals/computed/lists/templating) · [machin-web-demo-todo](https://github.com/javimosch/machin-web-demo-todo) (forms / text input).


### PR DESCRIPTION
I dogfooded the north-star flow with a **fresh agent** (no prior machin knowledge, cold start): *"learn machin and build me a users back-office."* It followed README → `machin guide` → the web skill and **succeeded** — a working SQLite-backed server, verified by curl. But it **silently shipped a bug** and hit several doc gaps. This PR fixes them. No language changes (patch release).

### The silent bug (highest impact)
The agent rendered `"\"Ada Lovelace\""` — quotes and all — because nothing said `json_get` returns the **raw JSON token** (a string field comes back quoted), and the recipe pointed at `json_get` for row data. The real fix is to **decode rows with `parse`**, which I verified works with a **slice witness**:
```go
users := parse(sqlite_query(db, "SELECT id,name,email FROM users"), []User{})  // typed []User, values decoded
```

### Fixes
- **`machin guide`** — `json_get` states it returns the raw (quoted) token; `parse` documents the slice witness; `sqlite_query` points at `parse(rows, []T{})`; new `sqlite-rows-decode` gotcha.
- **`skills/machin-web/SKILL.md`** — corrected the **wrong `sqlite_query -> []string`** signature (it's a JSON-array string); led the CRUD recipe with `parse`; documented the **form-encoded POST body** (browser `<form>` → `url_decode` builtin + a `form_field` helper; warned that defining `url_decode` shadows the builtin = compile error); linked the new example.
- **`examples/complex/sqlite_crud.mfl`** — new runnable SQLite data-layer reference (open → parameterized insert → `parse([]User{})` → update/delete → JSON). The repo had **no** in-tree SQLite example; this one runs under `make examples`.
- **`AGENTS.md`** — dogfood section now signposts the `machin-web` skill (was game-dev only).

Version bumped to **0.59.1** (guide badge/SPEC/guide.go/CHANGELOG). Full suite green; `machin guide` version-consistency test passes.

> Other friction the agent logged but I did **not** change (lower value / by design): the AGENTS.md "is your binary current" block is heavy but correct; the `form_field` helper is left as a recipe snippet rather than a new builtin (keeps the surface minimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runnable SQLite CRUD example showing creating, listing, updating, and deleting records.

* **Documentation**
  * Updated the web app guidance with a new “Building a web app” section and links to recommended reference material.
  * Clarified database and JSON-handling guidance, including how to work with query results and form submissions.
  * Bumped the documented release version across the README and spec.

* **Bug Fixes**
  * Corrected outdated SQLite query documentation and improved examples for typed result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->