### PR TITLE
encode: ship the framework modules in the binary (fix the bare-box quickstart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **The framework modules now ship in the binary.** `machweb.src`, the DB drivers,
+  `sso`/`ws`/`smtp`/`reactive`/`router`/`flags`/`bson` — the MFL libraries an app
+  composes against — are `//go:embed`'d, and `machin encode` resolves
+  `framework/<name>.src` from that embed when the local file is absent. So
+  `machin encode framework/machweb.src app.src` **works on a bare binary-only install**
+  (curl|sh), not just inside a repo checkout. A local copy still wins (vendoring is
+  respected). New `machin framework list | <name> | --vendor [dir]` for explicit
+  access. **Found by a clean-room re-validation:** in a fresh container the quickstart's
+  first command failed (`no such file: framework/machweb.src`) — the prior "loop
+  validated" was a false positive from running on a machin-saturated machine. Re-run in
+  the clean room now goes end-to-end: bare box → embedded framework → `--static` →
+  a working FROM-scratch SQLite binary.
+
 ## v0.81.0
 
 - **New `machin build --static` — a fully static binary that bundles SQLite.** The

--- a/framework.go
+++ b/framework.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The framework modules (machweb, the DB drivers, sso, ws, smtp, reactive, …) are
+// MFL libraries an app composes against — `machin encode framework/machweb.src
+// app.src`. They are embedded here so a binary-only install (curl|sh, no repo
+// checkout) can resolve them: without this, the very first quickstart command fails
+// with "no such file: framework/machweb.src".
+//
+//go:embed framework/*.src
+var frameworkFS embed.FS
+
+// readModule reads a source file for `machin encode`, falling back to an embedded
+// framework module when the local file is absent. A local copy always wins (so a
+// vendored or edited module is respected); the embed only fills the gap on a bare
+// install. Tries the path as given, then framework/<basename>.
+func readModule(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		return data, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, err // a real error (permissions, a directory, …) — surface it
+	}
+	if d, e := frameworkFS.ReadFile(path); e == nil {
+		return d, nil
+	}
+	if d, e := frameworkFS.ReadFile("framework/" + filepath.Base(path)); e == nil {
+		return d, nil
+	}
+	return nil, err // the original not-found error
+}
+
+// frameworkModules lists the embedded module file names (e.g. "machweb.src").
+func frameworkModules() []string {
+	entries, err := frameworkFS.ReadDir("framework")
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+// cmdFramework gives explicit access to the embedded framework modules:
+//
+//	machin framework list            list the embedded modules
+//	machin framework machweb         print one to stdout (machweb.src)
+//	machin framework --vendor [dir]  write them all into ./framework (or dir)
+func cmdFramework(args []string) error {
+	sub := "list"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "list", "-h", "--help":
+		for _, m := range frameworkModules() {
+			fmt.Println(m)
+		}
+		return nil
+	case "--vendor", "vendor":
+		dir := "framework"
+		if len(args) > 1 {
+			dir = args[1]
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		mods := frameworkModules()
+		for _, m := range mods {
+			data, err := frameworkFS.ReadFile("framework/" + m)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join(dir, m), data, 0o644); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(os.Stderr, "vendored %d framework modules -> %s/\n", len(mods), dir)
+		return nil
+	default:
+		name := sub
+		if !strings.HasSuffix(name, ".src") {
+			name += ".src"
+		}
+		data, err := frameworkFS.ReadFile("framework/" + filepath.Base(name))
+		if err != nil {
+			return fmt.Errorf("no framework module %q — run `machin framework list`", sub)
+		}
+		fmt.Print(string(data))
+		return nil
+	}
+}

--- a/framework_test.go
+++ b/framework_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// On a bare install (binary only, no repo checkout) `machin encode
+// framework/machweb.src app.src` must still work — the framework module resolves
+// from the embedded copy. This is the quickstart's first build command; before the
+// embed it failed with "no such file: framework/machweb.src".
+func TestEncodeResolvesEmbeddedFramework(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(cwd)
+
+	dir := t.TempDir()
+	app := `func main() { serve(8080, func(req) { return ok_text("hi") }) }`
+	if err := os.WriteFile(filepath.Join(dir, "app.src"), []byte(app), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil { // a dir with NO local framework/
+		t.Fatal(err)
+	}
+
+	// cmdEncode prints the result to stdout; silence it for a clean test log.
+	old := os.Stdout
+	devnull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	os.Stdout = devnull
+	err = cmdEncode([]string{"framework/machweb.src", "app.src"})
+	os.Stdout = old
+	if devnull != nil {
+		devnull.Close()
+	}
+	if err != nil {
+		t.Fatalf("encode should resolve the embedded framework on a bare box, got: %v", err)
+	}
+}
+
+// A local framework copy must win over the embedded one (vendoring is respected).
+func TestReadModulePrefersLocal(t *testing.T) {
+	dir := t.TempDir()
+	fwdir := filepath.Join(dir, "framework")
+	if err := os.MkdirAll(fwdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	local := []byte("// a local override\n")
+	if err := os.WriteFile(filepath.Join(fwdir, "machweb.src"), local, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readModule(filepath.Join(fwdir, "machweb.src"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, local) {
+		t.Fatalf("local module should win; got %q", got)
+	}
+}
+
+// The embedded set covers the real modules an app composes against.
+func TestFrameworkModulesEmbedded(t *testing.T) {
+	mods := frameworkModules()
+	for _, want := range []string{"machweb.src", "postgres.src", "smtp.src", "ws.src"} {
+		found := false
+		for _, m := range mods {
+			if m == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("embedded framework missing %s (have %v)", want, mods)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ func main() {
 		err = cmdGuide(os.Args[2:])
 	case "skill":
 		err = cmdSkill(os.Args[2:])
+	case "framework":
+		err = cmdFramework(os.Args[2:])
 	case "help", "-h", "--help":
 		usage()
 	default:
@@ -63,7 +65,8 @@ usage:
   machin build <file.mfl> --static   fully static binary (bundles SQLite; pair with CC=musl-gcc for FROM scratch)
   machin build <file.mfl> --emit-c   print the generated C and stop
   machin build|run <file.mfl> --safe  insert bounds / div-zero / overflow checks
-  machin encode <src>                mint canonical MFL from loose Go-like text
+  machin encode <src>                mint canonical MFL from loose Go-like text (framework/*.src resolve from the binary)
+  machin framework list|<name>|--vendor   the embedded framework modules (machweb, db drivers, …)
   machin pack  <file.mfl>            emit the dense base64 form (distribution)
   machin guide                       full feature catalog as JSON (--text for prose)
   machin skill install               register the agent skills where coding agents look
@@ -240,7 +243,7 @@ func cmdEncode(args []string) error {
 	}
 	var combined strings.Builder
 	for _, path := range args {
-		data, err := os.ReadFile(path)
+		data, err := readModule(path) // local file, else an embedded framework module
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## The blocker (found by clean-room re-validation)

The first adoption-loop validation ran on a machin-*saturated* machine and reported a PASS. Re-running it in a genuine clean room — a fresh `debian:stable-slim` container, the real `curl|sh` install, **no `~/ai`, no vendored framework** — the quickstart's **first build command failed**:

```
$ machin encode framework/machweb.src app.src
-> error: open framework/machweb.src: no such file or directory
```

`curl|sh` ships **only the binary** (+ skills). The framework modules (`machweb.src`, the DB drivers, `sso`/`ws`/`smtp`/…) — the entire web/backend story — live only in the repo. So **no newcomer can follow the quickstart at all.** The first "loop validated ✅" was a false positive: that agent only succeeded by copying `machweb.src` from a local machin project — the exact crutch the clean room removed.

## The fix

`//go:embed framework/*.src` into the binary, and `machin encode` resolves `framework/<name>.src` from the embed when the local file is absent. So `machin encode framework/machweb.src app.src` **just works on a bare install** — zero change to the quickstart, the skills, or any app. A local copy still wins (vendoring respected). Plus `machin framework list | <name> | --vendor [dir]` for explicit access.

## Re-validated (clean room, end-to-end)

Bare `debian:stable-slim`, only the machin binary copied in, **0 framework files on disk**:

```
$ machin encode framework/machweb.src app.src > app.mfl   -> OK (resolved from the embed)
$ CC=./muslcc machin build --static app.mfl -o app        -> 1.25 MB, statically linked
$ ./app + curl                                             -> POST/LIST work, SQLite-backed
```

The quickstart now works for a real stranger. Regression tests added (embedded resolution, local-wins, module set). Full `go test .` green, `go vet ./...` clean. Unreleased (a 0.82.0 candidate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)