### PR TITLE
release: v0.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.82.0
+
 - **The framework modules now ship in the binary.** `machweb.src`, the DB drivers,
   `sso`/`ws`/`smtp`/`reactive`/`router`/`flags`/`bson` — the MFL libraries an app
   composes against — are `//go:embed`'d, and `machin encode` resolves

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.81.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.82.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.81.0"
+const machinVersion = "0.82.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Cuts **v0.82.0**. Bumps `machinVersion` + the README badge and rolls the CHANGELOG `Unreleased` into `v0.82.0`.

## Highlight
- **Framework modules ship in the binary** (#270) — `machin encode framework/machweb.src app.src` works on a bare `curl|sh` install, fixing the quickstart for newcomers (caught by clean-room re-validation). Adds `machin framework list|<name>|--vendor`.

This is the release that makes the quickstart actually followable by someone who isn't already in the repo — important to ship promptly, since the released v0.81.0 still has the broken first command.

After merge I'll tag `v0.82.0` → CI builds + attaches the multi-platform binaries + SHA256SUMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Framework modules are now bundled with the shipped binary for more reliable access.
  * `machin encode` can fall back to embedded framework sources when a local copy isn’t available, while still preferring local files when present.
  * Added a new way to list and access vendor frameworks directly from the CLI.

* **Documentation / Chores**
  * Updated version references to **v0.82.0** across release notes and project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->