### PR TITLE
v0.79.0: a WebSocket server (RFC 6455) for machweb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.79.0
+
+- **A WebSocket *server* (RFC 6455) for machweb** — `framework/ws.src`, the symmetric half
+  of the existing wss client. A handler returns `ws(req, fn)` and machweb hands over the
+  raw socket (new generic `hijack(fn)` response: write nothing, run `fn(conn)`); `fn` does
+  the upgrade handshake (`Sec-WebSocket-Accept = base64(sha1(key + GUID))`) and speaks
+  frames. The frame codec is **pure MFL over bytes + the bitwise builtins**: unmasked
+  server frames out (`ws_send_text` / `ws_send_bytes` / `ws_send_close` / 7-, 16-, 64-bit
+  lengths), masked client frames in (`ws_recv` unmasks via the 4-byte XOR key),
+  `ws_next_text` transparently answers pings and stops on close. Verified against the
+  Python `websockets` reference client (handshake, unicode, fragmented lengths, ping/pong).
+- machweb gains **`is_hijack`** on `Response` (hand the raw connection to a closure for any
+  protocol upgrade) — no new builtin needed; the codec rides existing `bytes`/bitwise ops
+  + `sha1_bytes`/`base64_encode_bytes`.
+- Dogfooded by **[machin-rooms](https://github.com/javimosch/machin-rooms)** — a
+  self-hostable real-time chat server: multi-room, broadcast fan-out, join/leave + live
+  member count, two goroutines per connection (a reader + a writer over the shared fd),
+  all in one MFL binary.
+
 ## v0.78.0
 
 - **Production hardening + reverse-proxy awareness in machweb.** A machin app usually

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.78.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.79.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -27,7 +27,15 @@ type Response struct {
     location string    // Location header (set by redirect); empty for most responses
     extra   []string   // extra header lines "Name: value" (added via with_header), e.g. Content-Disposition
     is_stream int      // 1 = a streaming response: ignore body/bin, call stream(conn) instead
-    stream  func       // func(conn): writes the body incrementally over a long-lived socket (SSE / chunked)
+    is_hijack int      // 1 = hand the raw socket to stream(conn) with NO response written (protocol upgrade, e.g. WebSocket)
+    stream  func       // func(conn): writes the body incrementally over a long-lived socket (SSE / chunked / hijack)
+}
+
+// hijack returns a response that hands the raw connection to fn(conn) — machweb writes
+// nothing and closes after fn returns. The basis for a protocol upgrade: fn sends its own
+// handshake then speaks the new protocol (see framework/ws.src for WebSocket).
+func hijack(fn) (r) {
+    r = Response{status: "101 Switching Protocols", ctype: "", is_hijack: 1, stream: fn}
 }
 
 // with_header returns res with an extra response header added (e.g. Content-Disposition
@@ -494,6 +502,12 @@ func machweb_handle(conn, handler) {
         return
     }
     res := handler(req)
+    if res.is_hijack == 1 {
+        // protocol upgrade: hand over the raw socket, write no HTTP response of our own.
+        res.stream(conn)
+        close(conn)
+        return
+    }
     if res.is_stream == 1 {
         // streaming body: write the headers (no Content-Length), then let the handler
         // write events over the open socket. X-Accel-Buffering disables nginx buffering.

--- a/framework/ws.src
+++ b/framework/ws.src
@@ -1,0 +1,166 @@
+// ws.src — a WebSocket (RFC 6455) server for machweb. Compose after machweb.src:
+//   machin encode framework/machweb.src framework/ws.src yourapp.src > app.mfl
+//
+// A handler turns a request into a live socket by returning ws(req, fn): machweb hands
+// over the raw connection (Response.is_hijack), fn does the RFC 6455 upgrade handshake
+// (Sec-WebSocket-Accept = base64(sha1(key + GUID))) and then speaks frames. The codec is
+// pure MFL over bytes — server->client frames are unmasked, client->server frames are
+// masked (a 4-byte XOR key), all built/parsed with the bytes + bitwise builtins.
+//
+//   func chat(req) (res) {
+//       res = ws(req, func(c) {                 // c is a WSConn
+//           ws_send_text(c.fd, "welcome")
+//           for {
+//               msg, ok := ws_next_text(c)      // answers pings, stops on close/EOF
+//               if ok == 0 { return }
+//               n := ws_send_text(c.fd, "echo: " + msg)
+//           }
+//       })
+//   }
+
+// A live WebSocket connection: the fd plus a one-slot "box" holding bytes read off the
+// socket but not yet consumed (a frame can split across reads; reads can over-deliver).
+// The box persists across calls even though the struct is passed by value (the slice
+// shares its backing array).
+type WSConn struct {
+    fd  int
+    buf []bytes
+}
+
+func ws_conn(fd) (c) {
+    bx := []bytes{}
+    bx = append(bx, bytes(""))
+    c = WSConn{fd: fd, buf: bx}
+}
+
+// ws_accept computes Sec-WebSocket-Accept for a client's Sec-WebSocket-Key.
+func ws_accept(key) (a) {
+    a = base64_encode_bytes(sha1_bytes(bytes(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")))
+}
+
+// is_ws_request reports whether a request is a WebSocket upgrade (Upgrade: websocket).
+func is_ws_request(req) (yes) {
+    yes = 0
+    if to_lower(header(req, "upgrade")) == "websocket" { yes = 1 }
+}
+
+// ws upgrades a request to a WebSocket and runs fn(WSConn) for the life of the socket.
+func ws(req, fn) (r) {
+    key := header(req, "sec-websocket-key")
+    r = hijack(func(conn) {
+        write(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + ws_accept(key) + "\r\n\r\n")
+        fn(ws_conn(conn))
+    })
+}
+
+// ---- frame codec ----
+
+func ws_nyb(v) (c) { d := "0123456789abcdef"  c = substr(d, v & 15, (v & 15) + 1) }
+func ws_hex2(n) (s) { s = ws_nyb((n & 255) / 16) + ws_nyb(n) }    // an int 0-255 -> 2 hex chars
+func ws_byte(n) (b) { b = from_hex(ws_hex2(n)) }                  // an int 0-255 -> one byte
+
+// ws_frame builds an unmasked server frame (FIN set) for an opcode + payload.
+func ws_frame(opcode, payload) (f) {
+    n := len(payload)
+    f = ws_byte(128 | opcode)                       // FIN=1 + opcode
+    if n < 126 {
+        f = bytes_concat(f, ws_byte(n))
+    } else {
+        if n < 65536 {
+            f = bytes_concat(f, ws_byte(126))
+            f = bytes_concat(f, ws_byte((n >> 8) & 255))
+            f = bytes_concat(f, ws_byte(n & 255))
+        } else {
+            f = bytes_concat(f, ws_byte(127))
+            i := 7
+            while i >= 0 { f = bytes_concat(f, ws_byte((n >> (i * 8)) & 255))  i = i - 1 }
+        }
+    }
+    f = bytes_concat(f, payload)
+}
+
+func ws_send_text(fd, s) (n)   { n = write_bytes(fd, ws_frame(1, bytes(s))) }
+func ws_send_bytes(fd, b) (n)  { n = write_bytes(fd, ws_frame(2, b)) }
+func ws_send_pong(fd, p) (n)   { n = write_bytes(fd, ws_frame(10, p)) }
+func ws_send_ping(fd) (n)      { n = write_bytes(fd, ws_frame(9, bytes(""))) }
+func ws_send_close(fd) (n)     { n = write_bytes(fd, ws_frame(8, bytes(""))) }
+
+// ws_fill ensures >= n bytes are buffered (reads more); 0 on EOF / read timeout.
+func ws_fill(c, n) (ok) {
+    ok = 1
+    while len(c.buf[0]) < n {
+        chunk := read_bytes(c.fd)
+        if len(chunk) == 0 { ok = 0  return }
+        c.buf[0] = bytes_concat(c.buf[0], chunk)
+    }
+}
+
+// ws_take consumes and returns the first n buffered bytes.
+func ws_take(c, n) (b) {
+    b = bytes_sub(c.buf[0], 0, n)
+    c.buf[0] = bytes_sub(c.buf[0], n, len(c.buf[0]))
+}
+
+// ws_recv reads one frame -> (opcode, payload, ok). Client frames are unmasked here.
+// ok == 0 on close/EOF. Control frames (ping 9, pong 10, close 8) are returned as-is.
+func ws_recv(c) (opcode, payload, ok) {
+    opcode = 0
+    payload = bytes("")
+    ok = 0
+    if ws_fill(c, 2) == 0 { return }
+    h := ws_take(c, 2)
+    b0 := byte_at(h, 0)
+    b1 := byte_at(h, 1)
+    opcode = b0 & 15
+    masked := b1 & 128
+    n := b1 & 127
+    if n == 126 {
+        if ws_fill(c, 2) == 0 { return }
+        e := ws_take(c, 2)
+        n = (byte_at(e, 0) << 8) | byte_at(e, 1)
+    }
+    if n == 127 {
+        if ws_fill(c, 8) == 0 { return }
+        e := ws_take(c, 8)
+        n = 0
+        i := 0
+        while i < 8 { n = (n << 8) | byte_at(e, i)  i = i + 1 }
+    }
+    mask := bytes("")
+    if masked != 0 {
+        if ws_fill(c, 4) == 0 { return }
+        mask = ws_take(c, 4)
+    }
+    if ws_fill(c, n) == 0 { return }
+    raw := ws_take(c, n)
+    if masked != 0 {
+        hx := ""
+        i := 0
+        while i < n {
+            u := byte_at(raw, i) ^ byte_at(mask, i & 3)      // unmask: XOR with the 4-byte key
+            hx = hx + ws_hex2(u)
+            i = i + 1
+        }
+        payload = from_hex(hx)
+    } else {
+        payload = raw
+    }
+    ok = 1
+}
+
+// ws_next_text reads the next TEXT/binary message, transparently answering pings and
+// stopping on a close or EOF -> (text, ok). The everyday read for a chat-style server.
+func ws_next_text(c) (text, ok) {
+    text = ""
+    ok = 0
+    while 1 == 1 {
+        op, payload, good := ws_recv(c)
+        if good == 0 { return }
+        if op == 8 { return }                                   // close
+        if op == 9 { p := ws_send_pong(c.fd, payload)  continue }   // ping -> pong
+        if op == 10 { continue }                                // pong
+        text = bytes_str(payload)
+        ok = 1
+        return                                                  // text or binary payload
+    }
+}

--- a/guide.go
+++ b/guide.go
@@ -25,7 +25,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.78.0"
+const machinVersion = "0.79.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -79,6 +79,14 @@ func main() { serve(48080, func(req) { return handle(req) }) }
   (one producer → many live subscribers) use a single hub goroutine that owns the
   subscriber set (a `chan` field inside a struct, a `[]Sub` registry) — see
   [machin-live](https://github.com/javimosch/machin-live).
+- **WebSockets (`framework/ws.src`):** compose `ws.src` after `machweb.src`, then a handler
+  returns `ws(req, func(c) { ... })`. machweb does the upgrade (via the generic
+  `hijack(fn)` response) and `c` is a `WSConn`: `ws_next_text(c)` → `(msg, ok)` reads the
+  next message (answering pings, stopping on close); `ws_send_text(c.fd, s)` /
+  `ws_send_bytes(c.fd, b)` send. A connection that also receives broadcasts wants **two
+  goroutines** — the handler loop reads, a spawned `go writer(c.fd, ch)` drains an outbound
+  channel (read + write are independent on the fd). Fan-out is the same hub-goroutine
+  pattern as SSE. See [machin-rooms](https://github.com/javimosch/machin-rooms).
 - **A database:** machin has SQLite builtins — `sqlite_open(path)` / `sqlite_exec(db,
   sql)` / `sqlite_exec(db, sql, []string params)` (`?`-bind, injection-safe) /
   `sqlite_query(db, sql[, params]) -> string` (a **JSON-array-of-rows string**) /

--- a/ws_test.go
+++ b/ws_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// wsProg composes machweb.src + ws.src + the test app (ws.src needs machweb's hijack).
+func wsProg(t *testing.T, app string) *Program {
+	t.Helper()
+	mw, err := os.ReadFile("framework/machweb.src")
+	if err != nil {
+		t.Skip("framework/machweb.src not found")
+	}
+	ws, err := os.ReadFile("framework/ws.src")
+	if err != nil {
+		t.Skip("framework/ws.src not found")
+	}
+	prog, perr := progFromSrcErr(string(mw) + string(ws) + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	return prog
+}
+
+// A full WebSocket round-trip over the socket: the server upgrades (RFC 6455 handshake)
+// and echoes; the client sends a hand-built *masked* "hi" frame and reads the server's
+// *unmasked* echo frame. Proves the handshake accept key, client-frame unmasking, and
+// server-frame building all in the real socket path.
+//
+//   masked "hi": 81 82 | 01020304 (mask) | 69 6b  ('h'^01, 'i'^02)
+//   key "dGhlIHNhbXBsZSBub25jZQ==" -> accept "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" (the RFC example)
+func TestWebSocketEchoRoundTrip(t *testing.T) {
+	app := `
+func serve_one(srv, handler) { conn := accept(srv)  machweb_handle(conn, handler) }
+func echo(req) (res) {
+    res = ws(req, func(c) {
+        while 1 == 1 {
+            msg, ok := ws_next_text(c)
+            if ok == 0 { return }
+            s := ws_send_text(c.fd, "echo: " + msg)
+            if s < 0 { return }
+        }
+    })
+}
+func read_some(c) (s) {
+    s = ""
+    i := 0
+    while i < 6 {
+        chunk := read(c)
+        if chunk == "" { return }
+        s = s + chunk
+        i = i + 1
+    }
+}
+func main() {
+    port := 48241
+    srv := listen(port)
+    if srv < 0 { println("listen-failed")  return }
+    go serve_one(srv, func(req) { return echo(req) })
+    sleep(50)
+    c := dial("127.0.0.1", port)
+    if c < 0 { println("dial-failed")  return }
+    write(c, "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n")
+    sleep(40)
+    hs := read(c)
+    write_bytes(c, from_hex("818201020304696b"))     // a masked "hi" frame
+    sleep(40)
+    frame := read(c)
+    close(c)
+    println("HS<" + hs + ">")
+    println("FRAME<" + frame + ">")
+}`
+	out, err := RunCaptured(wsProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(out, "listen-failed") || strings.Contains(out, "dial-failed") {
+		t.Fatalf("loopback setup failed:\n%s", out)
+	}
+	// the upgrade handshake completed with the correct RFC 6455 accept key
+	if !strings.Contains(out, "101 Switching Protocols") || !strings.Contains(out, "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=") {
+		t.Fatalf("handshake should be a 101 with the correct accept key; got:\n%s", out)
+	}
+	// the client's masked "hi" was unmasked and echoed back in an (unmasked) text frame
+	if !strings.Contains(out, "echo: hi") {
+		t.Fatalf("server should unmask the client frame and echo it; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## v0.79.0 — a WebSocket server (RFC 6455) for machweb

The symmetric half of the existing wss *client* — machin now does **both ends** of WebSockets. Dogfooded by **[machin-rooms](https://github.com/javimosch/machin-rooms)**, a self-hostable real-time chat server.

### `framework/ws.src` (new)
- **`ws(req, fn)`** — upgrade a request and run `fn(WSConn)` for the life of the socket. The handshake computes `Sec-WebSocket-Accept = base64(sha1(key + GUID))`.
- **Pure-MFL RFC 6455 frame codec** over `bytes` + the bitwise builtins: unmasked server frames out (`ws_send_text` / `ws_send_bytes` / `ws_send_close`; 7/16/64-bit lengths), masked client frames in (`ws_recv` unmasks via the 4-byte XOR key), `ws_next_text(c)` transparently answers pings and stops on close.
- A per-connection read buffer (the slice-box trick) so a frame split across reads reassembles.

### `framework/machweb.src`
- `Response.is_hijack` + **`hijack(fn)`** — hand the raw socket to a closure with *no* HTTP response written. A generic protocol-upgrade hook; WebSocket is its first user. **No new builtin** — the codec rides existing `bytes`/bitwise ops + `sha1_bytes` / `base64_encode_bytes`.

### Tests
`TestWebSocketEchoRoundTrip` drives a hand-built **masked** frame over the socket and asserts the `101` handshake (correct RFC 6455 accept key) + the unmasked echo. Also verified end-to-end against the Python `websockets` reference client (unicode, 16-bit length path, ping/pong, clean close). machin-rooms proves multi-client broadcast, room isolation, and join/leave/count. Full suite green.

### Docs
Web SKILL gains a WebSocket section; CHANGELOG v0.79.0; README badge → 0.79.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket support for real-time connections, including upgrade handling and text/binary message exchange.
  * Added support for protocol hijacking so upgraded connections can be handed off directly to handlers.

* **Documentation**
  * Updated the changelog and version references to **v0.79.0**.
  * Expanded WebSocket usage guidance in the developer docs.

* **Tests**
  * Added end-to-end coverage for WebSocket handshake and message echo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->