### PR TITLE
v0.76.0: file uploads in machweb (multipart/form-data) + binary-safe requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.76.0
+
+- **File uploads in machweb (multipart/form-data).** Requests are now read **binary-safe**
+  — `read_request_bytes`/`parse_request_bytes` keep the body as raw bytes
+  (`req.body_bytes`), so an upload with NUL bytes survives intact (the old `read()` path
+  truncated at the first NUL). New `parse_multipart(req)` splits a `multipart/form-data`
+  body into its `MultipartPart`s (fields + files), with `multipart_file(req, field)` and
+  `multipart_field(req, name)` convenience helpers. Responses gain extra headers via
+  `with_header(res, name, value)` (e.g. `Content-Disposition` for download filenames).
+- **Three enabling builtins**: `bytes_index(haystack, needle, from) -> int` (NUL-safe
+  byte search, for binary protocols / multipart boundaries), `write_file_bytes(path,
+  bytes) -> int` (binary-safe file write, for storing uploads), and the binary request
+  path above. `req.body` (text view) is unchanged for existing apps.
+- Dogfooded by **[machin-share](https://github.com/javimosch/machin-share)** — a
+  self-hostable file/paste drop in one MFL binary (the upload/download/streaming surface
+  that surfaced all of the above).
+
 ## v0.75.0
 
 - **A `machin-backend` skill** — the backend domain now has its own how-to (the five

--- a/codegen.go
+++ b/codegen.go
@@ -539,6 +539,16 @@ static mfl_bytes mfl_bytes_sub(mfl_bytes b, int64_t start, int64_t end) {
     memcpy(r.data, b.data + start, (size_t)n);
     return r;
 }
+/* find needle in haystack at or after start, NUL-safe; -1 if absent. For binary
+   protocols (e.g. a multipart/form-data boundary inside an upload body). */
+static int64_t mfl_bytes_index(mfl_bytes h, mfl_bytes nd, int64_t from) {
+    if (from < 0) from = 0;
+    if (nd.len == 0) return from <= h.len ? from : -1;
+    for (int64_t i = from; i + nd.len <= h.len; i++) {
+        if (memcmp(h.data + i, nd.data, (size_t)nd.len) == 0) return i;
+    }
+    return -1;
+}
 static mfl_bytes mfl_bytes_concat(mfl_bytes a, mfl_bytes b) {
     mfl_bytes r; r.len = a.len + b.len; r.data = (uint8_t*)mfl_alloc(r.len ? r.len : 1);
     memcpy(r.data, a.data, (size_t)a.len);
@@ -881,6 +891,15 @@ static int64_t mfl_write_file(const char* path, const char* content) {
     size_t w = fwrite(content, 1, len, f);
     fclose(f); return (int64_t)w;
 }
+/* write raw bytes to a file, NUL-safe (length-driven) — for binary uploads/assets. */
+static int64_t mfl_write_file_bytes(const char* path, mfl_bytes b) {
+    FILE* f = fopen(path, "wb");
+    if (!f) return -1;
+    size_t w = b.len ? fwrite(b.data, 1, (size_t)b.len, f) : 0;
+    fclose(f); return (int64_t)w;
+}
+/* delete a file (0 on success, -1 on error) — e.g. removing a stored upload. */
+static int64_t mfl_remove_file(const char* path) { return remove(path) == 0 ? 0 : -1; }
 /* read a file's raw bytes (NUL-safe, unlike read_file which returns a C string).
    Empty bytes if the file can't be opened. */
 static mfl_bytes mfl_read_file_bytes(const char* path) {
@@ -3829,6 +3848,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_byte_at(%s, %s)", args[0], args[1]), nil
 	case "bytes_sub":
 		return fmt.Sprintf("mfl_bytes_sub(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "bytes_index":
+		return fmt.Sprintf("mfl_bytes_index(%s, %s, %s)", args[0], args[1], args[2]), nil
 	case "bytes_concat":
 		return fmt.Sprintf("mfl_bytes_concat(%s, %s)", args[0], args[1]), nil
 	case "rand_bytes":
@@ -4093,6 +4114,10 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_write_bytes(%s, %s)", args[0], args[1]), nil
 	case "write_file":
 		return fmt.Sprintf("mfl_write_file(%s, %s)", args[0], args[1]), nil
+	case "write_file_bytes":
+		return fmt.Sprintf("mfl_write_file_bytes(%s, %s)", args[0], args[1]), nil
+	case "remove":
+		return fmt.Sprintf("mfl_remove_file(%s)", args[0]), nil
 	case "list_dir":
 		return fmt.Sprintf("mfl_list_dir(%s)", args[0]), nil
 	case "system":

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -9,10 +9,11 @@
 // own goroutine; the goroutine's memory is reclaimed when the response is sent.
 
 type Request struct {
-    method  string
-    path    string
-    body    string
-    headers map[string]string   // lowercased header name -> value; read via header(req, name)
+    method     string
+    path       string
+    body       string             // text view of the body (truncates at a NUL — use body_bytes for uploads)
+    body_bytes bytes              // raw body, binary-safe (file uploads / multipart)
+    headers    map[string]string  // lowercased header name -> value; read via header(req, name)
 }
 
 type Response struct {
@@ -23,6 +24,14 @@ type Response struct {
     is_bin  int        // 1 = serve bin (raw bytes), 0 = serve body (text)
     cookies []string   // Set-Cookie values (added via set_cookie); empty for most responses
     location string    // Location header (set by redirect); empty for most responses
+    extra   []string   // extra header lines "Name: value" (added via with_header), e.g. Content-Disposition
+}
+
+// with_header returns res with an extra response header added (e.g. Content-Disposition
+// for a download filename, or Cache-Control). Structs are values, so use the copy.
+func with_header(res, name, value) (r) {
+    r = res
+    r.extra = append(r.extra, name + ": " + value)
 }
 
 // redirect returns a 302 to url (a Location header). Compose with set_cookie /
@@ -83,7 +92,8 @@ func parse_request(raw) (req) {
         m = parts[0]
         p = parts[1]
     }
-    req = Request{method: m, path: p, body: http_body(raw), headers: parse_headers(raw)}
+    b := http_body(raw)
+    req = Request{method: m, path: p, body: b, body_bytes: bytes(b), headers: parse_headers(raw)}
 }
 
 // header returns a request header value (case-insensitive), or "" if absent.
@@ -111,6 +121,111 @@ func query(req, name) (v) {
         eq := index(part, "=")
         if eq > 0 {
             if substr(part, 0, eq) == name { v = url_decode(substr(part, eq + 1, len(part))) }
+        }
+    }
+}
+
+// ---- multipart/form-data (file uploads) ----
+//
+// A browser uploads files as multipart/form-data: parts separated by a boundary, each
+// with its own headers (Content-Disposition: name / filename, Content-Type) and a raw,
+// possibly-binary body. parse_multipart splits req.body_bytes into those parts,
+// binary-safe (it works on bytes, not the NUL-truncating text view).
+
+type MultipartPart struct {
+    name     string   // form field name
+    filename string   // original filename ("" for a plain, non-file field)
+    ctype    string   // the part's Content-Type ("" if absent)
+    data     bytes    // the part's raw body (binary-safe)
+}
+
+// multipart_boundary extracts the boundary token from a multipart Content-Type, or "".
+func multipart_boundary(ctype) (b) {
+    b = ""
+    i := index(to_lower(ctype), "boundary=")
+    if i < 0 { return }
+    b = substr(ctype, i + 9, len(ctype))
+    if charat(b, 0) == "\"" {                       // quoted boundary
+        e := index(substr(b, 1, len(b)), "\"")
+        if e >= 0 { b = substr(b, 1, 1 + e) }
+    } else {
+        sc := index(b, ";")
+        if sc >= 0 { b = substr(b, 0, sc) }
+    }
+    b = trim(b)
+}
+
+// mp_attr pulls a quoted attribute (name= / filename=) out of a part's header block.
+func mp_attr(head, key) (v) {
+    v = ""
+    needle := key + "=\""
+    i := index(head, needle)
+    if i < 0 { return }
+    rest := substr(head, i + len(needle), len(head))
+    e := index(rest, "\"")
+    if e >= 0 { v = substr(rest, 0, e) }
+}
+
+// mp_ctype reads a part's own Content-Type header line, or "".
+func mp_ctype(head) (v) {
+    v = ""
+    i := index(to_lower(head), "content-type:")
+    if i < 0 { return }
+    rest := substr(head, i + 13, len(head))
+    nl := index(rest, "\r\n")
+    if nl >= 0 { rest = substr(rest, 0, nl) }
+    v = trim(rest)
+}
+
+// parse_multipart parses a multipart/form-data request body into its parts (fields and
+// files), binary-safe. Returns [] for a non-multipart request. File parts carry a
+// filename; plain fields have filename == "". Each part's raw bytes are in .data.
+func parse_multipart(req) (parts) {
+    parts = []MultipartPart{}
+    bnd := multipart_boundary(header(req, "content-type"))
+    if bnd == "" { return }
+    body := req.body_bytes
+    delim := bytes("--" + bnd)
+    pos := bytes_index(body, delim, 0)
+    if pos < 0 { return }
+    pos = pos + len(delim)
+    for {
+        if pos + 2 > len(body) { return }
+        if byte_at(body, pos) == 45 { return }      // "--" after boundary -> closing delimiter
+        hstart := pos + 2                            // skip the CRLF after the boundary line
+        hsep := bytes_index(body, bytes("\r\n\r\n"), hstart)
+        if hsep < 0 { return }
+        headstr := bytes_str(bytes_sub(body, hstart, hsep))
+        dstart := hsep + 4
+        next := bytes_index(body, delim, dstart)     // next boundary ends this part's data
+        if next < 0 { return }
+        dend := next
+        if dend - 2 >= dstart {
+            if byte_at(body, dend - 2) == 13 { dend = dend - 2 }   // strip the CRLF before the boundary
+        }
+        p := MultipartPart{name: mp_attr(headstr, "name"), filename: mp_attr(headstr, "filename"), ctype: mp_ctype(headstr), data: bytes_sub(body, dstart, dend)}
+        parts = append(parts, p)
+        pos = next + len(delim)
+    }
+}
+
+// multipart_file returns the first uploaded file part with the given field name (or any
+// file if name == ""), and ok == 1 if one was found.
+func multipart_file(req, name) (part, ok) {
+    ok = 0
+    for _, p := range parse_multipart(req) {
+        if p.filename != "" {
+            if name == "" || p.name == name { part = p  ok = 1  return }
+        }
+    }
+}
+
+// multipart_field returns the text value of a non-file form field, or "".
+func multipart_field(req, name) (v) {
+    v = ""
+    for _, p := range parse_multipart(req) {
+        if p.filename == "" {
+            if p.name == name { v = bytes_str(p.data)  return }
         }
     }
 }
@@ -148,6 +263,7 @@ func cookie_lines(res) (h) {
     h = ""
     for _, c := range res.cookies { h = h + "Set-Cookie: " + c + "\r\n" }
     if res.location != "" { h = h + "Location: " + res.location + "\r\n" }
+    for _, e := range res.extra { h = h + e + "\r\n" }
 }
 
 // ---- signed sessions ----
@@ -209,9 +325,47 @@ func read_request(conn) (raw) {
     }
 }
 
+// read_request_bytes reads a whole HTTP request as raw bytes — binary-safe, so a file
+// upload body (which contains NUL bytes a string read would truncate) survives intact.
+// Like read_request it keeps reading until Content-Length bytes of body have arrived.
+func read_request_bytes(conn) (raw) {
+    raw = read_bytes(conn)
+    sep := bytes_index(raw, bytes("\r\n\r\n"), 0)
+    if sep >= 0 {
+        clen := content_length(bytes_str(bytes_sub(raw, 0, sep)))   // header block is ASCII
+        body_start := sep + 4
+        for len(raw) - body_start < clen {
+            chunk := read_bytes(conn)
+            if len(chunk) == 0 { break }        // connection closed early
+            raw = bytes_concat(raw, chunk)
+        }
+    }
+}
+
+// parse_request_bytes builds a Request from raw request bytes, keeping the body as
+// bytes (body_bytes) for binary-safe file/multipart uploads; body is the text view.
+func parse_request_bytes(raw) (req) {
+    sep := bytes_index(raw, bytes("\r\n\r\n"), 0)
+    head := raw
+    bodyb := bytes("")
+    if sep >= 0 {
+        head = bytes_sub(raw, 0, sep)
+        bodyb = bytes_sub(raw, sep + 4, len(raw))
+    }
+    hs := bytes_str(head)
+    nl := index(hs, "\r\n")
+    if nl < 0 { nl = len(hs) }
+    line := substr(hs, 0, nl)
+    parts := split(line, " ")
+    m := ""
+    p := "/"
+    if len(parts) >= 2 { m = parts[0]  p = parts[1] }
+    req = Request{method: m, path: p, body: bytes_str(bodyb), body_bytes: bodyb, headers: parse_headers(hs)}
+}
+
 func machweb_handle(conn, handler) {
-    raw := read_request(conn)
-    req := parse_request(raw)
+    raw := read_request_bytes(conn)
+    req := parse_request_bytes(raw)
     res := handler(req)
     if res.is_bin == 1 {
         // binary body: write the headers, then the raw bytes (NUL-safe).

--- a/guide.go
+++ b/guide.go
@@ -22,7 +22,7 @@ var skillBackend string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.75.0"
+const machinVersion = "0.76.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -124,7 +124,9 @@ func machinGuide() guideCatalog {
 			{"read_key", "() -> string", "non-blocking single-key read: a 1-char string, or \"\" if no key is waiting (needs raw_mode for live input)", "io"},
 			{"read_file", "(string) -> string", "read a whole file (\"\" on error)", "io"},
 			{"read_file_bytes", "(string) -> bytes", "read a whole file's raw bytes, NUL-safe (empty on error) — for binary assets", "io"},
-			{"write_file", "(string, string) -> int", "write a file (bytes; -1 on error)", "io"},
+			{"write_file", "(string, string) -> int", "write a file (text; -1 on error)", "io"},
+			{"write_file_bytes", "(string, bytes) -> int", "write raw bytes to a file, NUL-safe (-1 on error) — for binary uploads/assets", "io"},
+			{"remove", "(string) -> int", "delete a file (0 ok; -1 error)", "io"},
 			{"list_dir", "(string) -> []string", "directory entries (excludes . / ..)", "io"},
 			{"mkdir", "(string) -> int", "create a directory (0 ok; -1 error)", "io"},
 			// cli / process
@@ -207,6 +209,7 @@ func machinGuide() guideCatalog {
 			{"from_hex", "(string) -> bytes", "parse hex -> bytes (skips non-hex chars)", "bytes"},
 			{"byte_at", "(bytes, int) -> int", "byte value 0-255 at an index (-1 if out of range)", "bytes"},
 			{"bytes_sub", "(bytes, int, int) -> bytes", "sub-range [start, end) of a bytes value", "bytes"},
+			{"bytes_index", "(bytes, bytes, int) -> int", "find a needle in bytes at/after an offset, NUL-safe (-1 if absent); for binary protocols / multipart boundaries", "bytes"},
 			{"bytes_concat", "(bytes, bytes) -> bytes", "concatenate two bytes values", "bytes"},
 			// crypto over bytes (OpenSSL libcrypto, linked only when used)
 			{"rand_bytes", "(int) -> bytes", "n cryptographically-random bytes (CSPRNG)", "crypto"},

--- a/machweb_io_test.go
+++ b/machweb_io_test.go
@@ -103,6 +103,53 @@ func main() {
 	}
 }
 
+// End-to-end multipart/form-data upload: the client sends a real multipart body — a
+// text field plus a "file" whose bytes include NULs — over the socket via write_bytes.
+// The server reads it with the binary-safe read_request_bytes path and parse_multipart,
+// then echoes the file's length + hex. The proof of binary-safety is that the 4-byte
+// file (0011ff00, two NULs) round-trips intact; a NUL-truncating string path would lose
+// everything from the first 0x00.
+func TestMachwebMultipartUpload(t *testing.T) {
+	app := loopbackHelpers + `
+func handle(req) (res) {
+    title := multipart_field(req, "title")
+    f, ok := multipart_file(req, "file")
+    res = ok_text("title=" + title + " ok=" + str(ok) + " name=" + f.filename + " ct=" + f.ctype + " len=" + str(len(f.data)) + " hex=" + to_hex(f.data))
+}
+func main() {
+    port := 48236
+    srv := listen(port)
+    if srv < 0 { println("listen-failed")  return }
+    go serve_one(srv, func(req) { return handle(req) })
+    sleep(50)
+    c := dial("127.0.0.1", port)
+    if c < 0 { println("dial-failed")  return }
+    bnd := "----mfltestB"
+    pre := "--" + bnd + "\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nSME share\r\n--" + bnd + "\r\nContent-Disposition: form-data; name=\"file\"; filename=\"x.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+    post := "\r\n--" + bnd + "--\r\n"
+    body := bytes_concat(bytes_concat(bytes(pre), from_hex("0011ff00")), bytes(post))
+    head := "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Type: multipart/form-data; boundary=" + bnd + "\r\nContent-Length: " + str(len(body)) + "\r\n\r\n"
+    write_bytes(c, bytes_concat(bytes(head), body))
+    resp := read_all(c)
+    close(c)
+    println(resp)
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(out, "listen-failed") || strings.Contains(out, "dial-failed") {
+		t.Fatalf("loopback setup failed:\n%s", out)
+	}
+	if !strings.Contains(out, "title=SME share") {
+		t.Fatalf("server should read the text field; got:\n%s", out)
+	}
+	// the binary file round-tripped intact through the multipart parser, NULs and all
+	if !strings.Contains(out, "ok=1 name=x.bin ct=application/octet-stream len=4 hex=0011ff00") {
+		t.Fatalf("multipart file should round-trip binary-safe (len=4, hex=0011ff00); got:\n%s", out)
+	}
+}
+
 // The binary response path (is_bin=1) writes the headers then write_bytes(conn,
 // bin) — NUL-safe. The body here starts with a 0x00 byte, so a text/strlen path
 // would report Content-Length 0; the binary path reports the true byte count (4).

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -51,7 +51,8 @@ goroutine per connection). `req.method` / `req.path` (path carries the query
 string) / `req.body` / `header(req, name)` / `cookie(req, name)`.
 
 Response builders: `ok_text` · `ok_html` · `ok_json` · `ok_bytes(ctype, b)` ·
-**`ok_wasm(b)`** · `created` · `bad_request` · `not_found`.
+**`ok_wasm(b)`** · `created` · `bad_request` · `not_found`. Add any header with
+`with_header(res, name, value)` (e.g. `Content-Disposition` for a download filename).
 
 ```go
 func handle(req) (res) {
@@ -64,6 +65,12 @@ func main() { serve(48080, func(req) { return handle(req) }) }
 
 - **Serve your own wasm:** `ok_wasm(read_file_bytes("app.wasm"))` — `read_file_bytes`
   is NUL-safe (a `.wasm` has NUL bytes a string body would truncate).
+- **File uploads (`multipart/form-data`):** requests are read binary-safe, so a browser
+  file upload survives intact. `multipart_file(req, "file")` → `(part, ok)` with
+  `part.filename` / `part.ctype` / `part.data` (raw bytes — store with
+  `write_file_bytes`); `multipart_field(req, "name")` reads a text field of the same form.
+  `parse_multipart(req)` returns every part. The raw binary body is `req.body_bytes`. See
+  [machin-share](https://github.com/javimosch/machin-share).
 - **A database:** machin has SQLite builtins — `sqlite_open(path)` / `sqlite_exec(db,
   sql)` / `sqlite_exec(db, sql, []string params)` (`?`-bind, injection-safe) /
   `sqlite_query(db, sql[, params]) -> string` (a **JSON-array-of-rows string**) /

--- a/types.go
+++ b/types.go
@@ -1770,6 +1770,14 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[1], c.cInt)
 		c.addPair(argSlots[2], c.cInt)
 		return c.cBytes, nil
+	case "bytes_index":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("bytes_index: 3 args (haystack bytes, needle bytes, from int)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cBytes)
+		c.addPair(argSlots[2], c.cInt)
+		return c.cInt, nil
 	case "bytes_concat":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("bytes_concat: 2 args (bytes, bytes)")
@@ -2206,6 +2214,19 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cString)
 		c.addPair(argSlots[1], c.cString)
+		return c.cInt, nil
+	case "write_file_bytes":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("write_file_bytes: 2 args (path, bytes)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cBytes)
+		return c.cInt, nil
+	case "remove":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("remove: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
 		return c.cInt, nil
 	case "list_dir":
 		if len(argSlots) != 1 {


### PR DESCRIPTION
## v0.76.0 — file uploads in machweb (multipart/form-data)

Dogfooded by **[machin-share](https://github.com/javimosch/machin-share)**, a self-hostable file/paste drop. A browser file upload is `multipart/form-data` with a **binary** body, which the old text-oriented request path mangled (truncating at the first NUL). This PR makes file uploads first-class.

### machweb (`framework/machweb.src`)
- **Binary-safe requests**: `read_request_bytes` / `parse_request_bytes` keep the body as raw bytes in `Request.body_bytes`; `req.body` (text view) is unchanged, so existing apps are unaffected.
- **`parse_multipart(req)`** → `[]MultipartPart` (fields + files), with `multipart_file(req, field)` → `(part, ok)` and `multipart_field(req, name)` → string.
- **`with_header(res, name, value)`** for arbitrary response headers (e.g. `Content-Disposition` for a download filename).

### Builtins
- `bytes_index(haystack, needle, from) -> int` — NUL-safe byte search (for multipart boundaries / binary protocols).
- `write_file_bytes(path, bytes) -> int` — binary-safe file write (store an upload).
- `remove(path) -> int` — delete a file.

### Tests
`TestMachwebMultipartUpload` sends a real multipart body — a text field plus a file whose bytes include NULs — over the socket and asserts it round-trips **byte-for-byte**. Full suite green. (machin-share independently verifies a 4 KB binary upload→download with an identical SHA-256.)

### Docs
Web SKILL gains a file-uploads note; CHANGELOG v0.76.0; guide catalog lists the three builtins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added binary-safe file upload support, including multipart form handling for text fields and uploaded files.
  * Added support for returning extra response headers, enabling download-friendly filenames.
  * Introduced new bytes and file utilities for searching raw bytes, writing raw files, and removing files.
* **Bug Fixes**
  * Improved request handling so uploaded content with NUL bytes is processed safely end to end.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->