### PR TITLE
bench: cold-start / memory / ship-size vs Node & Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ no container. *Write it like a script, ship it like C.* That combination — not
 raw token count — is the whole idea. (`o200k_base`; `cl100k_base` gives the same
 ranking. Reproduce: `python3 bench/rest-sqlite/measure.py`.)
 
+…and then it ships in a way an interpreter can't ([`bench/cold-start`](bench/cold-start)):
+
+| same HTTP server | deployable image | cold start | idle RSS |
+|---|--:|--:|--:|
+| **machin** (static, `FROM scratch`) | **92.9 kB** | **0.49 ms** | **108 kB** |
+| Node (`.js` + `node:alpine`) | 178 MB · 1916× | 28.9 ms · 59× | 51 MB · 477× |
+| Python (`.py` + `python:alpine`) | 47.6 MB · 512× | 49.1 ms · 100× | 17.9 MB · 166× |
+
+A 92.9 kB image — the binary and nothing else — that's serving traffic in half a
+millisecond on ~0.1 MB of RAM.
+
 ## Why
 
 Every mainstream language was designed for **human** ergonomics — readable syntax, explicit types, multi-line formatting. For an AI agent, every output token costs, and that human-friendly ceremony taxes the writer without adding meaning. machin measured this: [`tools/tokcost.py`](tools/tokcost.py) showed base64 source costs ~2.5× the tokens to output; whitespace alone costs ~13%. The canonical one-line-per-declaration form, with every type inferred, is the end of that measurement — the smallest token surface that still produces C/Rust-class native code with zero runtime overhead.

--- a/bench/cold-start/.gitignore
+++ b/bench/cold-start/.gitignore
@@ -1,0 +1,5 @@
+# built artifacts — sources + Dockerfiles + scripts are the benchmark
+hello.mfl
+hello-machin
+hello-go
+*.err

--- a/bench/cold-start/Dockerfile.go
+++ b/bench/cold-start/Dockerfile.go
@@ -1,0 +1,5 @@
+# Go: a static (CGO_ENABLED=0) binary also ships FROM scratch — just larger.
+FROM scratch
+COPY hello-go /hello
+EXPOSE 8091
+ENTRYPOINT ["/hello"]

--- a/bench/cold-start/Dockerfile.machin
+++ b/bench/cold-start/Dockerfile.machin
@@ -1,0 +1,5 @@
+# machin: a fully static binary needs nothing else — the whole image is the binary.
+FROM scratch
+COPY hello-machin /hello
+EXPOSE 8090
+ENTRYPOINT ["/hello"]

--- a/bench/cold-start/Dockerfile.node
+++ b/bench/cold-start/Dockerfile.node
@@ -1,0 +1,5 @@
+# Node: the app is one line, but you ship the whole interpreter image under it.
+FROM node:alpine
+COPY hello.js /hello.js
+EXPOSE 8092
+CMD ["node", "/hello.js"]

--- a/bench/cold-start/Dockerfile.python
+++ b/bench/cold-start/Dockerfile.python
@@ -1,0 +1,5 @@
+# Python: same story — one-file app, full CPython image underneath.
+FROM python:alpine
+COPY hello.py /hello.py
+EXPOSE 8093
+CMD ["python", "/hello.py"]

--- a/bench/cold-start/README.md
+++ b/bench/cold-start/README.md
@@ -1,0 +1,68 @@
+# Benchmark — cold start, memory & ship size
+
+The two other benchmarks show machin *ties or beats* the native tier on speed and
+matches Python on agent-write cost. This is the axis where it **doesn't tie** — a
+tiny static native binary wins ship-size, cold-start, and memory by 1–3 orders of
+magnitude over a containerized interpreter.
+
+Same minimal HTTP "hello" server in each language (isolates the platform's floor,
+not app code), measured four ways.
+
+## Results (this machine — Docker 28, node 24, python 3.11)
+
+| | deployable image | cold start† | idle RSS | what you ship |
+|---|--:|--:|--:|---|
+| **machin** | **92.9 kB** | **0.49 ms** | **108 kB** | one static binary, `FROM scratch` |
+| Go | 4.77 MB | 1.70 ms | 5.3 MB | one static binary, `FROM scratch` |
+| Node | 178 MB | 28.9 ms | 51 MB | `.js` + `node:alpine` |
+| Python | 47.6 MB | 49.1 ms | 17.9 MB | `.py` + `python:alpine` |
+
+† cold start = `exec` → first HTTP 200, busy-polled, min of 15.
+
+**Relative to machin:**
+
+| | image | cold start | idle RSS |
+|---|--:|--:|--:|
+| Go | 51× | 3.5× | 49× |
+| Python | 512× | 100× | 166× |
+| Node | **1916×** | 59× | **477×** |
+
+The machin image is the **binary and nothing else** — verified to serve traffic
+from a `FROM scratch` container (no libc, no shell, no `/etc`). That's a 92.9 kB
+image with a ~0.1 MB resident footprint that's ready in half a millisecond.
+
+## Why this matters for the north star
+
+machin's audience is the SME backend you drop on a small VPS or a scale-to-zero
+platform. There, this axis is the product:
+
+- **Ship**: `scp` a 92.9 kB binary, or push a 92.9 kB image. No `node_modules`, no
+  `pip install`, no 178 MB pull on every cold node.
+- **Density**: 108 kB resident means hundreds of services per box, not dozens.
+- **Scale-to-zero / FaaS**: a sub-millisecond cold start has no warm-pool tax.
+
+It's *as terse as Python to write* (see [`../rest-sqlite`](../rest-sqlite)) and
+*native-tier fast* (see [`../native-speed`](../native-speed)) — and it ships like
+this.
+
+## How machin ships static
+
+By default `machin build` produces a small **dynamically-linked** glibc binary
+(~27 kB for this server). For a `FROM scratch` image, link it statically with musl
+— machin honors `$CC`, so a one-line wrapper does it:
+
+```sh
+# muslcc:  exec musl-gcc -static "$@"
+CC=./muslcc machin build hello.mfl -o hello-machin     # -> 92.9 kB, statically linked
+```
+
+machin is just C underneath, so this is the standard static-musl trick, nothing
+machin-specific.
+
+## Reproduce
+
+```bash
+./build.sh      # build the static machin + Go binaries; report artifact sizes
+python3 measure.py   # cold-start + idle RSS (node/python skipped if not installed)
+./images.sh     # build deployable Docker images, print sizes  (needs Docker)
+```

--- a/bench/cold-start/build.sh
+++ b/bench/cold-start/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Build the four hello servers as deployable artifacts.
+#   machin : fully static via musl (CC=./muslcc) -> runs FROM scratch
+#   Go     : fully static (CGO_ENABLED=0)        -> runs FROM scratch
+#   Node   : one .js file + the node:alpine image
+#   Python : one .py file + the python:alpine image
+set +e
+cd "$(dirname "$0")"
+chmod +x muslcc
+
+echo "== machin (static musl) =="
+machin encode ../../framework/machweb.src hello.src > hello.mfl 2>/dev/null
+CC="$PWD/muslcc" machin build hello.mfl -o hello-machin 2>/dev/null \
+  && echo "  hello-machin: $(stat -c%s hello-machin) bytes ($(file -b hello-machin | grep -o 'statically linked\|dynamically linked'))" \
+  || echo "  machin build FAIL (need musl-gcc)"
+
+echo "== Go (static) =="
+CGO_ENABLED=0 go build -ldflags='-s -w' -o hello-go hello.go 2>/dev/null \
+  && echo "  hello-go: $(stat -c%s hello-go) bytes ($(file -b hello-go | grep -o 'statically linked\|dynamically linked'))" \
+  || echo "  go build FAIL"
+
+echo "== Node / Python artifacts =="
+echo "  hello.js: $(stat -c%s hello.js) bytes (+ node runtime)"
+echo "  hello.py: $(stat -c%s hello.py) bytes (+ CPython runtime)"

--- a/bench/cold-start/hello.go
+++ b/bench/cold-start/hello.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "hello from go\n")
+	})
+	http.ListenAndServe(":8091", nil)
+}

--- a/bench/cold-start/hello.js
+++ b/bench/cold-start/hello.js
@@ -1,0 +1,2 @@
+const http = require("http");
+http.createServer((req, res) => res.end("hello from node\n")).listen(8092);

--- a/bench/cold-start/hello.py
+++ b/bench/cold-start/hello.py
@@ -1,0 +1,11 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"hello from python\n")
+
+
+HTTPServer(("", 8093), H).serve_forever()

--- a/bench/cold-start/hello.src
+++ b/bench/cold-start/hello.src
@@ -1,0 +1,3 @@
+// Minimal HTTP server — isolates the platform's shipping cost & startup floor.
+func handle(req) (res) { res = ok_text("hello from machin\n") }
+func main() { serve(8090, func(req) { return handle(req) }) }

--- a/bench/cold-start/images.sh
+++ b/bench/cold-start/images.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Build a deployable Docker image for each hello server and print the sizes —
+# the real "what you ship" number. machin & Go go FROM scratch; Node & Python
+# carry their interpreter's base image. Run ./build.sh first (needs the binaries).
+set +e
+cd "$(dirname "$0")"
+
+for v in machin go node python; do
+  docker build -q -f Dockerfile.$v -t coldstart-$v . >/dev/null 2>build-$v.err \
+    && echo "built coldstart-$v" || { echo "coldstart-$v FAILED (see build-$v.err)"; }
+done
+
+echo
+echo "deployable image sizes:"
+docker images --format '{{.Repository}} {{.Size}}' | grep '^coldstart-' | sort

--- a/bench/cold-start/measure.py
+++ b/bench/cold-start/measure.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Cold-start latency + idle memory for the same hello HTTP server, four ways.
+
+This is the axis where a tiny static native binary doesn't tie — it wins by a wide
+margin. For each server we measure:
+
+  COLD START  exec -> first successful HTTP 200, busy-polled (min of N, least noise).
+  IDLE RSS    resident memory once it's serving (/proc/<pid>/status VmRSS).
+
+Run ./build.sh first. Node/Python are skipped if their runtime isn't installed.
+Docker image sizes (the real 'what you ship' number) come from ./images.sh.
+"""
+import os
+import socket
+import subprocess
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RUNS = 15
+
+# name, argv, port
+SERVERS = [
+    ("machin", [os.path.join(HERE, "hello-machin")], 8090),
+    ("go", [os.path.join(HERE, "hello-go")], 8091),
+    ("node", ["node", os.path.join(HERE, "hello.js")], 8092),
+    ("python", ["python3", os.path.join(HERE, "hello.py")], 8093),
+]
+
+
+def try_get(port):
+    try:
+        s = socket.create_connection(("127.0.0.1", port), timeout=0.05)
+        s.sendall(b"GET / HTTP/1.0\r\n\r\n")
+        ok = b"200" in s.recv(64)
+        s.close()
+        return ok
+    except OSError:
+        return False
+
+
+def rss_kb(pid):
+    try:
+        with open(f"/proc/{pid}/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+    except OSError:
+        pass
+    return None
+
+
+def measure(argv, port):
+    best = None
+    rss = None
+    for _ in range(RUNS):
+        t0 = time.perf_counter()
+        p = subprocess.Popen(argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        while True:
+            if try_get(port):
+                dt = time.perf_counter() - t0
+                break
+            if time.perf_counter() - t0 > 10:
+                dt = None
+                break
+        if dt is not None:
+            best = dt if best is None else min(best, dt)
+            if rss is None:
+                rss = rss_kb(p.pid)
+        p.terminate()
+        try:
+            p.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            p.kill()
+        time.sleep(0.03)
+    return best, rss
+
+
+def have(argv):
+    if argv[0].startswith("/"):
+        return os.path.exists(argv[0])
+    return subprocess.run(["which", argv[0]], capture_output=True).returncode == 0
+
+
+def main():
+    print(f"cold start = exec -> first HTTP 200 (min of {RUNS}); RSS = idle resident memory\n")
+    print(f"{'server':<8} {'cold start':>12} {'idle RSS':>10}")
+    print("-" * 34)
+    base = None
+    rows = []
+    for name, argv, port in SERVERS:
+        if not have(argv):
+            print(f"{name:<8} {'(not built/installed)':>23}")
+            continue
+        dt, rss = measure(argv, port)
+        rows.append((name, dt, rss))
+        if name == "machin":
+            base = dt
+        ms = f"{dt*1000:.2f} ms" if dt else "n/a"
+        mem = f"{rss/1024:.1f} MB" if rss else "n/a"
+        print(f"{name:<8} {ms:>12} {mem:>10}")
+    if base:
+        print("\nrelative to machin:")
+        for name, dt, _ in rows:
+            if dt:
+                print(f"  {name:<8} {dt/base:6.1f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/cold-start/muslcc
+++ b/bench/cold-start/muslcc
@@ -1,0 +1,4 @@
+#!/bin/sh
+# A CC wrapper that links statically with musl, so `CC=./muslcc machin build ...`
+# produces a fully static binary that runs FROM scratch (no libc in the image).
+exec musl-gcc -static "$@"


### PR DESCRIPTION
## Why

Third and final axis of the measured pitch. The other two show machin *ties or beats* the native tier on speed and *matches Python* on agent-write cost. This is the axis where a tiny static native binary **wins outright** — the SME-backend deploy story.

## What

`bench/cold-start/` — the same minimal HTTP hello server in machin / Go / Node / Python. machin is linked **fully static via musl** (`CC=./muslcc machin build`, a one-line wrapper — machin honors `$CC`), so it ships `FROM scratch`. Verified: the 92.9 kB scratch image actually serves traffic (no libc, no shell, no `/etc`).

## Result (this machine)

| same HTTP server | deployable image | cold start | idle RSS |
|---|--:|--:|--:|
| **machin** | **92.9 kB** | **0.49 ms** | **108 kB** |
| Go (static) | 4.77 MB · 51× | 1.70 ms · 3.5× | 5.3 MB · 49× |
| Python | 47.6 MB · 512× | 49.1 ms · 100× | 17.9 MB · 166× |
| Node | 178 MB · **1916×** | 28.9 ms · 59× | 51 MB · **477×** |

A 92.9 kB image, ready in half a millisecond, on ~0.1 MB of RAM. That's the product for "drop it on a $4 VPS / scale-to-zero" — no `node_modules`, no `pip install`, no 178 MB pull per cold node.

Docs/bench only — no compiler change, no version bump. Reproduce: `./build.sh && python3 measure.py && ./images.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)