### PR TITLE
release: v0.81.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.81.0
+
 - **New `machin build --static` — a fully static binary that bundles SQLite.** The
   SQLite [amalgamation](vendor/sqlite/) (public domain, v3.53.3) is embedded in the
   compiler (gzipped, `//go:embed`) and compiled directly into a program in `--static`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.80.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.81.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.80.0"
+const machinVersion = "0.81.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Cuts **v0.81.0**. Bumps `machinVersion` + the README badge and rolls the CHANGELOG `Unreleased` section into `v0.81.0`.

## Highlights
- **`machin build --static`** — bundles the SQLite amalgamation; a REST+SQLite app ships `FROM scratch` (libc-free ~1 MB with `CC=musl-gcc`). (#268)
- **Agent-facing skill system** — the `machin-start` decision skill (#265) + `machin skill install` to register skills where agents look (#266); honest static/deploy story (#267).
- **`pbkdf2_sha256` + a wasm-target header fix** (#262).

After merge I'll tag `v0.81.0`, which triggers `.github/workflows/release.yml` to build and attach the multi-platform binaries + SHA256SUMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)