### PR TITLE
v0.74.0 — embed domain skills in the binary + guide domain routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,9 @@
 Orientation for agents working on **machin** (the toolchain) / **MFL** (the
 language). Humans state intent; the machine reads and writes the code.
 
-> **Start here to learn the language: run `machin guide`.** It emits the
+> **Start here: run `machin guide`.** It leads with a DOMAINS map (web / gamedev / backend) and embeds the domain how-tos — `machin guide --skill web` or `--skill gamedev` prints the full skill offline, so you never need to reverse-engineer a demo repo to learn a domain.
+>
+> **Learn the language:** It emits the
 > complete, version-exact feature surface — keywords, every builtin with its
 > signature, idioms, and gotchas — as JSON (default) or `--text` (prose), from
 > the compiler's own source-of-truth catalog (so it never drifts). This file is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.74.0
+
+- **Domain how-tos in the binary.** `machin guide` now leads with a **DOMAINS** section
+  routing an agent to the right per-domain how-to (web / gamedev / backend), and the
+  web + gamedev SKILLs are **embedded** — `machin guide --skill web` / `--skill gamedev`
+  print the full guide offline (no repo checkout needed). Closes the gap where an agent
+  with only the curl|sh binary reverse-engineered the language from demo repos. The JSON
+  guide gains a `domains` array. Web skill now points at the networked DB drivers; both
+  skill descriptions refreshed to current coverage.
+
 ## v0.73.0
 
 - **MySQL connection pooling** — the MySQL/MariaDB client is now handle-based

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.73.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.74.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.73.0
+Version 0.74.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -1,15 +1,25 @@
 package main
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 )
 
+// The domain how-to guides, embedded into the binary so an agent that installed via
+// curl|sh (no repo checkout) can read them offline: `machin guide --skill web|gamedev`.
+//
+//go:embed skills/machin-web/SKILL.md
+var skillWeb string
+
+//go:embed skills/machin-gamedev/SKILL.md
+var skillGamedev string
+
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.73.0"
+const machinVersion = "0.74.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -36,15 +46,31 @@ type guideNote struct {
 	Note  string `json:"note"`
 }
 
+type guideDomain struct {
+	Name    string `json:"name"`
+	Skill   string `json:"skill"`   // run `machin guide --skill <this>` for the full how-to ("" = none yet)
+	Howto   string `json:"howto"`   // where the how-to lives
+	Summary string `json:"summary"`
+}
+
 type guideCatalog struct {
 	Version  string         `json:"version"`
 	Schema   string         `json:"schema"`
 	Tagline  string         `json:"tagline"`
 	Keywords []string       `json:"keywords"`
+	Domains  []guideDomain  `json:"domains"`
 	Types    []guideNote    `json:"types"`
 	Builtins []guideBuiltin `json:"builtins"`
 	Idioms   []guideIdiom   `json:"idioms"`
 	Gotchas  []guideNote    `json:"gotchas"`
+}
+
+// guideDomains routes an agent from `machin guide` (the language) to the per-domain
+// how-to. Embedded skills are printable offline via `machin guide --skill <name>`.
+var guideDomains = []guideDomain{
+	{"web", "web", "machin guide --skill web", "Full-stack web: a native HTTP server (machweb), SSR, a reactive WebAssembly UI (signals + keyed lists), a client-side router, cookies + signed sessions, and OAuth2/OIDC SSO — one language both ends, no Node/bundler."},
+	{"gamedev", "gamedev", "machin guide --skill gamedev", "Native games: terminal TUI (raw_mode/read_key + ANSI) and raylib GUI/audio/3D through the C FFI — sprites, sound, 3D cameras, GPU meshes (pointer/array FFI), instancing, shaders, procedural worlds (noise)."},
+	{"backend", "", "see the *-client builtins/idioms below + docs/NORTH-STAR-BACKEND.md", "Single-binary backends: pure-MFL drivers for SQLite, PostgreSQL (SCRAM), MySQL/MariaDB, Redis, and MongoDB (all connection-pooled), plus signed sessions and SSO. See the postgres-client / mysql-client / mongo-client / redis-client / machweb-sessions / sso-oauth idioms."},
 }
 
 // builtinNames is the set of builtin function names (from the catalog), memoized.
@@ -71,6 +97,7 @@ func machinGuide() guideCatalog {
 			"select", "go", "chan", "make", "map", "struct", "type", "var", "arena",
 			"extern", "export", "true", "false", "nil",
 		},
+		Domains: guideDomains,
 		Types: []guideNote{
 			{"int", "64-bit signed"},
 			{"float", "double"},
@@ -308,12 +335,26 @@ func main() { println(str(sqrt(2.0))) }`},
 // intended agent entry point), or a dense prose form with --text.
 func cmdGuide(args []string) error {
 	text := false
-	for _, a := range args {
+	for i, a := range args {
 		switch a {
 		case "--text", "-t":
 			text = true
 		case "--json":
 			text = false
+		case "--skill":
+			name := ""
+			if i+1 < len(args) {
+				name = args[i+1]
+			}
+			switch name {
+			case "web":
+				fmt.Print(skillWeb)
+			case "gamedev", "game":
+				fmt.Print(skillGamedev)
+			default:
+				return fmt.Errorf("unknown skill %q — available: web, gamedev (see `machin guide` domains)", name)
+			}
+			return nil
 		}
 	}
 	g := machinGuide()
@@ -331,7 +372,11 @@ func renderGuideText(g guideCatalog) string {
 	fmt.Fprintf(&b, "machin %s — %s\n\n", g.Version, g.Tagline)
 	fmt.Fprintf(&b, "KEYWORDS: %s\n\n", strings.Join(g.Keywords, " "))
 
-	b.WriteString("TYPES\n")
+	b.WriteString("DOMAINS — building something specific? read the how-to FIRST (don't reverse-engineer demos):\n")
+	for _, d := range g.Domains {
+		fmt.Fprintf(&b, "  %-8s %s\n           %s\n", d.Name, d.Howto, d.Summary)
+	}
+	b.WriteString("\nTYPES\n")
 	for _, t := range g.Types {
 		fmt.Fprintf(&b, "  %-10s %s\n", t.Topic, t.Note)
 	}

--- a/skills/machin-gamedev/SKILL.md
+++ b/skills/machin-gamedev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: machin-gamedev
-description: Build native games and interactive desktop/terminal apps in machin (MFL) — the canonical setup, build-and-verify workflow, raylib C-FFI surface, audio, and the hard-won caveats/gotchas. Use when writing or debugging a machin game (terminal TUI or raylib GUI), or any machin program that draws a window, plays sound, or reads real-time input. Distilled from machin-game-demo-snake / -2048 / -flappy / -simon.
+description: Build native games and interactive desktop/terminal apps in machin (MFL) — the canonical setup, build-and-verify workflow, raylib C-FFI surface, audio, and the hard-won caveats/gotchas. Use when writing or debugging a machin game (terminal TUI or raylib GUI), or any machin program that draws a window, plays sound, or reads real-time input. Covers terminal TUI, raylib GUI/audio, 3D cameras, GPU meshes (pointer/array FFI), instancing, shaders, and procedural worlds (noise). Distilled from machin-game-demo-snake / -2048 / -flappy / -simon / -3d / -terrain / -planet / -cyberpunk.
 ---
 
 # Building games in machin

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: machin-web
-description: Build web apps in machin (MFL) — a native HTTP server, a JSON API, server-side rendering, and a reactive WebAssembly UI, all in one language with no Node/bundler. Use when writing or debugging a machin web app: a backend service, an SSR page, a wasm SPA, an isomorphic full-stack app, or a CRUD back-office. Covers the machweb/reactive/flags frameworks, the wasm bridge, host↔wasm marshaling, the generic JS host, build-and-verify, and the hard-won gotchas. Distilled from the web-domain dogfood (machin v0.50–v0.58).
+description: Build web apps in machin (MFL) — a native HTTP server, a JSON API, server-side rendering, and a reactive WebAssembly UI, all in one language with no Node/bundler. Use when writing or debugging a machin web app: a backend service, an SSR page, a wasm SPA, an isomorphic full-stack app, or a CRUD back-office. Covers the machweb/reactive/router/flags frameworks, cookies + signed sessions, OAuth2/OIDC SSO, the wasm bridge + host↔wasm marshaling, the generic JS host, the pure-MFL Postgres/MySQL/Mongo/Redis drivers, build-and-verify, and the hard-won gotchas. Distilled from the web + backend dogfood (machin v0.50–v0.73).
 ---
 
 # Building web apps in machin
@@ -78,6 +78,13 @@ func main() { serve(48080, func(req) { return handle(req) }) }
   "[0].name")` only to pull ONE field — and note **it returns the raw JSON token, so a
   string comes back quoted** (`"Ada"`); strip the quotes (`substr(s, 1, len(s)-1)`) or
   just use `parse`. Always parameterize (`?`, `[]string{...}`); never concat user input.
+- **A networked database** (shared across instances): machin has pure-MFL drivers for
+  **PostgreSQL**, **MySQL/MariaDB**, **Redis**, and **MongoDB** (all connection-pooled,
+  no cgo) — each returns rows as JSON the same way, so `parse(rows, []T{})` decodes them.
+  See the `postgres-client` / `mysql-client` / `mongo-client` / `redis-client` /
+  `machweb-sessions` / `sso-oauth` idioms in `machin guide`, and
+  [`docs/NORTH-STAR-BACKEND.md`](../../docs/NORTH-STAR-BACKEND.md) for the full backend
+  story (sessions, SSO, pooling, and the worked MachNotes / machin-cms apps).
 - **A CLI:** compose `framework/flags.src` — `new_flags` / `flag_int` / `flag_str` /
   `flag_bool` / `parse_flags(fs, args())` / `flag_int_val` / `flag_on(fs,"help")`
   (auto `--help`).


### PR DESCRIPTION
Closes the gap you flagged: an external agent spent ~10 min reverse-engineering the language from **demo repos** because the installed binary (`machin guide` = language only) never pointed to the domain how-tos, and the skills lived in the repo (not in a curl|sh install).

- **`machin guide` now leads with a DOMAINS section** — routing an agent to the right per-domain how-to (web / gamedev / backend) before it touches a demo. The JSON guide gains a `domains` array.
- **The web + gamedev skills are embedded** (`go:embed`): **`machin guide --skill web`** / **`--skill gamedev`** print the full SKILL.md **offline**, so an agent with only the binary gets the complete domain guide.
- The web skill now points at the **networked DB drivers** (Postgres/MySQL/Mongo/Redis — the one content gap); both skill **descriptions refreshed** to current coverage (router / sessions / SSO / drivers; 3d / GPU mesh / instancing / shaders / cyberpunk). `AGENTS.md` documents `--skill`.

Assessment while doing this: the skills themselves are **current and thorough** (gamedev covers all 8 demos incl. GPU meshes, instancing, shaders, far-clip; web covers SSR/wasm/router/sessions/SSO). The gap was purely **reachability from the binary** — now fixed.

`guide_test` green (every builtin still type-checks; the new `domains`/embed don't affect it). Full suite + `go vet` green. Bumped to **v0.74.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)