### PR TITLE
v0.78.0: production hardening + reverse-proxy awareness in machweb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.78.0
+
+- **Production hardening + reverse-proxy awareness in machweb.** A machin app usually
+  runs behind a proxy (nginx / Caddy / Traefik / Cloudflare) that terminates TLS — these
+  make it correct and safe there. All default **off**; turn them on in `main()` (or call
+  `harden(max_body_bytes, read_timeout_ms)` for the common set):
+  - **Proxy-awareness** — `scheme(req)` / `client_ip(req)` / `base_url(req)` read
+    `X-Forwarded-Proto` / `X-Forwarded-For` (only when `set_trust_proxy(1)`), so redirects,
+    OAuth `redirect_uri`s, emailed links, and logged client IPs are right behind a proxy.
+    `set_secure_cookies(1)` marks cookies `Secure`. `req.remote` is the raw socket peer.
+  - **Hardening** — `set_max_body(n)` rejects an over-cap body with `413` *without*
+    buffering it; `set_read_timeout(ms)` caps a slow client's request read (anti
+    slow-loris); `set_access_log(1)` emits one JSON access-log line per request on stderr.
+- **Two net builtins**: `peer_addr(fd)` (the socket peer IP via `getpeername`) and
+  `socket_timeout(fd, ms)` (cap blocking recv/send via `SO_RCVTIMEO`/`SO_SNDTIMEO`).
+- Dogfooded by **[machin-deploy](https://github.com/javimosch/machin-deploy)** — a
+  reference production-ready machin service (proxy-correct, hardened, with a systemd unit,
+  a slim Docker image, and nginx/Caddy snippets). New `machin guide --skill deploy`.
+
 ## v0.77.0
 
 - **Streaming responses in machweb (Server-Sent Events).** A handler can now return

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.77.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.78.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/codegen.go
+++ b/codegen.go
@@ -1081,6 +1081,23 @@ static int64_t mfl_listen(int64_t port) {
     return fd;
 }
 static int64_t mfl_accept(int64_t fd) { return accept((int)fd, NULL, NULL); }
+/* peer_addr: the remote IP of a connected socket (getpeername), "" on error — the real
+   client IP when not behind a proxy (behind one, prefer X-Forwarded-For). */
+static const char* mfl_peer_addr(int64_t fd) {
+    struct sockaddr_storage ss; socklen_t sl = sizeof(ss);
+    if (getpeername((int)fd, (struct sockaddr*)&ss, &sl) != 0) return "";
+    char host[64] = {0};
+    if (getnameinfo((struct sockaddr*)&ss, sl, host, sizeof(host), NULL, 0, NI_NUMERICHOST) != 0) return "";
+    char* r = (char*)mfl_alloc(strlen(host) + 1); strcpy(r, host); return r;
+}
+/* socket_timeout: cap blocking recv/send on a socket to ms milliseconds (0 = none), so a
+   slow client can't park a connection forever. Returns 0 on success, -1 on error. */
+static int64_t mfl_socket_timeout(int64_t fd, int64_t ms) {
+    struct timeval tv; tv.tv_sec = ms / 1000; tv.tv_usec = (ms % 1000) * 1000;
+    int a = setsockopt((int)fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    int b = setsockopt((int)fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    return (a == 0 && b == 0) ? 0 : -1;
+}
 /* dial: connect a TCP socket to host:port, returning an fd (-1 on failure).
    The fd is used with the same read/write/close as an accepted connection. */
 static int64_t mfl_dial(const char* host, int64_t port) {
@@ -4069,6 +4086,12 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "accept":
 		g.usesNet = true
 		return fmt.Sprintf("mfl_accept(%s)", args[0]), nil
+	case "peer_addr":
+		g.usesNet = true
+		return fmt.Sprintf("mfl_peer_addr(%s)", args[0]), nil
+	case "socket_timeout":
+		g.usesNet = true
+		return fmt.Sprintf("mfl_socket_timeout(%s, %s)", args[0], args[1]), nil
 	case "read":
 		g.usesNet = true
 		return fmt.Sprintf("mfl_read(%s)", args[0]), nil

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -14,6 +14,7 @@ type Request struct {
     body       string             // text view of the body (truncates at a NUL — use body_bytes for uploads)
     body_bytes bytes              // raw body, binary-safe (file uploads / multipart)
     headers    map[string]string  // lowercased header name -> value; read via header(req, name)
+    remote     string             // the socket peer IP (set by machweb_handle); see client_ip(req)
 }
 
 type Response struct {
@@ -289,7 +290,9 @@ func cookie(req, name) (v) {
 //   return set_cookie(ok_html(page()), "sid", token)
 func set_cookie(res, name, value) (r) {
     r = res
-    r.cookies = append(r.cookies, name + "=" + value + "; Path=/; HttpOnly; SameSite=Lax")
+    sec := ""
+    if machweb_secure_cookies == 1 { sec = "; Secure" }    // HTTPS-only when set_secure_cookies(1)
+    r.cookies = append(r.cookies, name + "=" + value + "; Path=/; HttpOnly; SameSite=Lax" + sec)
 }
 
 // clear_cookie returns res with a cookie expired (for logout).
@@ -334,6 +337,67 @@ func set_session(res, secret, name, value) (r) { r = set_cookie(res, name, sessi
 // get_session reads + verifies a signed session cookie: (value, ok).
 func get_session(req, secret, name) (value, ok) { value, ok = session_verify(secret, cookie(req, name)) }
 
+// ---- production config: proxy-awareness + hardening ----
+//
+// In production a machin app usually sits behind a reverse proxy (nginx / Caddy /
+// Traefik / Cloudflare) that terminates TLS. These knobs make the app correct + safe in
+// that setup. All default OFF, so existing apps are unchanged; turn them on in main().
+
+var machweb_trust_proxy   = 0    // 1 = trust X-Forwarded-Proto/For (ONLY behind a proxy you control)
+var machweb_secure_cookies = 0   // 1 = add "; Secure" to cookies (set when served over HTTPS)
+var machweb_access_log    = 0    // 1 = one JSON access-log line per request on stderr
+var machweb_max_body      = 0    // > 0 = reject a request body larger than N bytes (413)
+var machweb_read_timeout  = 0    // > 0 = cap a slow client's request read at N ms (anti slow-loris)
+
+func set_trust_proxy(n)    { machweb_trust_proxy = n }
+func set_secure_cookies(n) { machweb_secure_cookies = n }
+func set_access_log(n)     { machweb_access_log = n }
+func set_max_body(n)       { machweb_max_body = n }
+func set_read_timeout(n)   { machweb_read_timeout = n }
+
+// harden turns on the common production set in one call: trust the proxy, mark cookies
+// Secure (you're behind TLS), structured access logs, a body cap, and a read timeout.
+func harden(max_body_bytes, read_timeout_ms) {
+    machweb_trust_proxy = 1
+    machweb_secure_cookies = 1
+    machweb_access_log = 1
+    machweb_max_body = max_body_bytes
+    machweb_read_timeout = read_timeout_ms
+}
+
+// scheme is the request's original scheme. Behind a TLS-terminating proxy the socket is
+// plain HTTP, so the true scheme comes from X-Forwarded-Proto (only trusted when
+// set_trust_proxy(1)). Defaults to "http".
+func scheme(req) (s) {
+    s = "http"
+    if machweb_trust_proxy == 1 {
+        xf := header(req, "x-forwarded-proto")
+        if xf != "" {
+            ci := index(xf, ",")                  // may be a list "https, http"
+            if ci >= 0 { xf = substr(xf, 0, ci) }
+            s = trim(xf)
+        }
+    }
+}
+
+// client_ip is the real client IP: the first hop of X-Forwarded-For when trusting the
+// proxy, otherwise the socket peer (req.remote).
+func client_ip(req) (ip) {
+    ip = req.remote
+    if machweb_trust_proxy == 1 {
+        xf := header(req, "x-forwarded-for")
+        if xf != "" {
+            ci := index(xf, ",")
+            if ci >= 0 { xf = substr(xf, 0, ci) }   // left-most = original client
+            ip = trim(xf)
+        }
+    }
+}
+
+// base_url is scheme://host for the request — build absolute URLs (OAuth redirect_uri,
+// emailed links) that are correct even behind a TLS proxy.
+func base_url(req) (u) { u = scheme(req) + "://" + header(req, "host") }
+
 // ---- server ----
 
 // content_length parses the Content-Length header value from a request's headers.
@@ -373,11 +437,15 @@ func read_request_bytes(conn) (raw) {
     sep := bytes_index(raw, bytes("\r\n\r\n"), 0)
     if sep >= 0 {
         clen := content_length(bytes_str(bytes_sub(raw, 0, sep)))   // header block is ASCII
-        body_start := sep + 4
-        for len(raw) - body_start < clen {
-            chunk := read_bytes(conn)
-            if len(chunk) == 0 { break }        // connection closed early
-            raw = bytes_concat(raw, chunk)
+        // a declared body larger than the cap is left unread — machweb_handle 413s it
+        // (no buffering, no OOM) rather than draining megabytes off the socket.
+        if machweb_max_body == 0 || clen <= machweb_max_body {
+            body_start := sep + 4
+            for len(raw) - body_start < clen {
+                chunk := read_bytes(conn)
+                if len(chunk) == 0 { break }    // connection closed early (or read timeout)
+                raw = bytes_concat(raw, chunk)
+            }
         }
     }
 }
@@ -403,29 +471,53 @@ func parse_request_bytes(raw) (req) {
     req = Request{method: m, path: p, body: bytes_str(bodyb), body_bytes: bodyb, headers: parse_headers(hs)}
 }
 
+// access_log writes one structured JSON line per request to stderr (fd 2), so it never
+// pollutes a JSON/data response on stdout. Enabled by set_access_log(1).
+func access_log(req, status, bytes_out, ms) {
+    line := "{\"ip\":\"" + client_ip(req) + "\",\"method\":\"" + req.method + "\",\"path\":\"" + req.path + "\",\"status\":\"" + status + "\",\"bytes\":" + str(bytes_out) + ",\"ms\":" + str(ms) + "}\n"
+    w := write(2, line)
+}
+
 func machweb_handle(conn, handler) {
+    started := now_ms()
+    if machweb_read_timeout > 0 { t := socket_timeout(conn, machweb_read_timeout) }   // anti slow-loris
     raw := read_request_bytes(conn)
     req := parse_request_bytes(raw)
+    req.remote = peer_addr(conn)
+    // reject an over-cap body before dispatching (read_request_bytes stopped buffering it)
+    if machweb_max_body > 0 && parse_int(header(req, "content-length")) > machweb_max_body {
+        body := "request body exceeds the limit"
+        out := "HTTP/1.1 413 Payload Too Large\r\nContent-Type: text/plain\r\nContent-Length: " + str(len(body)) + "\r\nConnection: close\r\n\r\n" + body
+        write(conn, out)
+        close(conn)
+        if machweb_access_log == 1 { access_log(req, "413 Payload Too Large", len(body), now_ms() - started) }
+        return
+    }
     res := handler(req)
     if res.is_stream == 1 {
         // streaming body: write the headers (no Content-Length), then let the handler
         // write events over the open socket. X-Accel-Buffering disables nginx buffering.
         shead := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nCache-Control: no-cache\r\nX-Accel-Buffering: no\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n"
         write(conn, shead)
+        if machweb_access_log == 1 { access_log(req, res.status + " (stream)", 0, now_ms() - started) }
         res.stream(conn)
         close(conn)
         return
     }
+    nbytes := 0
     if res.is_bin == 1 {
         // binary body: write the headers, then the raw bytes (NUL-safe).
         head := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.bin)) + "\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n"
         write(conn, head)
         write_bytes(conn, res.bin)
+        nbytes = len(res.bin)
     } else {
         out := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.body)) + "\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n" + res.body
         write(conn, out)
+        nbytes = len(res.body)
     }
     close(conn)
+    if machweb_access_log == 1 { access_log(req, res.status, nbytes, now_ms() - started) }
 }
 
 // serve runs the HTTP server. Each connection is handled in its own goroutine.

--- a/guide.go
+++ b/guide.go
@@ -20,9 +20,12 @@ var skillGamedev string
 //go:embed skills/machin-backend/SKILL.md
 var skillBackend string
 
+//go:embed skills/machin-deploy/SKILL.md
+var skillDeploy string
+
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.77.0"
+const machinVersion = "0.78.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -74,6 +77,7 @@ var guideDomains = []guideDomain{
 	{"web", "web", "machin guide --skill web", "Full-stack web: a native HTTP server (machweb), SSR, a reactive WebAssembly UI (signals + keyed lists), a client-side router, cookies + signed sessions, and OAuth2/OIDC SSO — one language both ends, no Node/bundler."},
 	{"gamedev", "gamedev", "machin guide --skill gamedev", "Native games: terminal TUI (raw_mode/read_key + ANSI) and raylib GUI/audio/3D through the C FFI — sprites, sound, 3D cameras, GPU meshes (pointer/array FFI), instancing, shaders, procedural worlds (noise)."},
 	{"backend", "backend", "machin guide --skill backend", "Single-binary backends: HTTP/JSON APIs, pure-MFL drivers for SQLite, PostgreSQL (SCRAM), MySQL/MariaDB, Redis, and MongoDB (all connection-pooled, uniform JSON rows → parse([]T{})), signed sessions, OAuth2/OIDC SSO, agent-first CLIs, and daemons."},
+	{"deploy", "deploy", "machin guide --skill deploy", "Ship a machin web app to production: run it behind a reverse proxy (nginx/Caddy/Traefik/Cloudflare) correctly and safely — proxy-awareness (X-Forwarded-Proto/For → scheme/client_ip/base_url, Secure cookies), hardening (body cap, read timeout, access logs), a systemd unit, and a slim Docker image."},
 }
 
 // builtinNames is the set of builtin function names (from the catalog), memoized.
@@ -247,6 +251,8 @@ func machinGuide() guideCatalog {
 			{"dial", "(string, int) -> int", "TCP connect host:port -> fd (-1 on fail)", "net"},
 			{"listen", "(int) -> int", "open a listening TCP socket on a port", "net"},
 			{"accept", "(int) -> int", "accept a connection -> fd", "net"},
+			{"peer_addr", "(int) -> string", "remote IP of a connected socket (getpeername), \"\" on error — the real client IP when not behind a proxy", "net"},
+			{"socket_timeout", "(int, int) -> int", "cap blocking recv/send on a socket to N ms (0 = none) — anti slow-loris; 0 ok / -1 error", "net"},
 			{"read", "(int) -> string", "read a chunk from an fd (blocks); a C string, so it truncates at a NUL — use read_bytes for binary", "net"},
 			{"read_bytes", "(int) -> bytes", "read a chunk from an fd as raw bytes, NUL-safe (empty at EOF) — for binary wire protocols (Postgres/MySQL/Redis)", "net"},
 			{"write", "(int, string) -> int", "write to an fd", "net"},
@@ -359,8 +365,10 @@ func cmdGuide(args []string) error {
 				fmt.Print(skillGamedev)
 			case "backend":
 				fmt.Print(skillBackend)
+			case "deploy":
+				fmt.Print(skillDeploy)
 			default:
-				return fmt.Errorf("unknown skill %q — available: web, gamedev, backend (see `machin guide` domains)", name)
+				return fmt.Errorf("unknown skill %q — available: web, gamedev, backend, deploy (see `machin guide` domains)", name)
 			}
 			return nil
 		}

--- a/machweb_io_test.go
+++ b/machweb_io_test.go
@@ -150,6 +150,81 @@ func main() {
 	}
 }
 
+// Proxy-awareness: behind a TLS-terminating proxy the socket is plain HTTP, but
+// X-Forwarded-Proto/For carry the real scheme + client IP. With set_trust_proxy(1) the
+// handler sees scheme=https, the forwarded client IP, an https base_url, and cookies are
+// marked Secure. Proven over the socket with forged X-Forwarded-* headers.
+func TestMachwebProxyAwareness(t *testing.T) {
+	app := loopbackHelpers + `
+func handle(req) (res) {
+    res = set_cookie(ok_text("scheme=" + scheme(req) + " ip=" + client_ip(req) + " base=" + base_url(req)), "sid", "x")
+}
+func main() {
+    set_trust_proxy(1)
+    set_secure_cookies(1)
+    port := 48238
+    srv := listen(port)
+    if srv < 0 { println("listen-failed")  return }
+    go serve_one(srv, func(req) { return handle(req) })
+    sleep(50)
+    c := dial("127.0.0.1", port)
+    if c < 0 { println("dial-failed")  return }
+    write(c, "GET /acct HTTP/1.1\r\nHost: app.example\r\nX-Forwarded-Proto: https\r\nX-Forwarded-For: 203.0.113.7, 10.0.0.1\r\n\r\n")
+    resp := read_all(c)
+    close(c)
+    println(resp)
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(out, "listen-failed") || strings.Contains(out, "dial-failed") {
+		t.Fatalf("loopback setup failed:\n%s", out)
+	}
+	if !strings.Contains(out, "scheme=https") {
+		t.Fatalf("scheme should come from X-Forwarded-Proto; got:\n%s", out)
+	}
+	if !strings.Contains(out, "ip=203.0.113.7") {
+		t.Fatalf("client_ip should be the left-most X-Forwarded-For hop; got:\n%s", out)
+	}
+	if !strings.Contains(out, "base=https://app.example") {
+		t.Fatalf("base_url should be scheme://host; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Set-Cookie: sid=x; Path=/; HttpOnly; SameSite=Lax; Secure") {
+		t.Fatalf("cookies should be marked Secure when set_secure_cookies(1); got:\n%s", out)
+	}
+}
+
+// The request body cap: with set_max_body(N), a request declaring a larger body is
+// rejected 413 without buffering it all.
+func TestMachwebMaxBody(t *testing.T) {
+	app := loopbackHelpers + `
+func main() {
+    set_max_body(100)
+    port := 48239
+    srv := listen(port)
+    if srv < 0 { println("listen-failed")  return }
+    go serve_one(srv, func(req) { return ok_text("ok") })
+    sleep(50)
+    c := dial("127.0.0.1", port)
+    if c < 0 { println("dial-failed")  return }
+    write(c, "POST /up HTTP/1.1\r\nHost: x\r\nContent-Length: 5000\r\n\r\n" + "AAAAAAAAAA")
+    resp := read_all(c)
+    close(c)
+    println(resp)
+}`
+	out, err := RunCaptured(machwebProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(out, "listen-failed") || strings.Contains(out, "dial-failed") {
+		t.Fatalf("loopback setup failed:\n%s", out)
+	}
+	if !strings.Contains(out, "413 Payload Too Large") {
+		t.Fatalf("an over-cap body should be rejected 413; got:\n%s", out)
+	}
+}
+
 // A streaming (SSE) response: the handler returns sse(fn), and machweb writes the
 // event-stream headers (no Content-Length) then lets fn write data events over the open
 // socket. The client reads until the server closes. Proven by the text/event-stream

--- a/skills/machin-deploy/SKILL.md
+++ b/skills/machin-deploy/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: machin-deploy
+description: Ship a machin (MFL) web app to production — run it correctly and safely behind a reverse proxy (nginx / Caddy / Traefik / Cloudflare), with the machweb hardening + proxy-awareness knobs, a systemd unit, and a slim Docker image. Use when deploying or operationalizing a machin HTTP service: getting HTTPS via a proxy, fixing http→https redirects/cookies behind TLS termination, the real client IP, request size/time limits, access logs, and the run/restart story. Distilled from the deploy dogfood (machin v0.78) and the machin-deploy reference app.
+---
+
+# Deploying a machin web app
+
+A machin web service is **one static-ish native binary** (it links libc, OpenSSL, and
+maybe libsqlite3 — not fully static, but no runtime/interpreter). The standard production
+shape is that binary **behind a reverse proxy** that terminates TLS — nginx, Caddy,
+Traefik, or Cloudflare. You do **not** need machin to speak TLS itself; the proxy does
+HTTPS and forwards plain HTTP to your app. This skill is about making the app *correct and
+safe* in that setup.
+
+> Build the app with the [`machin-web`](web) / [`machin-backend`](backend) skills; this is
+> the *operate it in production* how-to.
+
+## Turn on the production knobs (in `main`)
+
+All default **off**, so dev is unchanged. Enable what you need before `serve`:
+
+```go
+func main() {
+    harden(20 * 1024 * 1024, 15000)   // body cap 20 MB, 15 s read timeout, +trust-proxy,
+                                       // +Secure cookies, +access log — the common set
+    serve(8080, func(req) { return handle(req) })
+}
+```
+
+`harden(max_body_bytes, read_timeout_ms)` is shorthand; the individual switches are:
+
+| Call | Effect |
+|---|---|
+| `set_trust_proxy(1)` | trust `X-Forwarded-Proto` / `X-Forwarded-For` (**only** behind a proxy you control) |
+| `set_secure_cookies(1)` | add `; Secure` to every cookie (you're served over HTTPS) |
+| `set_max_body(n)` | reject a request body larger than `n` bytes with `413` — *without buffering it* |
+| `set_read_timeout(ms)` | cap a slow client's request read (anti **slow-loris**) |
+| `set_access_log(1)` | one JSON access-log line per request on **stderr** (fd 2) |
+
+## Be proxy-correct
+
+Behind a TLS-terminating proxy the socket is plain HTTP, so without help your app thinks
+every request is `http://` and sees the *proxy's* IP. With `set_trust_proxy(1)`:
+
+- **`scheme(req)`** → `http`/`https` from `X-Forwarded-Proto`. Use it so redirects, OAuth
+  `redirect_uri`s, and emailed links are `https`, not `http`.
+- **`base_url(req)`** → `scheme://host` — build absolute URLs that survive the proxy.
+- **`client_ip(req)`** → the real client (left-most `X-Forwarded-For` hop), for logging /
+  rate-limiting / audit. `req.remote` is the raw socket peer (the proxy) if you need it.
+- **`set_secure_cookies(1)`** → sessions get `Secure` so they're never sent in clear.
+
+**Only trust these headers behind a proxy that sets them** — a client can forge
+`X-Forwarded-*`. If the app is ever directly exposed, leave `set_trust_proxy(0)`.
+
+## Reverse proxy snippets
+
+**nginx** — forward the headers machweb reads, and don't buffer SSE:
+```nginx
+location / {
+    proxy_pass         http://127.0.0.1:8080;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_buffering    off;          # let Server-Sent Events stream (machweb also sends X-Accel-Buffering: no)
+}
+```
+**Caddy** — TLS + the forwarded headers are automatic:
+```
+app.example.com {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+## Run it: systemd
+
+A single binary is a trivial unit. `Type=simple`, run as a non-root user, restart on
+failure, and rely on `set_access_log(1)` → journald:
+```ini
+[Unit]
+Description=machin app
+After=network.target
+
+[Service]
+ExecStart=/opt/app/server
+Environment=PORT=8080 APP_SECRET=change-me
+User=app
+Restart=on-failure
+RestartSec=2
+# SIGTERM stops it; in-flight requests are short-lived goroutines.
+
+[Install]
+WantedBy=multi-user.target
+```
+`listen` sets `SO_REUSEADDR`, so a restart rebinds immediately (no `TIME_WAIT` wait).
+
+## Run it: Docker (slim, not scratch)
+
+The binary needs libc + OpenSSL (`libssl`/`libcrypto`) at runtime (sessions/crypto), and
+`libsqlite3` if you use SQLite — so a `FROM scratch` image won't run it. A slim base does:
+```dockerfile
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libssl3 libsqlite3-0 ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY server /usr/local/bin/server
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/server"]
+```
+(Multi-stage: build with `machin build` in a builder stage, copy just the binary.)
+
+## Gotchas
+
+- **Trust the proxy, not the client.** `set_trust_proxy(1)` only behind a proxy that
+  *overwrites* `X-Forwarded-*`. Directly exposed → keep it off, or a client spoofs its IP.
+- **`set_secure_cookies(1)` requires HTTPS.** On a Secure cookie set over plain `http://`
+  the browser drops it — turn it on only once TLS (via the proxy) is in front.
+- **Access logs go to stderr** so stdout stays a clean data/JSON stream; capture fd 2 in
+  journald/Docker.
+- **Body cap is on the declared `Content-Length`** — an over-cap request is `413`'d before
+  its body is read (no OOM, no draining megabytes).
+- **Graceful shutdown is SIGTERM = exit.** Each request is its own short-lived goroutine,
+  so kill is safe in practice; there's no long-drain coordinator yet.
+
+## Reference
+
+- **[machin-deploy](https://github.com/javimosch/machin-deploy)** — a production-ready
+  machin service wired with all of the above: proxy-correct, hardened, a systemd unit, a
+  slim Dockerfile, and nginx/Caddy configs. Clone it as a deploy template.

--- a/types.go
+++ b/types.go
@@ -2102,6 +2102,19 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cString)
 		c.addPair(argSlots[1], c.cInt)
 		return c.cInt, nil
+	case "peer_addr":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("peer_addr: 1 arg (fd)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cString, nil
+	case "socket_timeout":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("socket_timeout: 2 args (fd, ms)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cInt, nil
 	case "read":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("read: 1 arg")


### PR DESCRIPTION
## v0.78.0 — production hardening + reverse-proxy awareness in machweb

Dogfooded by **[machin-deploy](https://github.com/javimosch/machin-deploy)**, a reference production-ready service. You raised the right point: a reverse proxy already gives HTTPS, so native TLS termination isn't needed to deploy. The real gaps are what a proxy *doesn't* solve — being correct and safe *behind* it. This PR fills those.

### machweb (`framework/machweb.src`) — all default off; `harden(max_body, read_timeout)` flips the common set
- **Proxy-awareness** (with `set_trust_proxy(1)`): `scheme(req)` / `client_ip(req)` / `base_url(req)` read `X-Forwarded-Proto` / `X-Forwarded-For`, so redirects, OAuth `redirect_uri`s, emailed links, and logged IPs are right behind a TLS-terminating proxy. `req.remote` is the raw socket peer. `set_secure_cookies(1)` marks cookies `Secure`.
- **Hardening**: `set_max_body(n)` rejects an over-cap body `413` *without buffering it*; `set_read_timeout(ms)` caps a slow client's read (anti slow-loris); `set_access_log(1)` emits one JSON access-log line per request on stderr.

### Runtime (`codegen.go`)
- `peer_addr(fd)` — the socket peer IP (`getpeername`).
- `socket_timeout(fd, ms)` — cap blocking recv/send (`SO_RCVTIMEO`/`SO_SNDTIMEO`).

### Tests
`TestMachwebProxyAwareness` (scheme/IP/base_url derived from forged `X-Forwarded-*`, Secure cookie) + `TestMachwebMaxBody` (`413`). Full suite green. machin-deploy independently proves the direct-vs-proxied behaviour, sessions, the body cap, and JSON access logs end-to-end.

### Docs
New embedded **`machin guide --skill deploy`** (systemd unit, slim Dockerfile, nginx/Caddy snippets, the trust-the-proxy gotchas) + a `deploy` domain in the guide. CHANGELOG v0.78.0; README badge → 0.78.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
