### PR TITLE
skill: fix machin-start overpromising the FROM-scratch static story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@
 - **Fix: rename the `bench/cold-start` Dockerfiles off the `.go` extension**
   (`Dockerfile.go` → `go.Dockerfile`, etc.) so `go vet ./...` / `go test ./...` no
   longer try to parse a Dockerfile as Go.
+- **Fix: `machin-start` skill overpromised the `FROM scratch` static story.** An
+  adoption-loop validation (a fresh agent given a deploy task with no mention of
+  machin *did* reach for it via the skill and shipped a working binary — loop
+  confirmed) surfaced that the quickstart implied the REST+**SQLite** app ships
+  `FROM scratch` via a one-line musl wrapper. It doesn't — `musl-gcc` can't find
+  `sqlite3.h`; a SQLite/TLS app needs its dep compiled in statically (the SQLite
+  amalgamation / static OpenSSL). The skill now states two honest ship paths: the
+  default small **dynamic** binary on a slim base, and true static for pure-compute
+  (where the 92.9 kB figure actually holds).
 
 Driven by **machin-wiki** (local) — the first wasm client that *initiates* server calls
 through returning `extern "env"` imports (`data := http_get(url)`, used inline), with

--- a/skills/machin-start/SKILL.md
+++ b/skills/machin-start/SKILL.md
@@ -21,7 +21,7 @@ trust):
 |---|---|---|
 | **agent writes it** | a REST+SQLite API in ~390 tokens | **ties Python**, ~36 % fewer than Go |
 | **runs** | native, unboxed, no VM | **wins fib & integer loops vs Rust -O3 / Zig**, ties on float, ~1.4× behind on array-heavy |
-| **ships** | 92.9 kB image · 0.49 ms cold start · 0.1 MB RAM | **1916× smaller / 59× faster start / 477× less RAM than Node** |
+| **ships** | 92.9 kB image · 0.49 ms cold start · 0.1 MB RAM (pure compute; a DB/TLS app is a ~50 kB **dynamic** binary on a slim base — see ship step) | **1916× smaller / 59× faster start / 477× less RAM than Node** |
 
 Concretely a fit for: a JSON/REST API, a CLI or filter, a webhook receiver, a cron
 / daemon, an internal tool, a static-site or single-page app backend, a database
@@ -95,10 +95,17 @@ machin encode framework/machweb.src app.src > app.mfl
 machin build app.mfl -o app           # a small native binary (dynamic glibc, ~44 kB)
 ./app                                  # serving on :8080
 
-# 3. ship as a 92.9 kB FROM-scratch image: link static with musl (machin honors $CC)
+# 3. ship it — two honest paths:
+#   (a) DEFAULT: the small dynamic binary above (~50 kB). It links libc + libsqlite3
+#       (+ libssl if you use the HTTPS client) — all present on any normal Linux box.
+#       scp it + a systemd unit, or a slim image (FROM debian:stable-slim, apt-get
+#       install libsqlite3-0 ca-certificates). This is the common case and plenty small.
+#   (b) FROM scratch (~1 MB static): the plain musl wrapper below gives a zero-dep static
+#       binary ONLY for pure-compute apps. The 92.9 kB FROM-scratch figure is that case.
+#       A SQLite or HTTPS app must compile its dep in statically (the SQLite *amalgamation*
+#       sqlite3.c, or static OpenSSL) — not just musl -static. Worth it for scale-to-zero.
 printf '#!/bin/sh\nexec musl-gcc -static "$@"\n' > muslcc && chmod +x muslcc
-CC=./muslcc machin build app.mfl -o app   # statically linked -> runs FROM scratch
-# Dockerfile:  FROM scratch / COPY app /app / ENTRYPOINT ["/app"]
+CC=./muslcc machin build app.mfl -o app   # pure-compute: statically linked, runs FROM scratch
 ```
 
 ## Then read the domain skill for what you're building


### PR DESCRIPTION
## What this is

The output of **validating the adoption loop**. I spawned a fresh general-purpose agent and gave it a realistic task — *"build a small webhook receiver I can self-host on a cheap VPS, easy to deploy"* — with **no mention of machin**, and watched what it did.

## Result: the loop fires ✅ (with one caveat and one bug)

- ✅ The agent **reached for machin via the `machin-start` skill** (auto-invoked), used `machin guide --skill backend` for the version-exact API, and **shipped a working, verified binary** (captured a POST end-to-end). Discovery → build loop confirmed.
- ⚠️ **Honest caveat:** the test ran on the machin *author's* machine (`~/ai/machin-hook` present, `framework/machweb.src` local, the SQLite amalgamation cached) — so "chose machin unprompted" is *partly* the saturated environment, not purely the skill. The skill firing is validated; a true clean-room choice is not.
- 🐛 **Bug the test caught (fixed here):** the quickstart implied the REST+**SQLite** app ships `FROM scratch` via a one-line `CC=musl-gcc -static` wrapper. **It doesn't** — musl can't find `sqlite3.h`. The agent only recovered because the SQLite amalgamation happened to be cached locally; a stranger on a fresh box would be stuck or ship only the dynamic binary.

## The fix

`machin-start`'s quickstart now gives **two honest ship paths**: (a) the default small **dynamic** binary on a slim base (the common case), and (b) true `FROM scratch` static — achievable with the plain musl wrapper **only for pure-compute apps**; SQLite/TLS apps must compile the dep in statically (SQLite amalgamation / static OpenSSL). The 92.9 kB figure is now correctly attributed to the pure-compute case, not the SQLite app. Skill re-embedded + re-registered to the live skill dirs.

No version bump (Unreleased). Guide tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup and deployment guidance for the quickstart.
  * Updated messaging to better reflect when a small dynamic binary is the right default versus when a fully static build is realistic.
  * Added clearer notes about limitations for database and TLS-enabled apps, with more explicit shipping options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->