### PR TITLE
Link the browser playground (play.intrane.fr) from README + landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A language **shaped for AI agents to write and edit cheaply**: zero type annotat
 
 [Spec](SPEC.md) · [Language tour](docs/LANGUAGE.md) · [Agent guide](AGENTS.md) · [Ecosystem → **awesome-machin**](https://github.com/javimosch/awesome-machin) · [Landing](https://javimosch.github.io/machin/) · [Releases](https://github.com/javimosch/machin/releases)
 
+> ### ▶ [Try machin in your browser → **play.intrane.fr**](https://play.intrane.fr)
+> Write MFL, hit Run — it compiles to WebAssembly and runs client-side. No install.
+
 <p align="center">
   <img src="docs/machin-demo.gif" alt="machin: write a REST+SQLite service, compile to a tiny native binary, run it" width="760">
 </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,7 +58,8 @@
   <p class="tag">A language <b>optimized for the AI agent writing it</b>, not the human reading it.<br>
     As terse as Python to write, compiled through C to a tiny native binary. <i>Write it like a script, ship it like C.</i></p>
   <div class="cta">
-    <a class="primary" href="https://github.com/javimosch/machin">GitHub</a>
+    <a class="primary" href="https://play.intrane.fr">▶ Try in your browser</a>
+    <a href="https://github.com/javimosch/machin">GitHub</a>
     <a href="#install">Install</a>
     <a href="#bench">Benchmarks</a>
     <a href="https://github.com/javimosch/machin/blob/main/SPEC.md">Spec</a>


### PR DESCRIPTION
The [playground](https://play.intrane.fr) is live but was linked nowhere. Adds a **▶ Try in your browser** CTA to the top of the README and as the primary button on the landing page — the two highest-traffic surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser-based playground link at the top of the README and docs, making it easier to try the tool without installing anything.
  * Updated the “Try in your browser” call-to-action so the primary button opens the online playground, with GitHub now available as a secondary option.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->