### PR TITLE
v0.77.0: streaming responses in machweb (Server-Sent Events) + ignore SIGPIPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.77.0
+
+- **Streaming responses in machweb (Server-Sent Events).** A handler can now return
+  `sse(fn)` / `stream_response(status, ctype, fn)` instead of a whole `Response`: machweb
+  writes the headers (no `Content-Length`), then hands `fn` the connection so it writes
+  the body **incrementally over a long-lived socket** — live logs, metrics, progress, LLM
+  tokens. Helpers `sse_data(conn, msg)` / `sse_event(conn, name, msg)` /
+  `sse_comment(conn, keepalive)` format SSE frames and return the write result (`< 0`
+  once the client has gone, so a producer loop breaks cleanly). Normal (whole-Response)
+  handlers are unchanged — streaming and normal routes coexist on one port.
+- **SIGPIPE is ignored** in every binary's `main`, so writing to a peer that closed the
+  connection (an SSE client that navigated away) returns `-1`/`EPIPE` instead of killing
+  the process. (A latent hazard for any long-lived server, not just streaming.)
+- Dogfooded by **[machin-live](https://github.com/javimosch/machin-live)** — a
+  self-hostable live event/log stream hub: producers `POST /push/<topic>`, browsers watch
+  `GET /stream/<topic>` over SSE, fanned out across goroutines by a single hub goroutine
+  that owns the subscriber set (the idiomatic lock-free channel pattern — a `chan` inside
+  a struct, a `[]Sub` registry).
+
 ## v0.76.0
 
 - **File uploads in machweb (multipart/form-data).** Requests are now read **binary-safe**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.75.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.77.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/codegen.go
+++ b/codegen.go
@@ -121,6 +121,7 @@ const cRuntime = `#define _GNU_SOURCE
 #include <termios.h>
 #include <sys/select.h>
 #include <sys/wait.h>
+#include <signal.h>
 
 /* slices: a Go-style header over an unboxed backing array */
 typedef struct { void* data; int64_t len; int64_t cap; } mfl_slice;
@@ -2493,7 +2494,9 @@ func (g *cgen) program(p *Program) (string, error) {
 	// host drives it through the exported functions, so emit the C main only for
 	// native, and only when the program actually defines an MFL main.
 	if !g.wasm() && g.c.HasMain() {
-		out.WriteString("int main(int argc, char** argv) { mfl_argc = argc; mfl_argv = argv; mfl_main(); return 0; }\n")
+		// Ignore SIGPIPE so a write to a peer that closed the connection (e.g. an SSE
+		// client that navigated away) returns -1/EPIPE instead of killing the process.
+		out.WriteString("int main(int argc, char** argv) { signal(SIGPIPE, SIG_IGN); mfl_argc = argc; mfl_argv = argv; mfl_main(); return 0; }\n")
 	}
 	return out.String(), nil
 }

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -25,6 +25,8 @@ type Response struct {
     cookies []string   // Set-Cookie values (added via set_cookie); empty for most responses
     location string    // Location header (set by redirect); empty for most responses
     extra   []string   // extra header lines "Name: value" (added via with_header), e.g. Content-Disposition
+    is_stream int      // 1 = a streaming response: ignore body/bin, call stream(conn) instead
+    stream  func       // func(conn): writes the body incrementally over a long-lived socket (SSE / chunked)
 }
 
 // with_header returns res with an extra response header added (e.g. Content-Disposition
@@ -61,6 +63,44 @@ func ok_bytes(ctype, b) (r) {
 // ok_wasm serves a WebAssembly module with the correct content type, so a single
 // machin binary can ship both its SSR HTML and its own .wasm SPA bundle.
 func ok_wasm(b) (r) { r = ok_bytes("application/wasm", b) }
+
+// ---- streaming responses (Server-Sent Events / live tail) ----
+//
+// A normal handler computes a whole Response and machweb writes it, then closes. A
+// STREAMING handler instead returns stream_response(...)/sse(fn): machweb writes the
+// headers, then hands fn the connection so it can write the body incrementally over a
+// long-lived socket — live logs, metrics, progress, LLM tokens. There is no
+// Content-Length; the socket stays open until fn returns. Writing to a client that has
+// gone away returns < 0 (the runtime ignores SIGPIPE), so a stream loop should break on
+// a negative write to stop cleanly.
+
+// stream_response builds a streaming response driven by fn(conn).
+func stream_response(status, ctype, fn) (r) {
+    r = Response{status: status, ctype: ctype, body: "", is_bin: 0, is_stream: 1, stream: fn}
+}
+
+// sse builds a text/event-stream response — the browser consumes it with EventSource.
+func sse(fn) (r) { r = stream_response("200 OK", "text/event-stream; charset=utf-8", fn) }
+
+// sse_data sends one SSE message (a "data:" event). Multi-line text is split so each
+// line is its own data field (per the spec). Returns the write result — < 0 once the
+// client has disconnected, which a producer loop should treat as "stop".
+func sse_data(conn, data) (n) {
+    msg := ""
+    for _, line := range split(data, "\n") { msg = msg + "data: " + line + "\n" }
+    n = write(conn, msg + "\n")
+}
+
+// sse_event sends a named SSE event (dispatched by name on the client).
+func sse_event(conn, event, data) (n) {
+    msg := "event: " + event + "\n"
+    for _, line := range split(data, "\n") { msg = msg + "data: " + line + "\n" }
+    n = write(conn, msg + "\n")
+}
+
+// sse_comment sends a comment line — a keepalive ping browsers ignore (returns < 0 if
+// the client has gone, so it doubles as a liveness probe).
+func sse_comment(conn, c) (n) { n = write(conn, ": " + c + "\n\n") }
 
 // ---- request helpers ----
 
@@ -367,6 +407,15 @@ func machweb_handle(conn, handler) {
     raw := read_request_bytes(conn)
     req := parse_request_bytes(raw)
     res := handler(req)
+    if res.is_stream == 1 {
+        // streaming body: write the headers (no Content-Length), then let the handler
+        // write events over the open socket. X-Accel-Buffering disables nginx buffering.
+        shead := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nCache-Control: no-cache\r\nX-Accel-Buffering: no\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n"
+        write(conn, shead)
+        res.stream(conn)
+        close(conn)
+        return
+    }
     if res.is_bin == 1 {
         // binary body: write the headers, then the raw bytes (NUL-safe).
         head := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.bin)) + "\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n"

--- a/guide.go
+++ b/guide.go
@@ -22,7 +22,7 @@ var skillBackend string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.76.0"
+const machinVersion = "0.77.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/machweb_io_test.go
+++ b/machweb_io_test.go
@@ -150,6 +150,56 @@ func main() {
 	}
 }
 
+// A streaming (SSE) response: the handler returns sse(fn), and machweb writes the
+// event-stream headers (no Content-Length) then lets fn write data events over the open
+// socket. The client reads until the server closes. Proven by the text/event-stream
+// content type + the three "data:" events arriving in the body.
+func TestMachwebSSEStream(t *testing.T) {
+	app := loopbackHelpers + `
+func emit(conn) {
+    i := 0
+    while i < 3 {
+        n := sse_data(conn, "tick " + str(i))
+        if n < 0 { return }
+        i = i + 1
+    }
+}
+func handle(req) (res) {
+    if req.path == "/events" { res = sse(func(conn) { emit(conn) })  return }
+    res = ok_text("home")
+}
+func main() {
+    port := 48237
+    srv := listen(port)
+    if srv < 0 { println("listen-failed")  return }
+    go serve_one(srv, func(req) { return handle(req) })
+    sleep(50)
+    c := dial("127.0.0.1", port)
+    if c < 0 { println("dial-failed")  return }
+    write(c, "GET /events HTTP/1.1\r\nHost: x\r\n\r\n")
+    resp := read_all(c)
+    close(c)
+    println(resp)
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(out, "listen-failed") || strings.Contains(out, "dial-failed") {
+		t.Fatalf("loopback setup failed:\n%s", out)
+	}
+	if !strings.Contains(out, "Content-Type: text/event-stream") {
+		t.Fatalf("SSE response should carry the event-stream content type; got:\n%s", out)
+	}
+	// a streaming response has no Content-Length, and all three events arrived
+	if strings.Contains(out, "Content-Length:") {
+		t.Fatalf("a streaming response must not send Content-Length; got:\n%s", out)
+	}
+	if !strings.Contains(out, "data: tick 0") || !strings.Contains(out, "data: tick 1") || !strings.Contains(out, "data: tick 2") {
+		t.Fatalf("all three SSE events should stream through; got:\n%s", out)
+	}
+}
+
 // The binary response path (is_bin=1) writes the headers then write_bytes(conn,
 // bin) — NUL-safe. The body here starts with a 0x00 byte, so a text/strlen path
 // would report Content-Length 0; the binary path reports the true byte count (4).

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -71,6 +71,14 @@ func main() { serve(48080, func(req) { return handle(req) }) }
   `write_file_bytes`); `multipart_field(req, "name")` reads a text field of the same form.
   `parse_multipart(req)` returns every part. The raw binary body is `req.body_bytes`. See
   [machin-share](https://github.com/javimosch/machin-share).
+- **Streaming / Server-Sent Events:** return `sse(func(conn) { ... })` instead of a whole
+  Response and write events over the open socket with `sse_data(conn, msg)` /
+  `sse_event(conn, name, msg)` / `sse_comment(conn, ping)` — for live logs, progress, or
+  LLM tokens. A write returns `< 0` once the client disconnects (break the loop). SIGPIPE
+  is ignored so a vanished client can't kill the server. For cross-goroutine fan-out
+  (one producer → many live subscribers) use a single hub goroutine that owns the
+  subscriber set (a `chan` field inside a struct, a `[]Sub` registry) — see
+  [machin-live](https://github.com/javimosch/machin-live).
 - **A database:** machin has SQLite builtins — `sqlite_open(path)` / `sqlite_exec(db,
   sql)` / `sqlite_exec(db, sql, []string params)` (`?`-bind, injection-safe) /
   `sqlite_query(db, sql[, params]) -> string` (a **JSON-array-of-rows string**) /


### PR DESCRIPTION
## v0.77.0 — streaming responses in machweb (Server-Sent Events)

Dogfooded by **[machin-live](https://github.com/javimosch/machin-live)**, a self-hostable live event/log stream hub. machweb's model was "compute a whole `Response`, write it, close" — this PR adds the inverse: keep the socket open and flush events over time.

### machweb (`framework/machweb.src`)
- `Response` gains `is_stream` + a `stream func(conn)` field. A handler returns **`sse(fn)`** or **`stream_response(status, ctype, fn)`**; machweb writes the headers (no `Content-Length`) then calls `fn(conn)`, which writes the body incrementally over the long-lived socket.
- Frame helpers: **`sse_data(conn, msg)`**, **`sse_event(conn, name, msg)`**, **`sse_comment(conn, keepalive)`** — each returns the write result (`< 0` once the client disconnects, so a producer loop breaks cleanly).
- Streaming and normal whole-`Response` routes coexist on the same port.

### Runtime (`codegen.go`)
- **`main()` now ignores `SIGPIPE`** (`signal(SIGPIPE, SIG_IGN)`), so writing to a peer that closed the connection (an SSE client that navigated away) returns `-1`/`EPIPE` instead of killing the process. This was a latent hazard for *any* long-lived server. Added `<signal.h>`.

### Tests
`TestMachwebSSEStream` asserts an `sse()` handler streams three `data:` frames with a `text/event-stream` content type and **no** `Content-Length`. Full suite green. machin-live independently proves cross-goroutine fan-out, topic filtering, history replay, and survival of client disconnects.

### Docs
Web SKILL gains a streaming/SSE note; CHANGELOG v0.77.0; README version badge corrected to 0.77.0 (it was stale at 0.75.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming Server-Sent Events support for long-lived responses.
  * Introduced helpers for sending event data, event names, and comments.

* **Bug Fixes**
  * Prevented binaries from terminating unexpectedly when a streaming client disconnects.

* **Documentation**
  * Updated the changelog, README version badge, and web streaming guidance.

* **Tests**
  * Added an end-to-end test covering SSE streaming behavior and response headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->