### PR TITLE
wasm: unbuffer stdout/stderr so reactor output isn't lost

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -2516,6 +2516,13 @@ func (g *cgen) program(p *Program) (string, error) {
 		out.WriteString(ctor.String())
 		out.WriteString("}\n")
 	}
+	// wasm reactor has no exit() to flush stdio, so buffered output is lost when an
+	// exported function returns. Make stdout/stderr unbuffered at _initialize so every
+	// println is written through immediately (e.g. for the browser playground). Native
+	// keeps normal buffering — exit() flushes it.
+	if g.wasm() {
+		out.WriteString("__attribute__((constructor)) static void mfl_wasm_stdio_init(void) { setvbuf(stdout, NULL, _IONBF, 0); setvbuf(stderr, NULL, _IONBF, 0); }\n")
+	}
 	// Native entry point. The wasm target is a reactor module (no `int main`): the
 	// host drives it through the exported functions, so emit the C main only for
 	// native, and only when the program actually defines an MFL main.


### PR DESCRIPTION
A `wasm32-wasi` **reactor** module has no `exit()` to flush stdio, so buffered output written by an exported function was lost when it returned — a 3-`println` program emitted only **one** `fd_write` (just the first line).

Fix: emit a `__attribute__((constructor))` (runs at `_initialize`) that sets `stdout`/`stderr` unbuffered for the wasm target. Native keeps normal buffering (`exit()` flushes it). After the fix the same program emits all three lines.

Surfaced while de-risking the **browser playground** (MFL → wasm → run in-browser via a hand-rolled WASI shim) — the playground is already driving fixes into the wasm target. Guide/wasm tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)