### PR TITLE
bench: native-speed suite — machin vs Rust vs Zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,18 @@ Built something? Add it to [awesome-machin](https://github.com/javimosch/awesome
 
 ## Performance
 
-`fib(40)` (~331M calls): **MFL 0.20s** · C 0.19s · Rust 0.29s. Values are unboxed; no interpreter, no VM.
+machin compiles through C, so it runs in the **native tier**, not the scripting tier.
+On four kernels with byte-identical output, `cc -O2` on machin's generated C **wins 2,
+ties 1, loses 1** against Rust `-O3` and Zig `ReleaseFast` (min of 5, this machine):
+
+| | fib(40) | mandelbrot 1000² | sieve 10⁷ | intsum 10⁹ |
+|---|--:|--:|--:|--:|
+| **machin** | **245 ms** | 827 ms | 203 ms | **2832 ms** |
+| Rust `-O3` | 303 ms | **814 ms** | 153 ms | 3764 ms |
+| Zig fast | 306 ms | 819 ms | **145 ms** | 3556 ms |
+
+Fastest on scalar recursion + integer loops; ~1.4× behind on array-heavy code. Unboxed
+values, no interpreter, no VM. Numbers + reproduce: [`bench/native-speed`](bench/native-speed).
 
 ## License
 

--- a/bench/native-speed/.gitignore
+++ b/bench/native-speed/.gitignore
@@ -1,0 +1,19 @@
+# compiled binaries + build artifacts — sources + measure.py are the benchmark
+*.mfl
+*.err
+*.o
+.zig-cache/
+zig-cache/
+# bare-name binaries (machin/fib, rust/fib, zig/fib, ...)
+machin/fib
+machin/mandel
+machin/sieve
+machin/intsum
+rust/fib
+rust/mandel
+rust/sieve
+rust/intsum
+zig/fib
+zig/mandel
+zig/sieve
+zig/intsum

--- a/bench/native-speed/README.md
+++ b/bench/native-speed/README.md
@@ -1,0 +1,60 @@
+# Benchmark — native speed vs Rust & Zig
+
+machin compiles MFL **through C** (`cc -O2`) to a native binary, so its runtime
+*is* whatever the C optimizer produces. The README claims "C/Rust-class speed."
+This puts a number on it against the two reference native toolchains — **Rust**
+and **Zig** — on four compute kernels.
+
+Every kernel produces **byte-for-byte identical output** in all three languages
+(verified each run), so this times the *same computation*, not three different
+ones.
+
+## Results (this machine — gcc 11.4, rustc 1.98, zig 0.16; min of 5 runs)
+
+| kernel | what it stresses | machin | Rust `-O3` | Zig `ReleaseFast` | machin vs best |
+|---|---|--:|--:|--:|--:|
+| **fib(40)** | recursion / call overhead | **245 ms** ✦ | 303 ms | 306 ms | **1.00×** |
+| **mandel** 1000² | float tight loop | 827 ms | **814 ms** ✦ | 819 ms | 1.02× |
+| **sieve** 10⁷ | array indexing / memory | 203 ms | 153 ms | **145 ms** ✦ | 1.40× |
+| **intsum** 10⁹ | integer ALU (mul+mod) | **2832 ms** ✦ | 3764 ms | 3556 ms | **1.00×** |
+
+✦ = fastest. **machin wins 2, ties 1, loses 1.**
+
+## The honest read
+
+machin is **native, full stop** — it competes in the same tier as Rust and Zig,
+not the scripting tier. Because it *is* C underneath:
+
+- On **scalar recursion and integer loops** (`fib`, `intsum`), `gcc -O2` on
+  machin's generated C matches or **beats** `rustc -O3` and Zig `ReleaseFast` here
+  — by ~20–25 %. This is gcc's optimizer on straightforward C, and on this CPU it
+  wins these two.
+- On the **float kernel** it's a dead heat (within 2 %).
+- On the **array-heavy sieve** machin trails by ~1.4× — its slice indexing/layout
+  is less optimal than a Rust `Vec` or a Zig slice. A real, current limitation, not
+  hidden.
+
+The point is not "machin beats Rust" (it doesn't, in general — the sieve shows
+that). It's that machin is squarely in the **compiled-native performance class**,
+with no VM, no interpreter, unboxed values — and it gets there from source an AI
+agent writes about as cheaply as Python (see [`../rest-sqlite`](../rest-sqlite)).
+
+## Fairness notes
+
+- Each language at its **standard release** setting; Rust at `opt-level=3` (its real
+  release level, not the weaker `-O`/level-2), Zig at `ReleaseFast`. machin has one
+  setting: `cc -O2`.
+- **No `-march=native`** for anyone — machin's build doesn't use it, so neither do
+  the references.
+- Same algorithm, same constants, same loop structure; integer kernels use 64-bit
+  elements in all three so the sieve compares codegen, not element size.
+- Zig's modulo uses `@rem` (truncated, like C/Rust `%`), not `@mod` (Euclidean),
+  which would emit extra sign-handling.
+
+## Reproduce
+
+```bash
+./run.sh        # builds all 12, checks identical output, prints the timing table
+```
+
+Needs `machin`, `cc`, `rustc`, `zig`, and `python3`.

--- a/bench/native-speed/machin/fib.src
+++ b/bench/native-speed/machin/fib.src
@@ -1,0 +1,9 @@
+// Recursive fib(40) — function-call overhead, no memoization.
+func fib(n) (r) {
+    if n < 2 { r = n  return r }
+    r = fib(n-1) + fib(n-2)
+}
+
+func main() {
+    println(fib(40))
+}

--- a/bench/native-speed/machin/intsum.src
+++ b/bench/native-speed/machin/intsum.src
@@ -1,0 +1,13 @@
+// One billion iterations of a multiply + add + modulo — pure integer ALU.
+// s = sum(i*i) mod 1_000_000_007 for i in 1..=1_000_000_000.
+func main() {
+    n := 1000000000
+    md := 1000000007
+    s := 0
+    i := 1
+    while i <= n {
+        s = (s + i*i) % md
+        i = i + 1
+    }
+    println(s)
+}

--- a/bench/native-speed/machin/mandel.src
+++ b/bench/native-speed/machin/mandel.src
@@ -1,0 +1,31 @@
+// Mandelbrot escape-time over a 1000x1000 grid, max 1000 iterations.
+// Prints the summed iteration count (a checksum that must match across languages).
+func main() {
+    w := 1000
+    h := 1000
+    maxit := 1000
+    total := 0
+    py := 0
+    while py < h {
+        px := 0
+        while px < w {
+            x0 := (float(px)/float(w))*3.5 - 2.5
+            y0 := (float(py)/float(h))*2.0 - 1.0
+            x := 0.0
+            y := 0.0
+            it := 0
+            while it < maxit {
+                x2 := x*x
+                y2 := y*y
+                if x2 + y2 > 4.0 { break }
+                y = 2.0*x*y + y0
+                x = x2 - y2 + x0
+                it = it + 1
+            }
+            total = total + it
+            px = px + 1
+        }
+        py = py + 1
+    }
+    println(total)
+}

--- a/bench/native-speed/machin/sieve.src
+++ b/bench/native-speed/machin/sieve.src
@@ -1,0 +1,23 @@
+// Sieve of Eratosthenes to 10,000,000 — integer + memory access.
+// Prints the prime count (664579). All three languages use a 64-bit element
+// array (parity), so this measures codegen, not element size.
+func main() {
+    n := 10000000
+    sieve := []int{}
+    i := 0
+    while i <= n { sieve = append(sieve, 1)  i = i+1 }
+    sieve[0] = 0
+    sieve[1] = 0
+    p := 2
+    while p*p <= n {
+        if sieve[p] == 1 {
+            m := p*p
+            while m <= n { sieve[m] = 0  m = m+p }
+        }
+        p = p+1
+    }
+    count := 0
+    k := 0
+    while k <= n { count = count + sieve[k]  k = k+1 }
+    println(count)
+}

--- a/bench/native-speed/measure.py
+++ b/bench/native-speed/measure.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Time the same four compute kernels built three ways: machin, Rust, Zig.
+
+The README claims machin is "C/Rust-class speed" — machin compiles MFL through C
+to native (`cc -O2`), so its runtime is whatever the C optimizer produces. This
+checks that against the two reference native toolchains: Rust (`rustc -O`) and Zig
+(`-OReleaseFast`). Each kernel is byte-for-byte identical in output across all
+three (verified separately), so we are timing the SAME computation.
+
+Reports the MIN wall-clock over N runs (min = least noise / scheduler interference).
+Build the binaries with ./run.sh first.
+"""
+import os
+import subprocess
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+LANGS = ["machin", "rust", "zig"]
+KERNELS = ["fib", "mandel", "sieve", "intsum"]
+RUNS = 5
+
+
+def bench(path):
+    best = None
+    out = None
+    for _ in range(RUNS):
+        t0 = time.perf_counter()
+        r = subprocess.run([path], capture_output=True, text=True)
+        dt = time.perf_counter() - t0
+        out = (r.stdout + r.stderr).strip()
+        best = dt if best is None else min(best, dt)
+    return best, out
+
+
+def main():
+    results = {}  # (kernel, lang) -> (sec, out)
+    for k in KERNELS:
+        for lang in LANGS:
+            p = os.path.join(HERE, lang, k)
+            if not os.path.exists(p):
+                results[(k, lang)] = (None, "MISSING")
+                continue
+            results[(k, lang)] = bench(p)
+
+    print(f"min wall-clock over {RUNS} runs (lower = faster)\n")
+    print(f"{'kernel':<8} {'machin':>10} {'rust':>10} {'zig':>10}   {'machin vs best':>16}")
+    print("-" * 60)
+    for k in KERNELS:
+        times = {lang: results[(k, lang)][0] for lang in LANGS}
+        outs = {lang: results[(k, lang)][1] for lang in LANGS}
+        ok = len(set(outs.values())) == 1  # all checksums equal
+        best = min(t for t in times.values() if t)
+        cells = []
+        for lang in LANGS:
+            t = times[lang]
+            mark = "*" if t == best else " "
+            cells.append(f"{t*1000:8.1f}ms{mark}" if t else f"{'--':>10}")
+        ratio = times["machin"] / best
+        flag = "" if ok else "  !! checksum mismatch"
+        print(f"{k:<8} {cells[0]:>10} {cells[1]:>10} {cells[2]:>10}   {ratio:>14.2f}x{flag}")
+    print("\n* = fastest for that kernel. 'machin vs best' = how far machin is off the leader.")
+    print("All kernels verified to print identical results across the three languages.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/native-speed/run.sh
+++ b/bench/native-speed/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Build the same four kernels in machin, Rust, and Zig — each at its standard
+# release optimization — then verify identical output and time them.
+#
+#   machin : machin build  (cc -O2, machin's only setting)
+#   Rust   : rustc -C opt-level=3   (Rust's real release level — no sandbagging)
+#   Zig    : -OReleaseFast          (Zig's fastest mode)
+#
+# No -march=native for anyone (machin doesn't use it, so neither do the others).
+set +e
+cd "$(dirname "$0")"
+KERNELS="fib mandel sieve intsum"
+
+echo "== build machin (cc -O2) =="
+for k in $KERNELS; do
+  machin encode machin/$k.src > machin/$k.mfl 2>/dev/null \
+    && machin build machin/$k.mfl -o machin/$k 2>/dev/null && echo "  machin/$k ok" || echo "  machin/$k FAIL"
+done
+
+echo "== build Rust (rustc -C opt-level=3) =="
+for k in $KERNELS; do rustc -C opt-level=3 rust/$k.rs -o rust/$k 2>/dev/null && echo "  rust/$k ok" || echo "  rust/$k FAIL"; done
+
+echo "== build Zig (-OReleaseFast) =="
+( cd zig && for k in $KERNELS; do zig build-exe -OReleaseFast $k.zig 2>/dev/null && echo "  zig/$k ok" || echo "  zig/$k FAIL"; done )
+
+echo "== verify identical output =="
+for k in $KERNELS; do
+  m=$(./machin/$k 2>&1); r=$(./rust/$k 2>&1); z=$(./zig/$k 2>&1)
+  [ "$m" = "$r" ] && [ "$r" = "$z" ] && echo "  $k: $m (match)" || echo "  $k: MISMATCH m=$m r=$r z=$z"
+done
+
+echo "== timing =="
+python3 measure.py

--- a/bench/native-speed/rust/fib.rs
+++ b/bench/native-speed/rust/fib.rs
@@ -1,0 +1,8 @@
+fn fib(n: i64) -> i64 {
+    if n < 2 { return n; }
+    fib(n - 1) + fib(n - 2)
+}
+
+fn main() {
+    println!("{}", fib(40));
+}

--- a/bench/native-speed/rust/intsum.rs
+++ b/bench/native-speed/rust/intsum.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let n: i64 = 1_000_000_000;
+    let md: i64 = 1_000_000_007;
+    let mut s: i64 = 0;
+    let mut i: i64 = 1;
+    while i <= n {
+        s = (s + i * i) % md;
+        i += 1;
+    }
+    println!("{}", s);
+}

--- a/bench/native-speed/rust/mandel.rs
+++ b/bench/native-speed/rust/mandel.rs
@@ -1,0 +1,29 @@
+fn main() {
+    let w = 1000i64;
+    let h = 1000i64;
+    let maxit = 1000i64;
+    let mut total: i64 = 0;
+    let mut py = 0i64;
+    while py < h {
+        let mut px = 0i64;
+        while px < w {
+            let x0 = (px as f64 / w as f64) * 3.5 - 2.5;
+            let y0 = (py as f64 / h as f64) * 2.0 - 1.0;
+            let mut x = 0.0f64;
+            let mut y = 0.0f64;
+            let mut it = 0i64;
+            while it < maxit {
+                let x2 = x * x;
+                let y2 = y * y;
+                if x2 + y2 > 4.0 { break; }
+                y = 2.0 * x * y + y0;
+                x = x2 - y2 + x0;
+                it += 1;
+            }
+            total += it;
+            px += 1;
+        }
+        py += 1;
+    }
+    println!("{}", total);
+}

--- a/bench/native-speed/rust/sieve.rs
+++ b/bench/native-speed/rust/sieve.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let n = 10_000_000usize;
+    let mut sieve: Vec<i64> = Vec::new();
+    let mut i = 0usize;
+    while i <= n { sieve.push(1); i += 1; }
+    sieve[0] = 0;
+    sieve[1] = 0;
+    let mut p = 2usize;
+    while p * p <= n {
+        if sieve[p] == 1 {
+            let mut m = p * p;
+            while m <= n { sieve[m] = 0; m += p; }
+        }
+        p += 1;
+    }
+    let mut count: i64 = 0;
+    let mut k = 0usize;
+    while k <= n { count += sieve[k]; k += 1; }
+    println!("{}", count);
+}

--- a/bench/native-speed/zig/fib.zig
+++ b/bench/native-speed/zig/fib.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+
+fn fib(n: i64) i64 {
+    if (n < 2) return n;
+    return fib(n - 1) + fib(n - 2);
+}
+
+pub fn main() void {
+    std.debug.print("{d}\n", .{fib(40)});
+}

--- a/bench/native-speed/zig/intsum.zig
+++ b/bench/native-speed/zig/intsum.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+
+pub fn main() void {
+    const n: i64 = 1_000_000_000;
+    const md: i64 = 1_000_000_007;
+    var s: i64 = 0;
+    var i: i64 = 1;
+    while (i <= n) : (i += 1) {
+        s = @rem(s + i * i, md);
+    }
+    std.debug.print("{d}\n", .{s});
+}

--- a/bench/native-speed/zig/mandel.zig
+++ b/bench/native-speed/zig/mandel.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+pub fn main() void {
+    const w: i64 = 1000;
+    const h: i64 = 1000;
+    const maxit: i64 = 1000;
+    var total: i64 = 0;
+    var py: i64 = 0;
+    while (py < h) : (py += 1) {
+        var px: i64 = 0;
+        while (px < w) : (px += 1) {
+            const x0 = (@as(f64, @floatFromInt(px)) / @as(f64, @floatFromInt(w))) * 3.5 - 2.5;
+            const y0 = (@as(f64, @floatFromInt(py)) / @as(f64, @floatFromInt(h))) * 2.0 - 1.0;
+            var x: f64 = 0.0;
+            var y: f64 = 0.0;
+            var it: i64 = 0;
+            while (it < maxit) : (it += 1) {
+                const x2 = x * x;
+                const y2 = y * y;
+                if (x2 + y2 > 4.0) break;
+                y = 2.0 * x * y + y0;
+                x = x2 - y2 + x0;
+            }
+            total += it;
+        }
+    }
+    std.debug.print("{d}\n", .{total});
+}

--- a/bench/native-speed/zig/sieve.zig
+++ b/bench/native-speed/zig/sieve.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const n: usize = 10_000_000;
+    const alloc = std.heap.page_allocator;
+    const sieve = try alloc.alloc(i64, n + 1);
+    defer alloc.free(sieve);
+    var i: usize = 0;
+    while (i <= n) : (i += 1) sieve[i] = 1;
+    sieve[0] = 0;
+    sieve[1] = 0;
+    var p: usize = 2;
+    while (p * p <= n) : (p += 1) {
+        if (sieve[p] == 1) {
+            var m: usize = p * p;
+            while (m <= n) : (m += p) sieve[m] = 0;
+        }
+    }
+    var count: i64 = 0;
+    var k: usize = 0;
+    while (k <= n) : (k += 1) count += sieve[k];
+    std.debug.print("{d}\n", .{count});
+}


### PR DESCRIPTION
## Why

The README claimed "C/Rust-class speed" on the strength of a single `fib(40)` line. This backs it with a real four-kernel suite against the two reference native toolchains.

## What

`bench/native-speed/` — `fib`, `mandelbrot`, `sieve`, `intsum`, each written in **machin / Rust / Zig**, each producing **byte-for-byte identical output** (verified every run, so we time the *same* computation). Each language at its standard release setting: Rust `-C opt-level=3` (its real release, not the weaker `-O`), Zig `-OReleaseFast`, machin `cc -O2`. No `-march=native` for anyone.

## Result (this machine; min of 5)

| kernel | machin | Rust -O3 | Zig fast | machin vs best |
|---|--:|--:|--:|--:|
| fib(40) | **245 ms** | 303 | 306 | 1.00× |
| mandel 1000² | 827 | **814** | 819 | 1.02× |
| sieve 10⁷ | 203 | 153 | **145** | 1.40× |
| intsum 10⁹ | **2832 ms** | 3764 | 3556 | 1.00× |

**machin wins 2, ties 1, loses 1.** Because it *is* C underneath: gcc -O2 on the generated C matches or beats rustc -O3 / Zig on scalar recursion + integer loops here, ties on float, and trails ~1.4× on array-heavy indexing (a real, documented limitation — not hidden).

The point isn't "machin beats Rust" — it's that machin sits squarely in the **compiled-native tier**, reachable from source an agent writes about as cheaply as Python (the [`rest-sqlite`](../rest-sqlite) bench).

Docs/bench only — no compiler change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)