### PR TITLE
v0.62.0 — cookies + signed sessions in machweb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.62.0
+
+- **Cookies + signed sessions in machweb** (`framework/machweb.src`) — the auth
+  foundation. Request: `cookie(req, name)` reads a request cookie. Response (a value
+  type — the helpers return a new `Response`): `set_cookie` / `clear_cookie` add a
+  `Set-Cookie` with safe defaults (`Path=/; HttpOnly; SameSite=Lax`). Login sessions:
+  `set_session(res, secret, name, value)` stores `value` + an HMAC-SHA256 tag the
+  client can't forge, and `get_session(req, secret, name) -> (value, ok)` returns
+  `ok == 1` only if it verifies (rejects a tampered tag or the wrong secret). The
+  `Response` struct gained a `cookies []string` field; `machweb_handle` emits the
+  `Set-Cookie` lines. Keep `secret` server-side; the value is signed, not encrypted.
+
 ## v0.61.0
 
 - **Postgres parameterized queries** — `pg_exec(sql, []string params)` in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.61.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.62.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.61.0
+Version 0.62.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/docs/NORTH-STAR-BACKEND.md
+++ b/docs/NORTH-STAR-BACKEND.md
@@ -23,7 +23,7 @@ paid for two: `read_bytes` and binary-safe base64.
 | HTTP server | ✅ | `framework/machweb.src` (router, body, response builders, binary path) |
 | HTTP/TLS client | ✅ | `https_get`/`https_post`/`http_request`; `wss_*` WebSocket |
 | Crypto | ✅ | sha256, hmac, hkdf, ed25519, x25519, aes-gcm/cbc, rand_bytes; bitwise ops |
-| Sessions / cookies | ❌ | machweb parses headers but has no `Set-Cookie`/cookie helpers |
+| Sessions / cookies | ✅ | `cookie(req,name)` + `set_cookie`/`clear_cookie`; signed sessions `set_session`/`get_session` (HMAC tag, unforgeable) |
 | SSO / OAuth2 / OIDC | ❌ | buildable on the HTTP client + crypto (HS256 = hmac_sha256); RS256 needs RSA (gap) |
 | Email / SMTP | ❌ | SMTP over `dial()`/TLS |
 | Background jobs / cron | ❌ | a scheduler loop + goroutines; persistence via the DB |
@@ -35,16 +35,14 @@ paid for two: `read_bytes` and binary-safe base64.
 
 ## Roadmap (dogfood order)
 
-1. **Sessions/cookies in machweb.** `Set-Cookie` + cookie parsing + a signed-cookie
-   session helper (HMAC over `hmac_sha256_bytes`). Foundational for anything with login.
-2. **SSO library.** OAuth2 authorization-code login (Google/Microsoft) on top of (1):
-   `https_post` token exchange + `https_get` userinfo + `rand_bytes` state. Surfaces the
-   RSA/RS256 gap (sidestep via the userinfo endpoint for v1).
-3. **Redis client.** RESP over `dial()` — cache, sessions, rate-limit, simple queues.
+1. **SSO library.** OAuth2 authorization-code login (Google/Microsoft) on top of the
+   session helpers: `https_post` token exchange + `https_get` userinfo + `rand_bytes`
+   state. Surfaces the RSA/RS256 gap (sidestep via the userinfo endpoint for v1).
+2. **Redis client.** RESP over `dial()` — cache, sessions, rate-limit, simple queues.
    Proves the same "pure-MFL client" pattern Postgres established; small and high-value.
-4. **Connection pooling / reuse** for the Postgres client (keep a connection open
+3. **Connection pooling / reuse** for the Postgres client (keep a connection open
    across requests instead of dial-per-query), plus COPY and TLS when an app needs them.
-5. **The rest as pulled by real apps** — SMTP, a job scheduler, a `.env`/config loader,
+4. **The rest as pulled by real apps** — SMTP, a job scheduler, a `.env`/config loader,
    migrations, a JSON logger. Build when a dogfood app needs them.
 
 ## Milestones
@@ -53,7 +51,9 @@ paid for two: `read_bytes` and binary-safe base64.
 |---|---|
 | **PostgreSQL client** ([`framework/postgres.src`](../framework/postgres.src), v0.60.0) | First networked datastore: wire v3 + SCRAM-SHA-256, simple query → JSON rows that `parse([]T{})` decodes. Surfaced + filled `read_bytes` (NUL-safe socket read) and `base64_*_bytes` (binary base64). Pure MFL, no cgo. |
 | **Postgres parameterized queries** (`pg_exec`, v0.61.0) | Extended query protocol (Parse/Bind/Describe/Execute/Sync): `$1`/`$2` params bound server-side, injection-safe; SELECT + INSERT/UPDATE/DELETE. Closes the top v0.60.0 follow-up. |
+| **Cookies + signed sessions** (machweb, v0.62.0) | `cookie`/`set_cookie`/`clear_cookie` + unforgeable HMAC sessions (`set_session`/`get_session`). The auth foundation — the half of login that isn't the identity provider. |
 
-The language is now close to a single-binary SME backend: HTTP server + SSR/wasm UI +
-**SQLite or Postgres** (with safe parameterized queries) + a rich crypto kit. The main
-gap left is **auth** — sessions/cookies, then SSO — next on the roadmap.
+The language is now close to a single-binary SME backend: HTTP server (with cookies +
+signed sessions) + SSR/wasm UI + **SQLite or Postgres** (safe parameterized queries) +
+a rich crypto kit. The remaining auth piece is **SSO** (an identity provider on top of
+sessions) — next on the roadmap.

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -16,11 +16,12 @@ type Request struct {
 }
 
 type Response struct {
-    status string
-    ctype  string
-    body   string
-    bin    bytes      // binary body, used when is_bin == 1 (NUL-safe; body is ignored)
-    is_bin int        // 1 = serve bin (raw bytes), 0 = serve body (text)
+    status  string
+    ctype   string
+    body    string
+    bin     bytes      // binary body, used when is_bin == 1 (NUL-safe; body is ignored)
+    is_bin  int        // 1 = serve bin (raw bytes), 0 = serve body (text)
+    cookies []string   // Set-Cookie values (added via set_cookie); empty for most responses
 }
 
 // ---- response builders ----
@@ -93,6 +94,68 @@ func param(path, prefix) (v) {
     }
 }
 
+// ---- cookies ----
+
+// cookie returns a request cookie value by name (from the Cookie header), or "".
+func cookie(req, name) (v) {
+    v = ""
+    for _, part := range split(header(req, "cookie"), ";") {
+        kv := trim(part)
+        eq := index(kv, "=")
+        if eq > 0 {
+            if substr(kv, 0, eq) == name { v = substr(kv, eq + 1, len(kv)) }
+        }
+    }
+}
+
+// set_cookie returns res with a Set-Cookie added (Path=/, HttpOnly, SameSite=Lax —
+// safe defaults for a session). Structs are values, so use the returned copy:
+//   return set_cookie(ok_html(page()), "sid", token)
+func set_cookie(res, name, value) (r) {
+    r = res
+    r.cookies = append(r.cookies, name + "=" + value + "; Path=/; HttpOnly; SameSite=Lax")
+}
+
+// clear_cookie returns res with a cookie expired (for logout).
+func clear_cookie(res, name) (r) {
+    r = res
+    r.cookies = append(r.cookies, name + "=; Path=/; Max-Age=0")
+}
+
+// cookie_lines renders the Set-Cookie header block for a response.
+func cookie_lines(res) (h) {
+    h = ""
+    for _, c := range res.cookies { h = h + "Set-Cookie: " + c + "\r\n" }
+}
+
+// ---- signed sessions ----
+//
+// A session cookie the client cannot forge: value + "." + HMAC-SHA256(secret, value)
+// (a 64-char hex tag). set_session stores it; get_session returns (value, ok=1) only
+// if the tag verifies. Keep `secret` server-side (e.g. from env). The value is
+// readable by the client (signed, not encrypted) — store an id/handle, not secrets.
+
+func session_sign(secret, value) (s) { s = value + "." + hmac_sha256(secret, value) }
+
+func session_verify(secret, signed) (value, ok) {
+    value = ""
+    ok = 0
+    n := len(signed)
+    if n < 65 { return }                          // "." + 64-hex tag minimum
+    if charat(signed, n - 65) != "." { return }
+    v := substr(signed, 0, n - 65)
+    if hmac_sha256(secret, v) == substr(signed, n - 64, n) {
+        value = v
+        ok = 1
+    }
+}
+
+// set_session returns res with a signed session cookie set.
+func set_session(res, secret, name, value) (r) { r = set_cookie(res, name, session_sign(secret, value)) }
+
+// get_session reads + verifies a signed session cookie: (value, ok).
+func get_session(req, secret, name) (value, ok) { value, ok = session_verify(secret, cookie(req, name)) }
+
 // ---- server ----
 
 // content_length parses the Content-Length header value from a request's headers.
@@ -130,11 +193,11 @@ func machweb_handle(conn, handler) {
     res := handler(req)
     if res.is_bin == 1 {
         // binary body: write the headers, then the raw bytes (NUL-safe).
-        head := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.bin)) + "\r\nConnection: close\r\n\r\n"
+        head := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.bin)) + "\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n"
         write(conn, head)
         write_bytes(conn, res.bin)
     } else {
-        out := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.body)) + "\r\nConnection: close\r\n\r\n" + res.body
+        out := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.body)) + "\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n" + res.body
         write(conn, out)
     }
     close(conn)

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.61.0"
+const machinVersion = "0.62.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -272,6 +272,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"map-comma-ok", "There is no map comma-ok: `v, ok := m[k]` does NOT compile. A read of an absent key returns the value type's zero value; use has(m, k) to test presence. (comma-ok is for channel receives: `v, ok := <-ch`.)"},
 			{"parse-witness", "parse(s, T{}) needs a value of T as a type witness, e.g. `u := parse(body, User{})`. A SLICE witness decodes an array: `parse(jsonArray, []T{}) -> []T`. For schemaless extraction use json_get(s, path); json(x) serializes any value."},
 			{"sqlite-rows-decode", "sqlite_query returns a JSON-array-of-rows STRING — decode the whole result with parse(rows, []T{}) to get a typed []T you can range over (this is the row-iteration idiom; columns map to struct fields by name). Reach for json_get only to pull ONE field, and remember json_get returns the raw JSON token: a string field comes back QUOTED. Always use parameterized sqlite_exec/query (?, []string{...}) — never string-concat user input into SQL."},
+			{"machweb-sessions", "framework/machweb.src does cookies + signed sessions. Request: cookie(req, name) -> value. Response (a value type — chain the helpers, they return a new Response): set_cookie(res, name, value) / clear_cookie(res, name) add a Set-Cookie with safe defaults (Path=/; HttpOnly; SameSite=Lax). Login sessions: set_session(res, secret, name, value) stores value + an HMAC-SHA256 tag the client can't forge; get_session(req, secret, name) -> (value, ok) returns ok==1 only if it verifies. Keep secret server-side (env). The value is signed, not encrypted — store an id, not secrets."},
 			{"postgres-client", "framework/postgres.src is a pure-MFL PostgreSQL client (wire protocol v3 over dial(), SCRAM-SHA-256 auth) — no libpq/cgo. pg_connect(host, port, user, db, password); pg_disconnect(). Two query calls, both returning a JSON-array-of-rows STRING in the SAME shape as sqlite_query (so parse(rows, []T{}) decodes them; numeric/bool columns come back unquoted via their result OIDs): pg_query(sql) for trusted/constant SQL (simple protocol), and pg_exec(sql, []string params) which binds $1,$2,... server-side via the extended protocol (injection-safe — use it for any user input; works for SELECT and INSERT/UPDATE/DELETE). Built on read_bytes + base64_*_bytes + the crypto builtins. See docs/NORTH-STAR-BACKEND.md."},
 			{"multi-assign-only", "http_get and json_get return multiple values; use `a, b, c := http_get(u)`. Calling them as a single value is a compile error."},
 			{"int-float-no-implicit", "There is NO implicit int->float. Only a flexible numeric LITERAL (e.g. 5) promotes against a float; a CONCRETE int — a fn return, byte_at, len, a typed param, or an int-slice element — is a hard `int vs float` mismatch with a float. Wrap it: float(byte_at(b,0)) / 2.0. (int() goes the other way.) This also applies to f32/f64 struct fields in FFI cstructs."},

--- a/machweb_io_test.go
+++ b/machweb_io_test.go
@@ -64,6 +64,45 @@ func main() {
 	}
 }
 
+// End-to-end cookie round-trip over the socket: the client sends a Cookie header,
+// the server reads it with cookie(), verifies it as a session, and responds with a
+// fresh Set-Cookie — which must appear in the raw wire response.
+func TestMachwebCookieRoundTrip(t *testing.T) {
+	app := loopbackHelpers + `
+func handle(req) (res) {
+    got := cookie(req, "sid")
+    res = set_session(ok_text("saw=" + got), "secret", "sid", "user:7")
+}
+func main() {
+    port := 48235
+    srv := listen(port)
+    if srv < 0 { println("listen-failed")  return }
+    go serve_one(srv, func(req) { return handle(req) })
+    sleep(50)
+    c := dial("127.0.0.1", port)
+    if c < 0 { println("dial-failed")  return }
+    write(c, "GET / HTTP/1.1\r\nHost: x\r\nCookie: sid=incoming\r\n\r\n")
+    resp := read_all(c)
+    close(c)
+    println(resp)
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(out, "listen-failed") || strings.Contains(out, "dial-failed") {
+		t.Fatalf("loopback setup failed:\n%s", out)
+	}
+	// the server read the inbound cookie...
+	if !strings.Contains(out, "saw=incoming") {
+		t.Fatalf("server should read the inbound cookie; got:\n%s", out)
+	}
+	// ...and the response carries a Set-Cookie with the signed session value
+	if !strings.Contains(out, "Set-Cookie: sid=user:7.") || !strings.Contains(out, "HttpOnly") {
+		t.Fatalf("response should carry the signed Set-Cookie; got:\n%s", out)
+	}
+}
+
 // The binary response path (is_bin=1) writes the headers then write_bytes(conn,
 // bin) — NUL-safe. The body here starts with a 0x00 byte, so a text/strlen path
 // would report Content-Length 0; the binary path reports the true byte count (4).

--- a/machweb_test.go
+++ b/machweb_test.go
@@ -111,6 +111,46 @@ func main() {
 	}
 }
 
+// Cookies: parse named values from the request's Cookie header. Signed sessions:
+// value + HMAC tag; verify accepts the intact cookie and rejects a tampered tag or
+// the wrong secret — the client can read the value but cannot forge it.
+func TestMachwebCookiesAndSessions(t *testing.T) {
+	app := `
+func main() {
+    req := parse_request("GET / HTTP/1.1\r\nCookie: sid=abc; theme=dark\r\n\r\n")
+    println("sid=" + cookie(req, "sid"))
+    println("theme=" + cookie(req, "theme"))
+    println("missing=[" + cookie(req, "nope") + "]")
+    signed := session_sign("k", "user:42")
+    v, ok := session_verify("k", signed)
+    println("verify=" + v + ":" + str(ok))
+    bad := substr(signed, 0, len(signed) - 1) + "0"
+    _, t2 := session_verify("k", bad)
+    println("tampered=" + str(t2))
+    _, w := session_verify("wrong", signed)
+    println("wrongsecret=" + str(w))
+    // a Set-Cookie line carries the signed value + safe attributes
+    r := set_session(ok_html("x"), "k", "sid", "user:42")
+    println("setcookie=" + cookie_lines(r))
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"sid=abc", "theme=dark", "missing=[]",
+		"verify=user:42:1", // intact cookie verifies, value recovered
+		"tampered=0",       // a flipped tag byte fails
+		"wrongsecret=0",    // a different secret fails
+		"setcookie=Set-Cookie: sid=user:42.", // signed value embeds the cleartext
+		"HttpOnly; SameSite=Lax",             // safe defaults
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
 // The map-based router dispatches "METHOD PATH" to its handler closure and falls
 // back to 404 for an unregistered route.
 func TestMachwebRouterDispatch(t *testing.T) {

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -48,7 +48,7 @@ compiler — a single binary, no emscripten). The frameworks live in
 
 A handler is `func(Request) Response`. `serve(port, handler)` runs it (one
 goroutine per connection). `req.method` / `req.path` (path carries the query
-string) / `req.body` / `header(req, name)`.
+string) / `req.body` / `header(req, name)` / `cookie(req, name)`.
 
 Response builders: `ok_text` · `ok_html` · `ok_json` · `ok_bytes(ctype, b)` ·
 **`ok_wasm(b)`** · `created` · `bad_request` · `not_found`.
@@ -81,6 +81,25 @@ func main() { serve(48080, func(req) { return handle(req) }) }
 - **A CLI:** compose `framework/flags.src` — `new_flags` / `flag_int` / `flag_str` /
   `flag_bool` / `parse_flags(fs, args())` / `flag_int_val` / `flag_on(fs,"help")`
   (auto `--help`).
+- **Cookies & login sessions:** `cookie(req, name)` reads a request cookie;
+  `set_cookie(res, name, value)` / `clear_cookie(res, name)` return a `Response` with
+  a `Set-Cookie` (safe defaults: `Path=/; HttpOnly; SameSite=Lax`). For login, use a
+  **signed** session the client can't forge: `set_session(res, secret, "sid", userID)`
+  stores `userID` + an HMAC tag, and `get_session(req, secret, "sid") -> (value, ok)`
+  returns `ok == 1` only if it verifies. `Response` is a value, so chain the helper:
+  ```go
+  func login(req) (res) {
+      // ...check credentials...
+      res = set_session(ok_html(dashboard()), secret, "sid", "user:42")
+  }
+  func page(req) (res) {
+      uid, ok := get_session(req, secret, "sid")
+      if ok == 0 { return set_cookie(not_found(), "x", "")  /* or redirect to /login */ }
+      res = ok_html(home(uid))
+  }
+  ```
+  Keep `secret` server-side (e.g. `env("SESSION_SECRET")`). The value is signed, not
+  encrypted — store an id/handle, not secrets.
 
 ## The client — `framework/reactive.src` (signals + a patch list)
 


### PR DESCRIPTION
The **auth foundation** for the SME-backend track — the half of login that isn't the identity provider.

```go
func login(req) (res) {
    // ...check credentials...
    res = set_session(ok_html(dashboard()), secret, "sid", "user:42")   // signed cookie
}
func page(req) (res) {
    uid, ok := get_session(req, secret, "sid")                          // (value, ok)
    if ok == 0 { return not_found() }
    res = ok_html(home(uid))
}
```

- **`cookie(req, name)`** — read a request cookie from the `Cookie` header.
- **`set_cookie` / `clear_cookie`** — return a `Response` with a `Set-Cookie` (safe defaults `Path=/; HttpOnly; SameSite=Lax`). `Response` gained a `cookies []string` field; `machweb_handle` emits the lines.
- **`set_session` / `get_session`** — a **signed** session cookie: `value + "." + HMAC-SHA256(secret, value)`. `get_session` returns `ok == 1` only if the tag verifies — a tampered tag or the wrong secret is rejected. Signed, not encrypted (store an id, keep `secret` server-side).

### Tests
- `TestMachwebCookiesAndSessions` (pure): cookie parsing + sign/verify, and rejection of a flipped tag byte and a wrong secret.
- `TestMachwebCookieRoundTrip` (loopback): the server reads the inbound `Cookie` and the signed `Set-Cookie` reaches the wire.

Both CI-runnable. Skill (`machin-web`) + `machin guide` note + north-star updated. Full suite + `go vet` green.

Bumped to **v0.62.0**. Auth roadmap now: **SSO** (OAuth2 on top of these sessions) → Redis (see `docs/NORTH-STAR-BACKEND.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cookie support for web requests and responses.
  * Introduced signed login sessions with safer default cookie handling.
  * Responses can now include `Set-Cookie` headers automatically.

* **Documentation**
  * Updated version references across the changelog, README, spec, and related docs.
  * Expanded guidance for cookies and session-based login workflows.

* **Bug Fixes**
  * Improved request/response handling so cookies are preserved end-to-end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->