### PR TITLE
v0.68.0 — parse_float(string) -> float builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.68.0
+
+- **`parse_float(string) -> float`** — parse a floating-point number (strtod; 0.0 on
+  non-numeric), the float counterpart to `parse_int`. Lets a tool turn a textual number
+  (a SQLite REAL read as JSON, a CLI arg) into an MFL float — e.g. carry REAL columns
+  into Mongo doubles in `machin-db-migrate`.
+
 ## v0.67.0
 
 - **MongoDB client v2** (`framework/mongo.src` + `bson.src`): **SCRAM-SHA-256 auth**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.67.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.68.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.67.0
+Version 0.68.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/codegen.go
+++ b/codegen.go
@@ -861,6 +861,7 @@ static char* mfl_time_format_utc(int64_t unix, const char* fmt) {
     return out;
 }
 static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 10); }
+static double mfl_parse_float(const char* s) { return strtod(s, NULL); }
 
 /* file system: read/write whole files, list a directory, make a directory */
 static char* mfl_read_file(const char* path) {
@@ -4065,6 +4066,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_time_make(%s, %s, %s, %s, %s, %s)", args[0], args[1], args[2], args[3], args[4], args[5]), nil
 	case "parse_int":
 		return fmt.Sprintf("mfl_parse_int(%s)", args[0]), nil
+	case "parse_float":
+		return fmt.Sprintf("mfl_parse_float(%s)", args[0]), nil
 	case "read_file":
 		return fmt.Sprintf("mfl_read_file(%s)", args[0]), nil
 	case "read_file_bytes":

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// parse_float parses a string to a double (strtod; 0.0 on garbage) — the float
+// counterpart to parse_int, e.g. to carry a SQLite REAL value into a Mongo double.
+// f64_bits / f64_from_bits reinterpret a double's IEEE-754 bits as an int64 and back.
+func TestParseFloatAndF64Bits(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("pf=" + str(parse_float("3.5") + 0.5))    // 4
+    println("pi=" + str(parse_float("3.14159")))
+    println("bad=" + str(parse_float("nope")))         // 0
+    b := f64_bits(2.5)
+    println("rt=" + str(f64_from_bits(b)) + " same=" + str(f64_from_bits(b) == 2.5))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"pf=4", "pi=3.14159", "bad=0", "rt=2.5 same=true"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.67.0"
+const machinVersion = "0.68.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -114,6 +114,7 @@ func machinGuide() guideCatalog {
 			{"int", "(number) -> int", "truncate to int", "convert"},
 			{"float", "(number) -> float", "int -> float (identity on float). MFL has no implicit int->float, so a concrete int (fn return, byte_at, len, ...) needs this to enter float math", "convert"},
 			{"parse_int", "(string) -> int", "parse an integer (0 if non-numeric)", "convert"},
+			{"parse_float", "(string) -> float", "parse a floating-point number (strtod; 0.0 if non-numeric)", "convert"},
 			{"f64_bits", "(float) -> int", "reinterpret a double's IEEE-754 bits as an int64 (for byte-level (de)serialization, e.g. BSON doubles); inverse f64_from_bits", "convert"},
 			{"f64_from_bits", "(int) -> float", "reinterpret an int64 bit pattern as a double (inverse of f64_bits)", "convert"},
 			// math (libm, linked -lm only when used; numeric in, float out)

--- a/types.go
+++ b/types.go
@@ -2175,6 +2175,12 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cString)
 		return c.cInt, nil
+	case "parse_float":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("parse_float: 1 arg (string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cFloat, nil
 	case "read_file":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("read_file: 1 arg (path)")


### PR DESCRIPTION
The float counterpart to `parse_int` (`strtod`; `0.0` on non-numeric). Small, general, and the missing piece for carrying textual numbers into floats — e.g. a SQLite `REAL` column (read as a JSON number) into a Mongo double in `machin-db-migrate`, or a numeric CLI arg.

`convert_test.go` covers it (+ an `f64_bits`/`f64_from_bits` round-trip, which had only been exercised via BSON). Full suite + `go vet` green. Bumped to **v0.68.0**.

Next: wire `REAL`-> Mongo double + `--auth` into machin-db-migrate (separate repo) on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)