### PR TITLE
v0.80.0: an SMTP toolkit (send + receive mail in pure MFL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.80.0
+
+- **An SMTP toolkit — `framework/smtp.src`.** Send mail and receive it, both pure MFL over
+  `dial`/`listen` + read/write, no library, no cgo:
+  - **client** — `smtp_send(host, port, from, to, subject, body, user, pass) -> (ok, errmsg)`
+    runs the full `220`/`EHLO`/`AUTH LOGIN`/`MAIL`/`RCPT`/`DATA`/`QUIT` conversation, with
+    `base64` AUTH, multiple recipients, and dot-stuffing.
+  - **server** — `smtp_recv(conn) -> (Mail, ok)` plays the receiving side of one session
+    (a catcher), plus a buffered line reader (`line_reader`/`read_line`/`read_reply`) and
+    `mail_header`/`mail_body` parsers.
+  - Plaintext SMTP + AUTH (enough for a relay that doesn't force TLS, and for a local
+    catcher). STARTTLS/implicit TLS is the next step (it needs a wrap-an-fd-in-TLS
+    primitive). No new builtin — it rides `dial`/`read_bytes`/`base64_encode`.
+- Dogfooded by **[machin-mail](https://github.com/javimosch/machin-mail)** — a self-contained
+  SMTP toolkit binary: `send` mail and `sink` it (a local catcher + a web inbox, à la
+  MailHog/Mailpit), so the sender is testable with **zero external dependencies**. Verified
+  both directions against independent standard implementations (Python `smtplib` ⇄ the
+  machin client/sink).
+
 ## v0.79.0
 
 - **A WebSocket *server* (RFC 6455) for machweb** — `framework/ws.src`, the symmetric half

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.79.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.80.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/framework/smtp.src
+++ b/framework/smtp.src
@@ -1,0 +1,243 @@
+// smtp.src — a pure-MFL SMTP toolkit: a client that SENDS mail and the server side that
+// RECEIVES it, both over dial()/listen() + read/write. No external library, no cgo.
+//
+//   smtp_send(host, port, from, to, subject, body, user, pass) -> (ok, errmsg)   // a sender
+//   smtp_recv(conn) -> (Mail, ok)                                                 // one server session
+//
+// The protocol is line-oriented (CRLF), so reads go through a small buffered line reader
+// (the slice-box trick, so a line split across packets reassembles). This is plaintext
+// SMTP + AUTH LOGIN/PLAIN — enough to talk to a submission relay that doesn't force TLS,
+// and to a local catcher. (STARTTLS/implicit TLS would need a TLS-wrap-an-fd primitive.)
+
+// ---- a buffered line reader over a socket fd ----
+
+type LineReader struct {
+    fd  int
+    buf []bytes
+}
+
+func line_reader(fd) (r) {
+    bx := []bytes{}
+    bx = append(bx, bytes(""))
+    r = LineReader{fd: fd, buf: bx}
+}
+
+// read_line returns the next CRLF/LF-delimited line (without the terminator), ok=0 on EOF.
+func read_line(r) (line, ok) {
+    line = ""
+    ok = 0
+    while 1 == 1 {
+        idx := bytes_index(r.buf[0], bytes("\n"), 0)
+        if idx >= 0 {
+            raw := bytes_sub(r.buf[0], 0, idx)
+            r.buf[0] = bytes_sub(r.buf[0], idx + 1, len(r.buf[0]))
+            line = bytes_str(raw)
+            if len(line) > 0 { if charat(line, len(line) - 1) == "\r" { line = substr(line, 0, len(line) - 1) } }
+            ok = 1
+            return
+        }
+        chunk := read_bytes(r.fd)
+        if len(chunk) == 0 {
+            if len(r.buf[0]) > 0 { line = bytes_str(r.buf[0])  r.buf[0] = bytes("")  ok = 1 }
+            return
+        }
+        r.buf[0] = bytes_concat(r.buf[0], chunk)
+    }
+}
+
+// read_reply consumes a (possibly multi-line) SMTP reply and returns its 3-digit code.
+// Continuation lines have a '-' as the 4th char; the final line has a space.
+func read_reply(r) (code, ok) {
+    code = 0
+    ok = 0
+    while 1 == 1 {
+        line, good := read_line(r)
+        if good == 0 { return }
+        if len(line) >= 3 { code = parse_int(substr(line, 0, 3)) }
+        if len(line) >= 4 {
+            if charat(line, 3) == "-" { continue }   // continuation -> keep reading
+        }
+        ok = 1
+        return
+    }
+}
+
+// ---- the client ----
+
+// smtp_build assembles the DATA payload: headers + a blank line + the body, with
+// dot-stuffing (a line starting with "." gets an extra "." so it isn't read as the
+// end-of-data marker).
+func smtp_build(from, to, subject, body) (m) {
+    m = "From: " + from + "\r\n" +
+        "To: " + to + "\r\n" +
+        "Subject: " + subject + "\r\n" +
+        "MIME-Version: 1.0\r\n" +
+        "Content-Type: text/plain; charset=utf-8\r\n" +
+        "\r\n"
+    for _, raw := range split(body, "\n") {
+        l := raw
+        if len(l) > 0 { if charat(l, len(l) - 1) == "\r" { l = substr(l, 0, len(l) - 1) } }
+        if len(l) > 0 { if charat(l, 0) == "." { l = "." + l } }
+        m = m + l + "\r\n"
+    }
+}
+
+// smtp_send sends one message. user=="" skips AUTH. Returns (1,"") on success, else
+// (0, reason). Expects the standard 220/250/334/235/354/250 reply codes.
+func smtp_send(host, port, from, to, subject, body, user, pass) (ok, errmsg) {
+    ok = 0
+    errmsg = ""
+    conn := dial(host, port)
+    if conn < 0 { errmsg = "dial failed"  return }
+    r := line_reader(conn)
+
+    code, good := read_reply(r)
+    if good == 0 || code != 220 { errmsg = "no 220 greeting"  close(conn)  return }
+
+    w := write(conn, "EHLO machin-mail\r\n")
+    code, good = read_reply(r)
+    if code != 250 { errmsg = "EHLO rejected"  close(conn)  return }
+
+    if user != "" {
+        w = write(conn, "AUTH LOGIN\r\n")
+        code, good = read_reply(r)
+        if code != 334 { errmsg = "AUTH LOGIN unsupported"  close(conn)  return }
+        w = write(conn, base64_encode(user) + "\r\n")
+        code, good = read_reply(r)
+        if code != 334 { errmsg = "AUTH username rejected"  close(conn)  return }
+        w = write(conn, base64_encode(pass) + "\r\n")
+        code, good = read_reply(r)
+        if code != 235 { errmsg = "authentication failed"  close(conn)  return }
+    }
+
+    w = write(conn, "MAIL FROM:<" + from + ">\r\n")
+    code, good = read_reply(r)
+    if code != 250 { errmsg = "MAIL FROM rejected"  close(conn)  return }
+
+    for _, rcpt := range split(to, ",") {
+        addr := trim(rcpt)
+        if addr != "" {
+            w = write(conn, "RCPT TO:<" + addr + ">\r\n")
+            code, good = read_reply(r)
+            if code != 250 { errmsg = "RCPT rejected: " + addr  close(conn)  return }
+        }
+    }
+
+    w = write(conn, "DATA\r\n")
+    code, good = read_reply(r)
+    if code != 354 { errmsg = "DATA rejected"  close(conn)  return }
+
+    w = write(conn, smtp_build(from, to, subject, body))
+    w = write(conn, "\r\n.\r\n")
+    code, good = read_reply(r)
+    if code != 250 { errmsg = "message rejected"  close(conn)  return }
+
+    w = write(conn, "QUIT\r\n")
+    cq, gq := read_reply(r)
+    close(conn)
+    ok = 1
+}
+
+// ---- the server side (a catcher / sink) ----
+
+type Mail struct {
+    mail_from string
+    rcpt_to   string   // comma-joined recipients
+    data      string   // the raw message (headers + body)
+}
+
+// smtp_addr pulls the address out of "MAIL FROM:<a@b>" / "RCPT TO:<a@b>".
+func smtp_addr(line) (a) {
+    a = ""
+    lt := index(line, "<")
+    gt := index(line, ">")
+    if lt >= 0 {
+        if gt > lt { a = substr(line, lt + 1, gt)  return }
+    }
+    c := index(line, ":")
+    if c >= 0 { a = trim(substr(line, c + 1, len(line))) }
+}
+
+// smtp_recv plays the server side of ONE SMTP session on conn and returns the caught
+// Mail (ok=1) once the client finishes (QUIT, or EOF after a completed DATA). A catcher:
+// it accepts any AUTH and every recipient.
+func smtp_recv(conn) (mail, ok) {
+    mail = Mail{mail_from: "", rcpt_to: "", data: ""}
+    ok = 0
+    r := line_reader(conn)
+    w := write(conn, "220 machin-mail ESMTP ready\r\n")
+    rcpts := ""
+    got := 0
+    while 1 == 1 {
+        line, good := read_line(r)
+        if good == 0 {
+            if got == 1 { mail.rcpt_to = rcpts  ok = 1 }   // client dropped after a full message
+            return
+        }
+        up := to_upper(line)
+        if has_prefix(up, "EHLO") {
+            w = write(conn, "250-machin-mail\r\n250-AUTH LOGIN PLAIN\r\n250 OK\r\n")
+        } else if has_prefix(up, "HELO") {
+            w = write(conn, "250 machin-mail\r\n")
+        } else if has_prefix(up, "AUTH LOGIN") {
+            w = write(conn, "334 VXNlcm5hbWU6\r\n")          // base64("Username:")
+            u, _ := read_line(r)
+            w = write(conn, "334 UGFzc3dvcmQ6\r\n")          // base64("Password:")
+            p, _ := read_line(r)
+            w = write(conn, "235 2.7.0 Authentication successful\r\n")
+        } else if has_prefix(up, "AUTH PLAIN") {
+            w = write(conn, "235 2.7.0 Authentication successful\r\n")
+        } else if has_prefix(up, "MAIL FROM") {
+            mail.mail_from = smtp_addr(line)
+            w = write(conn, "250 2.1.0 OK\r\n")
+        } else if has_prefix(up, "RCPT TO") {
+            a := smtp_addr(line)
+            if rcpts == "" { rcpts = a } else { rcpts = rcpts + ", " + a }
+            w = write(conn, "250 2.1.5 OK\r\n")
+        } else if has_prefix(up, "DATA") {
+            w = write(conn, "354 End data with <CR><LF>.<CR><LF>\r\n")
+            body := ""
+            while 1 == 1 {
+                dl, dgood := read_line(r)
+                if dgood == 0 { break }
+                if dl == "." { break }
+                if len(dl) > 0 { if charat(dl, 0) == "." { dl = substr(dl, 1, len(dl)) } }   // un-dot-stuff
+                body = body + dl + "\n"
+            }
+            mail.data = body
+            got = 1
+            w = write(conn, "250 2.0.0 OK queued\r\n")
+        } else if has_prefix(up, "QUIT") {
+            w = write(conn, "221 2.0.0 Bye\r\n")
+            mail.rcpt_to = rcpts
+            if got == 1 { ok = 1 }
+            return
+        } else if has_prefix(up, "RSET") {
+            mail.mail_from = ""  rcpts = ""  mail.data = ""  got = 0
+            w = write(conn, "250 OK\r\n")
+        } else if has_prefix(up, "NOOP") {
+            w = write(conn, "250 OK\r\n")
+        } else {
+            w = write(conn, "250 OK\r\n")
+        }
+    }
+}
+
+// mail_header pulls a header value (e.g. "Subject") out of a raw message's header block.
+func mail_header(data, name) (v) {
+    v = ""
+    for _, line := range split(data, "\n") {
+        if line == "" { return }                 // blank line -> end of headers
+        ci := index(line, ":")
+        if ci > 0 {
+            if to_lower(substr(line, 0, ci)) == to_lower(name) { v = trim(substr(line, ci + 1, len(line)))  return }
+        }
+    }
+}
+
+// mail_body returns everything after the header block (the message body).
+func mail_body(data) (b) {
+    b = ""
+    i := index(data, "\n\n")
+    if i >= 0 { b = substr(data, i + 2, len(data)) } else { b = data }
+}

--- a/guide.go
+++ b/guide.go
@@ -25,7 +25,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.79.0"
+const machinVersion = "0.80.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/skills/machin-backend/SKILL.md
+++ b/skills/machin-backend/SKILL.md
@@ -97,6 +97,16 @@ SQLite "pools" as several `sqlite_open` handles (use WAL + `PRAGMA busy_timeout`
 - A common pattern is **sessions in Redis** (`rsetex("sess:"+sid, 3600, email)`) keyed by
   a signed cookie — see the MachNotes app.
 
+## Sending email (`framework/smtp.src`)
+
+`smtp_send(host, port, from, to, subject, body, user, pass) -> (ok, errmsg)` sends a
+message over plaintext SMTP + `AUTH LOGIN` (`user=""` skips auth) — transactional email
+(password resets, receipts, alerts) with no library. The receiving side is here too:
+`smtp_recv(conn)` plays the server for one session, so you can build a catcher. Test with
+**zero external deps** against [machin-mail](https://github.com/javimosch/machin-mail)'s
+`sink` (a local SMTP catcher + web inbox). STARTTLS/implicit TLS isn't here yet — point it
+at a relay that accepts plaintext submission, or a local catcher.
+
 ## Crypto you'll reach for
 
 `sha256` / `hmac_sha256` (hex), `sha256_bytes` / `hmac_sha256_bytes` / `sha1_bytes`

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func smtpProg(t *testing.T, app string) *Program {
+	t.Helper()
+	smtp, err := os.ReadFile("framework/smtp.src")
+	if err != nil {
+		t.Skip("framework/smtp.src not found")
+	}
+	prog, perr := progFromSrcErr(string(smtp) + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	return prog
+}
+
+// A full SMTP round-trip over the socket: a server goroutine plays the receiving side
+// (smtp_recv) and the client (smtp_send) sends a message through the real 220/EHLO/AUTH/
+// MAIL/RCPT/DATA/QUIT conversation. Proves the pure-MFL client and server interoperate,
+// including AUTH LOGIN and multi-recipient + dot-stuffing.
+func TestSMTPRoundTrip(t *testing.T) {
+	app := `
+func catch(srv) {
+    conn := accept(srv)
+    mail, ok := smtp_recv(conn)
+    close(conn)
+    if ok == 1 {
+        println("CAUGHT from=" + mail.mail_from + " to=[" + mail.rcpt_to + "] subj=" + mail_header(mail.data, "Subject"))
+        println("BODY=" + mail_body(mail.data))
+    } else {
+        println("CAUGHT-FAILED")
+    }
+}
+func main() {
+    port := 48261
+    srv := listen(port)
+    if srv < 0 { println("listen-failed")  return }
+    go catch(srv)
+    sleep(50)
+    ok, errmsg := smtp_send("127.0.0.1", port, "alice@x", "b@y, c@z", "Hello", "line one\n.dotline\nline three", "user", "pass")
+    println("SENT ok=" + str(ok) + " err=[" + errmsg + "]")
+    sleep(60)
+}`
+	out, err := RunCaptured(smtpProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.Contains(out, "listen-failed") {
+		t.Fatalf("loopback setup failed:\n%s", out)
+	}
+	if !strings.Contains(out, "SENT ok=1 err=[]") {
+		t.Fatalf("smtp_send (with AUTH) should succeed; got:\n%s", out)
+	}
+	// the server caught it with both recipients and the subject parsed from the headers
+	if !strings.Contains(out, "CAUGHT from=alice@x to=[b@y, c@z] subj=Hello") {
+		t.Fatalf("server should catch the message with both recipients + subject; got:\n%s", out)
+	}
+	// dot-stuffing round-tripped: the body line ".dotline" survives intact (not "" / "dotline")
+	if !strings.Contains(out, ".dotline") {
+		t.Fatalf("a dot-prefixed body line should survive dot-stuffing; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## v0.80.0 — an SMTP toolkit (`framework/smtp.src`): send + receive mail in pure MFL

Dogfooded by **[machin-mail](https://github.com/javimosch/machin-mail)**. Per your ask, it's kept **self-contained** — a sender *and* a local catcher — so the whole thing is testable with **zero external dependencies** (no real mail server, no credentials, no network).

### `framework/smtp.src` (new)
- **Client** — `smtp_send(host, port, from, to, subject, body, user, pass) -> (ok, errmsg)` runs the full `220` / `EHLO` / `AUTH LOGIN` / `MAIL` / `RCPT` / `DATA` / `QUIT` conversation, with `base64` AUTH, multiple recipients, and dot-stuffing.
- **Server** — `smtp_recv(conn) -> (Mail, ok)` plays the receiving side of one session (a catcher), plus a buffered line reader (`line_reader` / `read_line` / `read_reply`) and `mail_header` / `mail_body` parsers.
- Plaintext SMTP + AUTH — enough for a relay that doesn't force TLS, and for a local catcher. **No new builtin** (rides `dial` / `read_bytes` / `base64_encode`). STARTTLS/implicit TLS is the noted next step (it needs a wrap-an-fd-in-TLS primitive).

### Tests
`TestSMTPRoundTrip` runs a server goroutine (`smtp_recv`) and the client (`smtp_send`) over the socket, covering AUTH LOGIN, multi-recipient, and dot-stuffing. Full suite green. machin-mail additionally cross-checks **both directions** against independent standard implementations (Python stdlib `smtplib` ⇄ the machin client/sink) — all zero-dep.

### Docs
Backend SKILL gains an email section; CHANGELOG v0.80.0; README badge → 0.80.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in SMTP email sending and receiving support.
  * Included support for login-based authentication, multiple recipients, message headers, and body parsing.
  * Added a new mail relay-style utility for sending and catching messages.

* **Documentation**
  * Updated the changelog and version references to **v0.80.0**.
  * Added guidance for using the new email functionality, including basic usage notes and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->