### PR TITLE
landing: rebuild around the current pitch + benchmarks + demo GIF + analytics

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,11 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>MFL — the Machine-First Language</title>
-<meta name="description" content="A backend language shaped for machines: minimal syntax, no type annotations, one canonical function per line. Statically typed by inference, compiled to native code.">
+<title>machin (MFL) — a language optimized for the AI agent writing it</title>
+<meta name="description" content="A language that treats token cost as a design constraint: as terse as Python to write, compiled through C to a tiny static native binary. Write it like a script, ship it like C.">
+<meta property="og:title" content="machin (MFL) — write it like a script, ship it like C">
+<meta property="og:description" content="As terse as Python to write, native-tier fast, ships in a 92.9 kB FROM-scratch image. Measured against Go, Python, Rust, Zig, Node.">
+<meta property="og:image" content="https://raw.githubusercontent.com/javimosch/machin/main/docs/machin-demo.gif">
 <style>
   :root{
     --bg:#0a0c10; --panel:#12161d; --border:#222932; --fg:#e6edf3;
@@ -17,115 +20,116 @@
   a{color:var(--accent2);text-decoration:none} a:hover{text-decoration:underline}
   code,pre,.b64{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
   .wrap{max-width:860px;margin:0 auto;padding:0 20px}
-  header{padding:76px 0 30px;text-align:center}
+  header{padding:72px 0 24px;text-align:center}
   .badge{display:inline-block;font-size:12px;color:var(--accent);
     border:1px solid var(--border);border-radius:999px;padding:3px 12px;margin-bottom:20px}
   h1{font-size:clamp(40px,7vw,66px);margin:0;letter-spacing:-1.5px}
   .tag{color:var(--muted);font-size:20px;margin:14px 0 10px}
-  .tag b{color:var(--fg)}
+  .tag b{color:var(--fg)} .tag i{color:var(--accent);font-style:normal}
   .cta{margin-top:24px}
   .cta a{display:inline-block;margin:0 5px 8px;padding:10px 18px;border-radius:8px;
     border:1px solid var(--border);font-weight:600}
   .cta a.primary{background:var(--accent);color:#04150e;border-color:var(--accent)}
+  .demo{margin:8px auto 0;max-width:760px}
+  .demo img{width:100%;border:1px solid var(--border);border-radius:10px;display:block}
+  .demo .cap{font-size:12px;color:var(--muted);margin:8px 2px 0;text-align:center}
   section{padding:34px 0;border-top:1px solid var(--border)}
   h2{font-size:24px;letter-spacing:-.4px;margin:0 0 10px}
   p.lead{color:var(--muted);margin-top:0}
-  .b64{display:block;background:var(--code);border:1px solid var(--border);border-radius:10px;
-    padding:16px 18px;font-size:13px;color:#7fdcb0;white-space:pre-wrap;word-break:break-all;line-height:1.7}
-  .b64 + .b64{margin-top:10px}
+  table{border-collapse:collapse;width:100%;font-size:14px;margin-top:6px}
+  td,th{border:1px solid var(--border);padding:8px 12px;text-align:left}
+  th{color:var(--muted);font-weight:600}
+  td.n,th.n{text-align:right} .win{color:var(--accent);font-weight:700}
   .cap{font-size:12px;color:var(--muted);margin:8px 2px 0}
-  pre{background:var(--code);border:1px solid var(--border);border-radius:10px;
-    padding:14px 16px;overflow:auto;font-size:13.5px;color:#cdd9e5}
-  .cm{color:#6b7785}
-  .pipe{display:flex;gap:10px;flex-wrap:wrap;align-items:center;color:var(--muted);font-size:14px;margin-top:6px}
-  .pipe span{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:8px 12px}
-  .pipe .arrow{background:none;border:none;padding:0;color:var(--accent)}
-  .grid{display:grid;gap:14px;grid-template-columns:repeat(2,1fr)}
+  .grid{display:grid;gap:14px;grid-template-columns:repeat(2,1fr);margin-top:6px}
   @media(max-width:680px){.grid{grid-template-columns:1fr}}
   .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:16px}
   .card h3{margin:0 0 6px;font-size:16px} .card p{margin:0;color:var(--muted);font-size:14px}
-  table{border-collapse:collapse;width:100%;font-size:14px}
-  td,th{border:1px solid var(--border);padding:8px 12px;text-align:left}
-  th{color:var(--muted);font-weight:600}
+  pre{background:var(--code);border:1px solid var(--border);border-radius:10px;
+    padding:14px 16px;overflow:auto;font-size:13.5px;color:#cdd9e5}
+  .cm{color:#6b7785}
   footer{padding:40px 0 70px;color:var(--muted);font-size:14px;text-align:center;border-top:1px solid var(--border)}
 </style>
 </head>
 <body>
 <header><div class="wrap">
-  <div class="badge">v0.7.0 · compiled to native code</div>
+  <div class="badge">v0.82.0 · as terse as Python, ships like C</div>
   <h1>machin ⎯ MFL</h1>
-  <p class="tag">A backend language <b>shaped for machines</b>.<br>Minimal syntax, no type annotations, one canonical function per line — built so agents write code in the fewest tokens.</p>
+  <p class="tag">A language <b>optimized for the AI agent writing it</b>, not the human reading it.<br>
+    As terse as Python to write, compiled through C to a tiny native binary. <i>Write it like a script, ship it like C.</i></p>
   <div class="cta">
     <a class="primary" href="https://github.com/javimosch/machin">GitHub</a>
+    <a href="#install">Install</a>
+    <a href="#bench">Benchmarks</a>
     <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Spec</a>
-    <a href="changelog.html">Changelog</a>
+  </div>
+  <div class="demo">
+    <img src="machin-demo.gif" alt="machin: a REST + SQLite service, compiled to a tiny native binary, running">
+    <p class="cap">A whole REST + SQLite service → a native binary → serving, in ~20 seconds.</p>
   </div>
 </div></header>
 
 <div class="wrap">
 
-<section>
-  <h2>This is a program</h2>
-  <p class="lead">A `.mfl` file is plain canonical text — one normalized function per line, a blank line between them. No annotations, no formatting choices, nothing an agent spends tokens on that it doesn't have to. The recursive Fibonacci below is complete and runs:</p>
-  <code class="b64">func fib(n){if n&lt;2{return n}return fib(n-1)+fib(n-2)}</code>
-  <code class="b64">func main(){println(fib(10))}</code>
-  <p class="cap">Each line is independently addressable — tooling ships, caches, or rewrites one function without touching the rest — and because it is text, it stays greppable and diffable. (A dense base64 form is available via <code>machin pack</code> for distribution.)</p>
-</section>
+<section id="bench">
+  <h2>Measured, not asserted</h2>
+  <p class="lead">The same programs, written idiomatically in each language — all runnable under <code>bench/</code> in the repo.</p>
 
-<section>
-  <h2>Machine-first by design, not by encoding</h2>
-  <p class="lead">Human languages carry ceremony — annotations, boilerplate, formatting rules — that an agent pays for in output tokens on every edit. MFL strips it: types are inferred, the layout is canonical, the surface is minimal. You state intent; agents write the code. Measured, this costs an agent ~2.5× fewer tokens to write and edit than the same logic in a base64-encoded form.</p>
-  <div class="pipe">
-    <span>intent</span><span class="arrow">→</span>
-    <span>.mfl (canonical text)</span><span class="arrow">→</span>
-    <span>infer + monomorphize</span><span class="arrow">→</span>
-    <span>C</span><span class="arrow">→</span>
-    <span>cc -O2</span><span class="arrow">→</span>
-    <span>native binary</span>
-  </div>
-</section>
-
-<section>
-  <h2>Native speed, zero annotations</h2>
-  <p class="lead">Types are inferred by unification; values compile unboxed. There is no interpreter and no runtime VM.</p>
+  <p class="lead" style="margin-bottom:4px"><b>1 · As cheap for an agent to write as Python.</b> Tokens to author the same REST+SQLite API (tiktoken o200k):</p>
   <table>
-    <tr><th>fib(40), ~331M calls</th><th>time</th></tr>
-    <tr><td><b>MFL</b> (native via cc -O2)</td><td><b>0.20s</b></td></tr>
-    <tr><td>hand-written C</td><td>0.19s</td></tr>
-    <tr><td>Rust (rustc -O)</td><td>0.29s</td></tr>
+    <tr><th>language</th><th class="n">author tokens</th><th>ships as</th></tr>
+    <tr><td><b>machin</b></td><td class="n win">388</td><td>44 KB native binary, 0 deps</td></tr>
+    <tr><td>Python</td><td class="n">383 (0.99×)</td><td>source + a CPython interpreter</td></tr>
+    <tr><td>Go</td><td class="n">527 (1.36×)</td><td>14.8 MB binary + a module dep</td></tr>
   </table>
+
+  <p class="lead" style="margin:18px 0 4px"><b>2 · Native-tier fast.</b> Four kernels, byte-identical output, each at its best release setting (min of 5):</p>
+  <table>
+    <tr><th>kernel</th><th class="n">machin</th><th class="n">Rust -O3</th><th class="n">Zig</th></tr>
+    <tr><td>fib(40)</td><td class="n win">245 ms</td><td class="n">303</td><td class="n">306</td></tr>
+    <tr><td>mandelbrot 1000²</td><td class="n">827</td><td class="n win">814</td><td class="n">819</td></tr>
+    <tr><td>sieve 10⁷</td><td class="n">203</td><td class="n">153</td><td class="n win">145</td></tr>
+    <tr><td>intsum 10⁹</td><td class="n win">2832 ms</td><td class="n">3764</td><td class="n">3556</td></tr>
+  </table>
+  <p class="cap">It's C underneath — wins scalar recursion + integer loops, ties float, trails ~1.4× on array-heavy code. In the same tier as Rust/Zig; not "faster than Rust".</p>
+
+  <p class="lead" style="margin:18px 0 4px"><b>3 · Ships like nothing in the scripting world.</b> Same HTTP server, deployed:</p>
+  <table>
+    <tr><th>same server</th><th class="n">image</th><th class="n">cold start</th><th class="n">idle RAM</th></tr>
+    <tr><td><b>machin</b> (static, FROM scratch)</td><td class="n win">92.9 kB</td><td class="n win">0.49 ms</td><td class="n win">108 kB</td></tr>
+    <tr><td>Python (py + alpine)</td><td class="n">47.6 MB · 512×</td><td class="n">49 ms · 100×</td><td class="n">17.9 MB · 166×</td></tr>
+    <tr><td>Node (js + alpine)</td><td class="n">178 MB · 1916×</td><td class="n">29 ms · 59×</td><td class="n">51 MB · 477×</td></tr>
+  </table>
+  <p class="cap">A 92.9 kB image, ready in half a millisecond, on ~0.1 MB of RAM. <code>scp</code> one file to a $4 VPS.</p>
+</section>
+
+<section id="install">
+  <h2>Try it (~60 seconds)</h2>
+<pre>curl -fsSL https://raw.githubusercontent.com/javimosch/machin/main/install.sh | sh
+machin guide                                <span class="cm"># the whole language, version-exact, as JSON</span>
+
+<span class="cm"># write app.src (a REST+SQLite service), then:</span>
+machin encode framework/machweb.src app.src &gt; app.mfl   <span class="cm"># framework ships in the binary</span>
+machin build --static app.mfl -o app                    <span class="cm"># static (musl) → FROM scratch</span>
+./app</pre>
+  <p class="cap">Building programs needs a C compiler. <code>machin build &lt;file&gt; --emit-c</code> prints the C the compiler generated.</p>
 </section>
 
 <section>
-  <h2>The whole Go-flavored core</h2>
-  <p class="lead">Everything below is expressed in this canonical form and compiled to native code.</p>
+  <h2>Batteries included — pure MFL, one binary</h2>
   <div class="grid">
-    <div class="card"><h3>Composite types</h3><p>slices, structs, maps — all unboxed.</p></div>
-    <div class="card"><h3>Concurrency</h3><p>goroutines, channels, and a per-goroutine arena that keeps servers memory-bounded.</p></div>
-    <div class="card"><h3>Closures &amp; generics</h3><p>capturing function values and implicit generics by monomorphization.</p></div>
-    <div class="card"><h3>Returns</h3><p>multiple, named, comma-ok, and variadic parameters.</p></div>
-    <div class="card"><h3>JSON over HTTP</h3><p>sockets, serialize and parse, string ops, routing.</p></div>
-    <div class="card"><h3>One binary</h3><p>a backend compiles to a single native executable, no runtime deps.</p></div>
+    <div class="card"><h3>HTTP + router</h3><p>machweb: a native server, JSON, cookies, signed sessions, SSO, SSE, WebSockets.</p></div>
+    <div class="card"><h3>Databases</h3><p>SQLite built in (bundled with <code>--static</code>); pure-MFL Postgres / MySQL / Redis / Mongo drivers, pooled.</p></div>
+    <div class="card"><h3>Concurrency</h3><p>goroutines, channels, <code>select</code>; a per-goroutine arena that keeps servers memory-bounded.</p></div>
+    <div class="card"><h3>Crypto</h3><p>SHA-256, HMAC, HKDF, Ed25519, X25519, AES-GCM — binary and text paths.</p></div>
+    <div class="card"><h3>Frontend &amp; games</h3><p>a reactive WebAssembly UI target; raylib GUI/audio/3D via C FFI.</p></div>
+    <div class="card"><h3>One artifact</h3><p>compiles to a single native binary — no Node, no interpreter, no runtime.</p></div>
   </div>
 </section>
 
 <section>
-  <h2>A concurrent HTTP server — one line</h2>
-  <p class="lead">This single line is the entry point of a goroutine-per-connection web server (listen, accept loop, dispatch):</p>
-  <code class="b64">func main() { server := listen(48080) for { conn := accept(server) go handle(conn) } }</code>
-  <p class="cap">The machweb framework — itself written in MFL — adds routing and JSON on top. You compose it with your app and compile:</p>
-<pre><span class="cm"># the machine composes the framework + your intent into one program</span>
-machin encode framework/machweb.src app.src &gt; app.mfl
-machin run app.mfl</pre>
-</section>
-
-<section>
-  <h2>Run it</h2>
-<pre>git clone https://github.com/javimosch/machin &amp;&amp; cd machin
-make build                                  <span class="cm"># → bin/machin (needs Go + a C compiler)</span>
-bin/machin run examples/demo.mfl
-bin/machin build examples/complex/primes.mfl -o primes &amp;&amp; ./primes</pre>
-  <p class="cap">Curious what a line says? <code>machin build &lt;file&gt; --emit-c</code> prints the C the machine generated — an inspection escape hatch, not a step you live in.</p>
+  <h2>Built with it</h2>
+  <p class="lead"><a href="https://github.com/javimosch/machin-hook">machin-hook</a> — a self-hosted webhook relay + live inspector (webhook.site + smee.io in one binary): capture any request, watch it land live over SSE, replay or forward it. ~330 lines of MFL. The curated list of tools is <a href="https://github.com/javimosch/awesome-machin">awesome-machin</a>.</p>
 </section>
 
 </div>
@@ -133,11 +137,19 @@ bin/machin build examples/complex/primes.mfl -o primes &amp;&amp; ./primes</pre>
 <footer><div class="wrap">
   <a href="https://github.com/javimosch/machin">Repository</a> ·
   <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Specification</a> ·
-  <a href="changelog.html">Changelog</a> ·
-  <a href="https://github.com/javimosch/machin/tree/main/framework">Framework</a> ·
+  <a href="https://github.com/javimosch/machin/tree/main/bench">Benchmarks</a> ·
   <a href="https://github.com/javimosch/awesome-machin">Awesome machin</a> ·
   <a href="https://github.com/javimosch/machin/releases">Releases</a>
   <p>MIT — <a href="https://www.linkedin.com/in/arancibiajav/">Javier Leandro Arancibia</a></p>
 </div></footer>
+
+<!-- analytics (SuperInsights) -->
+<script src="https://superinsights.coolify.intrane.fr/sdk/superinsights.js"></script>
+<script>
+  if (window.SuperInsights) {
+    SuperInsights.init('pk_e06fb3e1202550226bebdac1fdcfceb82319f2cc4a443f83dd0f9fe0ded3c00a',
+      { apiUrl: 'https://superinsights.coolify.intrane.fr' });
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
The GitHub Pages landing (`docs/index.html`) was badly stale — v0.7.0 badge, the old "shaped for machines / 2.5× base64" framing, and only the ancient fib table. Rebuilt to match the README + the dev.to launch:

- **Leads with the demo GIF** (same asset as the README/launch).
- **The three measured benchmark tables** — agent write-cost (ties Python), native speed (vs Rust -O3 / Zig), ship size (1916× smaller than Node) — with the honest "trails ~1.4× on array-heavy" caption.
- **The working `curl|sh` quickstart** (incl. `--static` → FROM scratch) and a batteries-included + built-with (machin-hook) section.
- **SuperInsights pageview analytics** — a dedicated `machin-landing` project, browser-public ingestion key, verified ingesting end-to-end.

⚠️ **One thing to confirm before merge:** the analytics snippet points at `superinsights.coolify.intrane.fr` — see PR discussion / the agent's note about keeping `intrane` out of public repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revamped the homepage with a new introduction, updated navigation, and clearer highlights of what the project offers.
  * Added a benchmarks section showing performance, token-cost, and deployment comparisons.
  * Added a quick-start section with simplified install and usage guidance.
  * Added new feature cards showcasing bundled capabilities and real-world usage.

* **Bug Fixes**
  * Reworked the page structure and styling for a cleaner, more consistent browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->