### PR TITLE
v0.69.0 — system(string) -> int builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.69.0
+
+- **`system(string) -> int`** — run a shell command, returning its exit code (-1 if
+  unlaunchable). For process orchestration — e.g. a CLI spawning a detached daemon
+  (`system("./app serve >log 2>&1 &")`). Surfaced by the machin-cms dogfood (a
+  daemon start/stop mode).
+
 ## v0.68.0
 
 - **`parse_float(string) -> float`** — parse a floating-point number (strtod; 0.0 on

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.68.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.69.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.68.0
+Version 0.69.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/codegen.go
+++ b/codegen.go
@@ -120,6 +120,7 @@ const cRuntime = `#define _GNU_SOURCE
 #include <errno.h>
 #include <termios.h>
 #include <sys/select.h>
+#include <sys/wait.h>
 
 /* slices: a Go-style header over an unboxed backing array */
 typedef struct { void* data; int64_t len; int64_t cap; } mfl_slice;
@@ -909,6 +910,13 @@ static int64_t mfl_mkdir(const char* path) {
     int r = mkdir(path, 0755);
     if (r < 0 && errno == EEXIST) return 0;
     return r;
+}
+/* run a shell command, return its exit code (-1 if it could not be launched). For
+   process orchestration — e.g. spawning a detached daemon with a trailing "&". */
+static int64_t mfl_system(const char* cmd) {
+    int r = system(cmd);
+    if (r == -1) return -1;
+    return (int64_t)WEXITSTATUS(r);
 }
 
 /* copy n bytes into a fresh NUL-terminated arena string */
@@ -4079,6 +4087,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_write_file(%s, %s)", args[0], args[1]), nil
 	case "list_dir":
 		return fmt.Sprintf("mfl_list_dir(%s)", args[0]), nil
+	case "system":
+		return fmt.Sprintf("mfl_system(%s)", args[0]), nil
 	case "mkdir":
 		return fmt.Sprintf("mfl_mkdir(%s)", args[0]), nil
 	case "https_get":

--- a/guide.go
+++ b/guide.go
@@ -9,7 +9,7 @@ import (
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.68.0"
+const machinVersion = "0.69.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -101,6 +101,7 @@ func machinGuide() guideCatalog {
 			{"args", "() -> []string", "command-line args (args()[0] is program path)", "cli"},
 			{"env", "(string) -> string", "environment variable (\"\" if unset)", "cli"},
 			{"exit", "(int) ->", "terminate the process with a status code", "cli"},
+			{"system", "(string) -> int", "run a shell command, return its exit code (-1 if unlaunchable). For process orchestration, e.g. spawning a detached daemon: system(\"./app serve >log 2>&1 &\")", "cli"},
 			// time
 			{"now", "() -> int", "wall-clock Unix seconds", "time"},
 			{"now_ms", "() -> int", "wall-clock milliseconds", "time"},

--- a/system_test.go
+++ b/system_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// system runs a shell command and returns its exit code — for process orchestration
+// (e.g. a CLI spawning a detached daemon). stdout of the command goes to the child's
+// stdout; the return value is the exit status.
+func TestSystemBuiltin(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("ok=" + str(system("true")))        // 0
+    println("err=" + str(system("exit 7")))      // 7
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.Join(strings.Fields(out), " "); got != "ok=0 err=7" {
+		t.Fatalf("system() exit codes = %q, want %q", got, "ok=0 err=7")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -2219,6 +2219,12 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cString)
 		return c.cInt, nil
+	case "system":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("system: 1 arg (command string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cInt, nil
 	case "https_get":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("https_get: 1 arg (url string)")


### PR DESCRIPTION
Run a shell command, return its exit code (`-1` if unlaunchable; `WEXITSTATUS` otherwise). For **process orchestration** — the gap surfaced by the `machin-cms` headless-CMS dogfood, whose `daemon start` spawns a detached server: `system("./machcms serve >log 2>&1 &")` returns immediately.

`system_test.go` covers the exit-code path. Full suite + `go vet` green. Bumped to **v0.69.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)