### PR TITLE
plugin: publish a Claude Code marketplace for the machin agent skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://code.claude.com/schemas/marketplace.json",
+  "name": "machin",
+  "owner": {
+    "name": "Javier Leandro Arancibia"
+  },
+  "description": "machin (MFL) — agent skills for building small, deployable native binaries: when to reach for machin, plus web / backend / gamedev / deploy how-tos.",
+  "version": "0.82.0",
+  "plugins": [
+    {
+      "name": "machin",
+      "source": "./plugins/machin",
+      "description": "Decide when to use machin and how to build with it — bundles the machin-start decision skill plus the web, backend, gamedev, and deploy how-tos. A language an AI agent writes as cheaply as Python that compiles to a tiny native binary.",
+      "version": "0.82.0",
+      "author": { "name": "Javier Leandro Arancibia" }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Claude Code plugin marketplace.** The repo is now a Claude Code marketplace
+  (`.claude-plugin/marketplace.json`) shipping a `machin` plugin that bundles the 5
+  agent skills (machin-start + web/backend/gamedev/deploy). Install in any project:
+  `/plugin marketplace add javimosch/machin` then `/plugin install machin@machin` — so
+  an agent reaches for machin at the decision moment *everywhere*, not just where
+  `machin skill install` was run. Bundled skills are kept identical to the canonical
+  `skills/` (the embedded source of truth) by `tools/sync-plugin-skills.sh`, guarded by
+  a test; manifest validated with `claude plugin validate`.
+
 ## v0.82.0
 
 - **The framework modules now ship in the binary.** `machweb.src`, the DB drivers,

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ machin compiles MFL through C, so building programs needs a **C compiler** (`cc`
 `--target wasm` web target additionally needs [`zig`](https://ziglang.org). Building
 web apps? See the [`machin-web` skill](skills/machin-web/SKILL.md).
 
+## Use it from Claude Code
+
+Install machin's agent skills as a [Claude Code plugin](https://code.claude.com/docs/en/plugins),
+so an AI agent reaches for machin at the right moment — in any project:
+
+```
+/plugin marketplace add javimosch/machin
+/plugin install machin@machin
+```
+
+You get **machin-start** (when to reach for machin, and a zero→running→shipped
+quickstart, with the measured benchmarks as decision criteria) plus the web / backend
+/ gamedev / deploy how-tos — they auto-activate by intent. For any other agent runtime,
+`machin skill install` writes the same skills to a vendor-neutral `~/.agents/skills`.
+
 ## Use
 
 ```bash

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The Claude Code plugin (plugins/machin/skills/) bundles copies of the canonical
+// skills/ (which are also embedded in the binary). Keep them byte-identical so the
+// plugin never ships stale guidance — run tools/sync-plugin-skills.sh after edits.
+func TestPluginSkillsInSync(t *testing.T) {
+	skills := []string{"machin-start", "machin-web", "machin-backend", "machin-gamedev", "machin-deploy"}
+	for _, s := range skills {
+		canon, err := os.ReadFile(filepath.Join("skills", s, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("canonical skill %s: %v", s, err)
+		}
+		bundled, err := os.ReadFile(filepath.Join("plugins", "machin", "skills", s, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("plugin skill %s missing — run tools/sync-plugin-skills.sh: %v", s, err)
+		}
+		if !bytes.Equal(canon, bundled) {
+			t.Errorf("plugin skill %s is out of sync with skills/%s — run tools/sync-plugin-skills.sh", s, s)
+		}
+	}
+}

--- a/plugins/machin/.claude-plugin/plugin.json
+++ b/plugins/machin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "machin",
+  "description": "machin (MFL) agent skills — a language an AI agent writes as cheaply as Python that compiles through C to a tiny native binary. Bundles the machin-start decision skill (when to reach for machin, and a zero→running→shipped quickstart) plus the web, backend, gamedev, and deploy how-tos. The skills auto-activate by intent; pairs with `machin guide` (the in-binary, version-exact catalog).",
+  "version": "0.82.0",
+  "author": { "name": "Javier Leandro Arancibia" },
+  "homepage": "https://github.com/javimosch/machin",
+  "repository": "https://github.com/javimosch/machin",
+  "license": "MIT",
+  "keywords": ["machin", "mfl", "native", "wasm", "backend", "web", "gamedev", "agent", "single-binary"]
+}

--- a/plugins/machin/skills/machin-backend/SKILL.md
+++ b/plugins/machin/skills/machin-backend/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: machin-backend
+description: Build a single-binary backend service in machin (MFL) — HTTP/JSON APIs, five pooled datastores (SQLite, PostgreSQL, MySQL/MariaDB, Redis, MongoDB), signed sessions, OAuth2/OIDC SSO, and agent-first CLIs — all pure MFL, one static binary, no Node/ORM/cgo. Use when writing or debugging a machin backend: a REST/JSON service, a database client or migration, an auth flow, a daemon, or a headless-CMS-style tool. Covers the machweb/postgres/mysql/redis/mongo/bson/sso frameworks, the uniform JSON-rows + parse() pattern, connection pooling for concurrency, the agent-first CLI contract, and the hard-won gotchas. Distilled from the backend dogfood (machin v0.60–v0.74) and the MachNotes / machin-db-migrate / machin-cms apps.
+---
+
+# Building backends in machin
+
+machin compiles MFL to one **static native binary** — an HTTP server, a database client,
+auth, and a CLI in the same program, no Node, no ORM, no cgo, no client libraries. The
+datastore drivers are **pure MFL** over `dial()` + the crypto builtins.
+
+> Run `machin guide` first (the version-exact language catalog). For the web/UI side —
+> SSR, the reactive wasm UI, the router — read `machin guide --skill web`. This skill is
+> the *server / data / auth* how-to.
+
+## The HTTP server — `framework/machweb.src`
+
+A handler is `func(Request) Response`; `serve(port, handler)` runs it, **one goroutine
+per connection** (so shared state must be pooled — see below). `req.method` / `req.path`
+(carries the query string) / `req.body` / `header(req,name)` / `cookie(req,name)` /
+`query(req,name)`. Builders: `ok_text` `ok_html` `ok_json` `ok_bytes(ctype,b)` `ok_wasm` ·
+`created` `bad_request` `not_found` · `redirect(url)`. A map router: `new_router()`,
+`route(r,"GET","/x",h)`, `serve_router(port,r)`.
+
+```go
+func handle(req) (res) {
+    if has_prefix(req.path, "/api/users") { return ok_json(users_json()) }
+    res = not_found()
+}
+func main() { serve(8080, func(req) { return handle(req) }) }
+```
+
+## Datastores — one uniform shape
+
+**Every driver returns rows as a JSON-array-of-rows STRING, so `parse(rows, []T{})`
+decodes them into a typed slice** (numeric/bool columns come back unquoted). That single
+idiom works across all five. `json_get(rows, "[0].field")` pulls one value (but returns
+the *raw* token — a string stays quoted; prefer `parse`).
+
+| Store | Connect | Query / exec |
+|---|---|---|
+| **SQLite** (embedded) | `db := sqlite_open(path)` / `:memory:` | `sqlite_query(db, sql[, []string params])` → JSON · `sqlite_exec(db, sql[, params])` (`?`-bind) · `sqlite_close` |
+| **PostgreSQL** (`postgres.src`) | `pg_connect(host,port,user,db,pass)` + SCRAM | `pg_query(sql)` (trusted) · `pg_exec(sql, []string params)` (`$1`, extended protocol, injection-safe) · `pg_disconnect` |
+| **MySQL/MariaDB** (`mysql.src`) | `mysql_connect(host,port,user,pass,db)` (native_password) | `mysql_query(sql)` → JSON · `mysql_exec(sql)` → affected · `mysql_escape(s)` · `mysql_close` |
+| **Redis** (`redis.src`) | `redis_connect(host,port)` [+ `redis_auth(pw)`] | `redis_set/setex(k,secs,v)/get(k)->(v,ok)/del/incr/expire/rpush/lpush/lrange/keys` · `redis_cmd([]string)` |
+| **MongoDB** (`mongo.src`+`bson.src`) | `mongo_connect(host,port)` [+ `mongo_auth("admin",user,pw)`] | `mongo_insert_one(db,coll,doc)` · `mongo_find_all/find(db,coll[,filter])` · `mongo_find_by_id` · `mongo_count/drop/delete` · `mongo_close` |
+
+```go
+type User struct { id int  name string  email string }
+pg_connect("127.0.0.1", 5432, "postgres", "app", "secret")
+rows  := pg_exec("SELECT id, name, email FROM users WHERE active = $1", []string{"1"})
+users := parse(rows, []User{})          // typed slice, values decoded
+```
+
+**Mongo documents are BSON** — build with the `bson.src` builder, decode replies via the
+driver (which renders to JSON): `bson_new()` then `bson_str`/`bson_i32`/`bson_i64`/
+`bson_double`/`bson_bool`/`bson_null`/`bson_oid(key,hex)`/`bson_subdoc`/`bson_subarr`,
+finalize with `bson_finish`. `_id` ObjectIds decode to a hex string; query by it with
+`mongo_find_by_id`. SCRAM-SHA-256 auth, doubles, and cursor pagination (`getMore`) are all
+handled.
+
+## Connection pooling (a concurrent server)
+
+machweb runs each request in its own goroutine, so a **shared single connection would
+interleave**. Every networked driver is **handle-based + poolable** — the pool is an
+async channel of authenticated connections (a semaphore, built on machin's unbounded
+channels; no new primitive needed):
+
+```go
+pg_pool_init(8, "127.0.0.1", 5432, "postgres", "app", "secret")   // once, in main
+func handle(req) (res) {
+    c := pg_acquire()                       // per request -> its own connection
+    rows := pgx(c, "SELECT ... WHERE id = $1", []string{id})
+    pg_release(c)
+    res = ok_json(rows)
+}
+```
+
+Handle ops per driver (the global `*_connect`/`*_query` API stays for single-connection
+scripts): Postgres `pg_acquire`/`pgq`/`pgx`/`pg_release`; MySQL `mysql_acquire`/`myq`/
+`myx`/`mysql_release`; Redis `redis_acquire`/`rset`/`rget`/…/`redis_release`; Mongo
+`mongo_acquire`/`mins`/`mfind`/`mfindall`/`mfindid`/`mdel`/`mcount`/`mdrop`/`mongo_release`.
+SQLite "pools" as several `sqlite_open` handles (use WAL + `PRAGMA busy_timeout`).
+
+## Auth — sessions + SSO (`framework/machweb.src`, `sso.src`)
+
+- **Signed sessions** (a cookie the client can't forge): `set_session(res, secret, "sid",
+  userID)` stores `userID` + an HMAC-SHA256 tag; `get_session(req, secret, "sid") ->
+  (value, ok)` returns `ok==1` only if it verifies. `cookie(req,name)`, `set_cookie` /
+  `clear_cookie` (safe defaults `Path=/; HttpOnly; SameSite=Lax`). Keep `secret`
+  server-side (`env`); the value is signed, not encrypted — store an id, not secrets.
+- **SSO ("log in with Google/Microsoft/…")**: fill `OAuthProvider{auth_url, token_url,
+  userinfo_url, client_id, client_secret, redirect_uri, scope}`; route `GET /login` →
+  `sso_begin(p, secret)` (302 + signed CSRF state), `GET /callback` → `profile, ok :=
+  sso_complete(p, secret, req)` (verify state, exchange code, fetch userinfo). Identity
+  comes from the userinfo endpoint, so no JWT/RSA is needed. Then `set_session(...)`.
+- A common pattern is **sessions in Redis** (`rsetex("sess:"+sid, 3600, email)`) keyed by
+  a signed cookie — see the MachNotes app.
+
+## Sending email (`framework/smtp.src`)
+
+`smtp_send(host, port, from, to, subject, body, user, pass) -> (ok, errmsg)` sends a
+message over plaintext SMTP + `AUTH LOGIN` (`user=""` skips auth) — transactional email
+(password resets, receipts, alerts) with no library. The receiving side is here too:
+`smtp_recv(conn)` plays the server for one session, so you can build a catcher. Test with
+**zero external deps** against [machin-mail](https://github.com/javimosch/machin-mail)'s
+`sink` (a local SMTP catcher + web inbox). STARTTLS/implicit TLS isn't here yet — point it
+at a relay that accepts plaintext submission, or a local catcher.
+
+## Crypto you'll reach for
+
+`sha256` / `hmac_sha256` (hex), `sha256_bytes` / `hmac_sha256_bytes` / `sha1_bytes`
+(binary), `rand_bytes(n)`, `base64_encode/decode` + `_bytes` variants, `hkdf_sha256`,
+`aes_gcm_encrypt/decrypt`, `ed25519_*` / `x25519_*`. `to_hex(rand_bytes(16))` is the
+idiomatic token/id.
+
+## CLIs — be agent-first
+
+A backend tool is consumed by agents. Follow the contract (see
+[`AGENTS_FRIENDLY_TOOLS.md`] in your project, and the machin-cms app):
+- **stdout = the answer as JSON** (`{"ok":true,"data":...}`); **stderr = structured
+  errors** (`write(2, json+"\n")` — fd 2 is stderr) so logs never pollute the data stream.
+- **Semantic exit codes**: `0` ok · `80–89` input/validation · `90–99` resource
+  (not found / exists) · `100–109` integration (db/auth down) · `110–119` internal.
+  `exit(code)`.
+- **Non-interactive**, deterministic, composable subcommands; a `help-json` for
+  introspection. Parse args from `args()` (`args()[0]` is the program path).
+
+## Daemons (start/stop without PIDs)
+
+`system(cmd) -> int` runs a shell command (`-1` if unlaunchable). `daemon start` spawns a
+detached server and returns: `system(args()[0] + " serve " + port + " >log 2>&1 &")`;
+`stop` POSTs an internal `/_shutdown` route (the handler calls `exit(0)`); `status` probes
+`/_health`. No pidfiles or signals — see machin-cms.
+
+## Build & verify
+
+- Compose vendored frameworks + your app, then build: `machin encode framework/machweb.src
+  framework/postgres.src app.src > app.mfl && machin build app.mfl -o app`. The drivers
+  link only what they use (`-lsqlite3` for SQLite, OpenSSL for crypto/SCRAM, `-lm`, …).
+- **`machin encode` runs the typechecker** — most errors surface there (no `cc` needed).
+- **Verify against a real server** in a container (`docker run -d -p 5432:5432 postgres:16`,
+  `redis:7`, `mongo:7`, `mariadb:11`) and drive your binary with `curl`. The machin repo's
+  gated tests (`MACHIN_PG_TEST=1`, `MACHIN_MYSQL_TEST=1`, `MACHIN_MONGO_TEST=1`, …) show the
+  pattern; pool concurrency is proven with N goroutines over K connections.
+
+## Gotchas (hard-won)
+
+- **Pool, don't share.** A single global connection in a concurrent server corrupts reads.
+  Use the pool + acquire/release per request, releasing on **every** return path.
+- **Wire reads are NUL-binary** — the drivers use `read_bytes` (not `read`, which is a
+  C string and truncates at a NUL) and binary-safe `base64_*_bytes` (for SCRAM).
+- **`json_get` returns the raw token** — a string field comes back quoted (`"Ada"`).
+  Prefer `parse(rows, []T{})`; strip quotes only when pulling one field.
+- **Parameterize** (`?` / `$1` / Mongo filter docs) for user input; `mysql_escape` for the
+  text protocol. Never string-concat user input into SQL.
+- **A function named like a builtin is a compile error** (`len`/`str`/`keys`/…); and two
+  structurally-identical structs (e.g. two `{fd int  buf []bytes}` driver handles) can
+  confuse the checker — give the same-scope variable holding each a distinct name.
+
+## Worked apps + direction
+
+- **[machin-saas-demo](https://github.com/javimosch/machin-saas-demo)** (MachNotes) — SSO →
+  Redis sessions → pooled Postgres → reactive wasm UI, one binary.
+- **[machin-cms](https://github.com/javimosch/machin-cms)** — an agent-first, db-agnostic
+  headless CMS (schemas, RBAC, a REST API daemon over SQLite/MySQL/Mongo, all pooled).
+- **[machin-db-migrate](https://github.com/javimosch/machin-db-migrate)** — SQLite ⇄ MongoDB,
+  both directions.
+- Direction + capability/gap matrix: [`docs/NORTH-STAR-BACKEND.md`](../../docs/NORTH-STAR-BACKEND.md).

--- a/plugins/machin/skills/machin-deploy/SKILL.md
+++ b/plugins/machin/skills/machin-deploy/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: machin-deploy
+description: Ship a machin (MFL) web app to production — run it correctly and safely behind a reverse proxy (nginx / Caddy / Traefik / Cloudflare), with the machweb hardening + proxy-awareness knobs, a systemd unit, and a slim Docker image. Use when deploying or operationalizing a machin HTTP service: getting HTTPS via a proxy, fixing http→https redirects/cookies behind TLS termination, the real client IP, request size/time limits, access logs, and the run/restart story. Distilled from the deploy dogfood (machin v0.78) and the machin-deploy reference app.
+---
+
+# Deploying a machin web app
+
+A machin web service is **one static-ish native binary** (it links libc, OpenSSL, and
+maybe libsqlite3 — not fully static, but no runtime/interpreter). The standard production
+shape is that binary **behind a reverse proxy** that terminates TLS — nginx, Caddy,
+Traefik, or Cloudflare. You do **not** need machin to speak TLS itself; the proxy does
+HTTPS and forwards plain HTTP to your app. This skill is about making the app *correct and
+safe* in that setup.
+
+> Build the app with the [`machin-web`](web) / [`machin-backend`](backend) skills; this is
+> the *operate it in production* how-to.
+
+## Turn on the production knobs (in `main`)
+
+All default **off**, so dev is unchanged. Enable what you need before `serve`:
+
+```go
+func main() {
+    harden(20 * 1024 * 1024, 15000)   // body cap 20 MB, 15 s read timeout, +trust-proxy,
+                                       // +Secure cookies, +access log — the common set
+    serve(8080, func(req) { return handle(req) })
+}
+```
+
+`harden(max_body_bytes, read_timeout_ms)` is shorthand; the individual switches are:
+
+| Call | Effect |
+|---|---|
+| `set_trust_proxy(1)` | trust `X-Forwarded-Proto` / `X-Forwarded-For` (**only** behind a proxy you control) |
+| `set_secure_cookies(1)` | add `; Secure` to every cookie (you're served over HTTPS) |
+| `set_max_body(n)` | reject a request body larger than `n` bytes with `413` — *without buffering it* |
+| `set_read_timeout(ms)` | cap a slow client's request read (anti **slow-loris**) |
+| `set_access_log(1)` | one JSON access-log line per request on **stderr** (fd 2) |
+
+## Be proxy-correct
+
+Behind a TLS-terminating proxy the socket is plain HTTP, so without help your app thinks
+every request is `http://` and sees the *proxy's* IP. With `set_trust_proxy(1)`:
+
+- **`scheme(req)`** → `http`/`https` from `X-Forwarded-Proto`. Use it so redirects, OAuth
+  `redirect_uri`s, and emailed links are `https`, not `http`.
+- **`base_url(req)`** → `scheme://host` — build absolute URLs that survive the proxy.
+- **`client_ip(req)`** → the real client (left-most `X-Forwarded-For` hop), for logging /
+  rate-limiting / audit. `req.remote` is the raw socket peer (the proxy) if you need it.
+- **`set_secure_cookies(1)`** → sessions get `Secure` so they're never sent in clear.
+
+**Only trust these headers behind a proxy that sets them** — a client can forge
+`X-Forwarded-*`. If the app is ever directly exposed, leave `set_trust_proxy(0)`.
+
+## Reverse proxy snippets
+
+**nginx** — forward the headers machweb reads, and don't buffer SSE:
+```nginx
+location / {
+    proxy_pass         http://127.0.0.1:8080;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_buffering    off;          # let Server-Sent Events stream (machweb also sends X-Accel-Buffering: no)
+}
+```
+**Caddy** — TLS + the forwarded headers are automatic:
+```
+app.example.com {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+## Run it: systemd
+
+A single binary is a trivial unit. `Type=simple`, run as a non-root user, restart on
+failure, and rely on `set_access_log(1)` → journald:
+```ini
+[Unit]
+Description=machin app
+After=network.target
+
+[Service]
+ExecStart=/opt/app/server
+Environment=PORT=8080 APP_SECRET=change-me
+User=app
+Restart=on-failure
+RestartSec=2
+# SIGTERM stops it; in-flight requests are short-lived goroutines.
+
+[Install]
+WantedBy=multi-user.target
+```
+`listen` sets `SO_REUSEADDR`, so a restart rebinds immediately (no `TIME_WAIT` wait).
+
+## Run it: Docker
+
+By default the binary needs libc + OpenSSL (`libssl`/`libcrypto`, for sessions/crypto) and
+`libsqlite3` (if you use SQLite) at runtime, so ship it on a **slim base**:
+```dockerfile
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libssl3 libsqlite3-0 ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY server /usr/local/bin/server
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/server"]
+```
+(Multi-stage: build with `machin build` in a builder stage, copy just the binary.)
+
+**`FROM scratch` for a SQLite-only service:** `machin build --static` compiles the SQLite
+amalgamation in (no `libsqlite3`); with `CC=musl-gcc` you get a libc-free ~1 MB binary that
+runs from an empty image — `FROM scratch / COPY server / ENTRYPOINT`. This works when the
+program uses **no OpenSSL** — i.e. no HTTPS client (`https_*`) and no crypto builtins
+(`hmac_sha256`/`sha256`/`rand_bytes`/…, which signed sessions use). Those still link OpenSSL
+(so the slim base above) until native TLS lands (issue #260).
+
+## Gotchas
+
+- **Trust the proxy, not the client.** `set_trust_proxy(1)` only behind a proxy that
+  *overwrites* `X-Forwarded-*`. Directly exposed → keep it off, or a client spoofs its IP.
+- **`set_secure_cookies(1)` requires HTTPS.** On a Secure cookie set over plain `http://`
+  the browser drops it — turn it on only once TLS (via the proxy) is in front.
+- **Access logs go to stderr** so stdout stays a clean data/JSON stream; capture fd 2 in
+  journald/Docker.
+- **Body cap is on the declared `Content-Length`** — an over-cap request is `413`'d before
+  its body is read (no OOM, no draining megabytes).
+- **Graceful shutdown is SIGTERM = exit.** Each request is its own short-lived goroutine,
+  so kill is safe in practice; there's no long-drain coordinator yet.
+
+## Reference
+
+- **[machin-deploy](https://github.com/javimosch/machin-deploy)** — a production-ready
+  machin service wired with all of the above: proxy-correct, hardened, a systemd unit, a
+  slim Dockerfile, and nginx/Caddy configs. Clone it as a deploy template.

--- a/plugins/machin/skills/machin-gamedev/SKILL.md
+++ b/plugins/machin/skills/machin-gamedev/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: machin-gamedev
+description: Build native games and interactive desktop/terminal apps in machin (MFL) — the canonical setup, build-and-verify workflow, raylib C-FFI surface, audio, and the hard-won caveats/gotchas. Use when writing or debugging a machin game (terminal TUI or raylib GUI), or any machin program that draws a window, plays sound, or reads real-time input. Covers terminal TUI, raylib GUI/audio, 3D cameras, GPU meshes (pointer/array FFI), instancing, shaders, procedural worlds (noise), fixed-timestep sim loops, a pure-MFL math3d module (Vec3), verlet physics (position-based dynamics, constraint relaxation, collision), rlgl point-cloud rendering (RL_POINTS for particle systems and star fields), ballistic physics (gravity + quadratic drag + wind, trajectory prediction), and first-person player controllers (walking, jumping, platform stepping, object pushing, walk/fly toggle). Distilled from machin-game-demo-snake / -2048 / -flappy / -simon / -3d / -terrain / -planet / -cyberpunk / -solar / -physics / -galaxy / -ballistics / -player.
+---
+
+# Building games in machin
+
+machin (MFL) compiles to a native binary through C, and reaches real games two ways:
+
+- **Terminal (TUI):** ANSI escapes for drawing + `raw_mode`/`read_key` for input. A no-dependency single binary. → [machin-game-demo-snake](https://github.com/javimosch/machin-game-demo-snake) (Snake).
+- **GUI / audio:** [raylib](https://www.raylib.com/) through machin's C **FFI** — a real OpenGL window, textures, sound. Links the system graphics/audio stack, so **not** self-contained. → [machin-game-demo-2048](https://github.com/javimosch/machin-game-demo-2048) (shapes+text), [machin-game-demo-flappy](https://github.com/javimosch/machin-game-demo-flappy) (sprites/textures), [machin-game-demo-simon](https://github.com/javimosch/machin-game-demo-simon) (audio), [machin-game-demo-3d](https://github.com/javimosch/machin-game-demo-3d) (3D + per-object rotation), [machin-game-demo-anim](https://github.com/javimosch/machin-game-demo-anim) (2D procedural), [machin-game-demo-terrain](https://github.com/javimosch/machin-game-demo-terrain) (immediate-mode mesh), [machin-game-demo-planet](https://github.com/javimosch/machin-game-demo-planet) (GPU mesh / pointer FFI), [machin-game-demo-cyberpunk](https://github.com/javimosch/machin-game-demo-cyberpunk) (infinite noise world + fly camera), [machin-game-demo-solar](https://github.com/javimosch/machin-game-demo-solar) (solar-system sim, fixed-timestep, math3d module), [machin-game-demo-physics](https://github.com/javimosch/machin-game-demo-physics) (verlet physics sandbox, constraint relaxation, collision), [machin-game-demo-galaxy](https://github.com/javimosch/machin-game-demo-galaxy) (procedural spiral galaxy, rlgl point cloud), [machin-game-demo-ballistics](https://github.com/javimosch/machin-game-demo-ballistics) (interactive cannon sim, ballistic trajectory prediction, drag + wind), [machin-game-demo-player](https://github.com/javimosch/machin-game-demo-player) (first-person 3D playground, walk/fly toggle, platform stepping, object pushing).
+
+Where this domain is heading: [`docs/NORTH-STAR-GAMEDEV.md`](../../docs/NORTH-STAR-GAMEDEV.md) (tiers + the gap roadmap: pointer/array FFI for real GPU meshes, a vector/matrix layer, a noise builtin, shaders, callbacks).
+
+Each game is its own public repo with a `build.sh` (`machin encode src.src > app.mfl && machin build app.mfl -o app`), a `README.md`, a repo-root `SKILL.md`, and committed `assets/`. This skill is the shared substrate; each game's SKILL.md has its specifics.
+
+> Run `machin guide` for the version-exact language surface (builtins, idioms, gotchas). This skill is about *games* specifically.
+
+## Build & verify workflow (this environment)
+
+- **raylib, no root:** there's no system raylib and no passwordless sudo. The game `build.sh` auto-vendors raylib's prebuilt **static** release (`raylib-5.0_linux_amd64.tar.gz`) into `vendor/`, then injects `cflags "-I.../include -L.../lib"` + `link ":libraylib.a"` into a *throwaway* `.mfl` so the committed source stays system-style (`link "raylib"`). A copy is cached at `/tmp/rl/raylib-5.0_linux_amd64`. `build.sh` prefers a system raylib (`pkg-config --exists raylib`) when present.
+- **Display + audio are live:** `DISPLAY=:0`, PulseAudio works. Run a game backgrounded, `sleep`, then `kill` it.
+- **Screenshot to verify rendering:** `DISPLAY=:0 import -window root /tmp/shot.png` (ImageMagick). `scrot`/`maim`/`grim`/`xdotool` are NOT installed. It captures the whole root (1920×1080); the game window is inside it. Read the PNG back to confirm the frame.
+- **Can't inject keystrokes** (no xdotool). Verify *gameplay* with (a) a temporary **autopilot** build — `sed` the input line to a rule like `flap := bird_y > 320.0` and start in the playing state — screenshot mid-run; or (b) **headless logic tests** — factor the pure logic (slide/merge, collision) and run it with `machin run`, asserting output. Do the logic test first; it's faster and catches the type errors.
+- **Assets load by relative path** → run the binary from the repo root (`./app`, not from `/tmp`).
+- **`machin encode` runs the typechecker**, so most errors show at encode time (no `cc` needed). `machin build x.mfl --emit-c` prints the generated C when you need to see the FFI marshaling.
+
+## The raylib FFI surface
+
+One `extern "raylib" { … }` block is the entire C boundary; everything else is pure MFL. Template (declare only what you call):
+
+```
+extern "raylib" {
+    header "raylib.h"
+    link "raylib" link "GL" link "m" link "pthread" link "dl" link "rt" link "X11"
+    cstruct Color { r u8 g u8 b u8 a u8 }
+    cstruct Texture2D { id u32 width i32 height i32 mipmaps i32 format i32 }  // all-int handle
+    cstruct Rectangle { x f32 y f32 width f32 height f32 }                    // f32 fields
+    cstruct Vector2 { x f32 y f32 }
+    cstruct Sound {}                                                          // OPAQUE handle (v0.44.0)
+    fn InitWindow(i32, i32, string)   fn SetTargetFPS(i32)   fn WindowShouldClose() bool
+    fn BeginDrawing()   fn EndDrawing()   fn ClearBackground(Color)   fn CloseWindow()
+    fn DrawRectangle(i32, i32, i32, i32, Color)   fn DrawCircle(i32, i32, f32, Color)
+    fn DrawText(string, i32, i32, i32, Color)     fn MeasureText(string, i32) i32
+    fn LoadTexture(string) Texture2D              fn DrawTexture(Texture2D, i32, i32, Color)
+    fn DrawTextureRec(Texture2D, Rectangle, Vector2, Color)
+    fn DrawTexturePro(Texture2D, Rectangle, Rectangle, Vector2, f32, Color)
+    fn IsKeyPressed(i32) bool   fn IsMouseButtonPressed(i32) bool   fn GetMouseX() i32  fn GetMouseY() i32
+    fn InitAudioDevice()   fn LoadSound(string) Sound   fn PlaySound(Sound)   fn CloseAudioDevice()
+}
+```
+
+FFI tiers, all verified working:
+- **Scalars + by-value structs** (`Color`, and `f32`-field `Rectangle`/`Vector2`) passed by value.
+- **Struct return** — `LoadTexture` returns `Texture2D` (an all-int handle) by value.
+- **Opaque handles** (`cstruct Sound {}`, machin **v0.44.0**) — a by-value C struct that contains pointers (`Sound`/`Music`/`Font`). machin holds the real C struct and passes it back to fns without naming its fields. Receive it from a fn, store it (a var **or** `[]Sound`), pass it on; **no** construct or `.field`. (A single pointer is simpler: the `ptr` FFI type, an `int`.)
+- **Nested cstructs** (machin **v0.45.0**) — a `cstruct` field may be another `cstruct`, marshaled recursively. Declare the inner one **first**. Required for **3D** and 2D cameras: `cstruct Vector3 { x f32 y f32 z f32 }` then `cstruct Camera3D { position Vector3 target Vector3 up Vector3 fovy f32 projection i32 }`; construct with nested literals `Camera3D{Vector3{12.0,7.0,0.0}, Vector3{0.0,1.5,0.0}, Vector3{0.0,1.0,0.0}, 45.0, 0}` and pass by value to `BeginMode3D`.
+
+**3D** (see [machin-game-demo-3d](https://github.com/javimosch/machin-game-demo-3d)): bracket 3D draws with `BeginMode3D(cam)` / `EndMode3D()`; `DrawCube(Vector3, f32,f32,f32, Color)`, `DrawCubeWires`, `DrawSphere(Vector3, f32, Color)`, `DrawGrid(i32, f32)`; any `DrawText` after `EndMode3D` is screen-space. Rebuild the `Camera3D` each frame rather than mutating it. `projection` `0` = `CAMERA_PERSPECTIVE`.
+
+**Per-object transforms (rotation/scale).** `DrawCube`/`DrawSphere` only translate (axis-aligned). To rotate or scale an object, use raylib's immediate-mode matrix stack from **rlgl**: `rlPushMatrix` → `rlTranslatef(x,y,z)` → `rlRotatef(deg, ax,ay,az)` / `rlScalef(x,y,z)` → draw at the **local origin** → `rlPopMatrix`. Those functions live in `rlgl.h`, **not** `raylib.h` — but their symbols are in `libraylib.a`, so declare them in a **headerless extern block** (machin emits the prototypes itself; symbols link from the raylib block's libs). No new machin feature — the existing scalar/`void` FFI carries it:
+
+```
+extern "rlgl" { fn rlPushMatrix() fn rlPopMatrix() fn rlTranslatef(f32,f32,f32) fn rlRotatef(f32,f32,f32,f32) fn rlScalef(f32,f32,f32) }
+// spin a cube in place:
+rlPushMatrix()  rlTranslatef(x,y,z)  rlRotatef(deg, 0.0,1.0,0.0)  DrawCube(v3(0.0,0.0,0.0), s,s,s, c)  rlPopMatrix()
+```
+
+(The same stack works in 2D between `BeginDrawing`/`EndDrawing`. The **headerless-extern** trick is general: any `libraylib.a`/system-lib symbol that's scalar/`void` can be reached this way without its header.)
+
+**Procedural meshes (immediate mode)** — see [machin-game-demo-terrain](https://github.com/javimosch/machin-game-demo-terrain). Compute geometry in MFL and stream it triangle-by-triangle with rlgl: `extern "rlgl" { fn rlBegin(i32) fn rlEnd() fn rlColor4ub(u8,u8,u8,u8) fn rlVertex3f(f32,f32,f32) fn rlDisableBackfaceCulling() }`; `rlBegin(4)` (= `RL_TRIANGLES`), one `rlColor4ub` then three `rlVertex3f` per triangle, `rlEnd()` — inside `BeginMode3D`. **Flat-shade in MFL** (no light shader otherwise): face normal = cross of two edges, `sh = 0.4 + 0.6*clamp(dot(n_unit, lightDir),0,1)` (`sqrt` to normalize), multiply color by `sh`. `rlDisableBackfaceCulling()` if the surface is seen from both sides (else winding-dependent triangles vanish → thin sliver). ~10–15k `rlVertex3f`/frame is fine.
+
+**Point clouds via rlgl (RL_POINTS)** — see [machin-game-demo-galaxy](https://github.com/javimosch/machin-game-demo-galaxy). For thousands of individual points (stars, particles, sparks, dust), use `rlBegin(0)` (= `RL_POINTS`) instead of per-item `DrawSphere` calls. The same rlgl extern block applies: `rlBegin(0)`, then per point `rlColor4ub(r,g,b,255)` + `rlVertex3f(x,y,z)`, then `rlEnd()`. This renders the entire set in **one GPU draw call** vs N calls for N `DrawSphere`s. Good for ~5000+ points at 60fps. Brightness/visual size can be faked by emitting **multiple overlapping `rlVertex3f` at the same position** — 1 pass = 1 pixel, 2 passes = 2 pixels (medium bright), 3+ passes = bright/large. Combine with a dark `ClearBackground` (near-black blue: `col(2,2,8)`) for a space/atmosphere look. The headerless extern trick works: `extern "rlgl" { fn rlBegin(i32) fn rlEnd() fn rlColor4ub(u8,u8,u8,u8) fn rlVertex3f(f32,f32,f32) }`.
+
+**GPU meshes / pointer-array FFI** (v0.47.0–v0.48.0). Build C buffers in raw memory and a C struct as a cstruct, then hand them to the GPU. Raw memory (pointers are `int`s): `p := alloc(nbytes)` (zeroed), `poke_f32`/`poke_i32`/`poke_u8`/`poke_u16`/`poke_ptr(p, byteOffset, v)`, `peek_f32`/`peek_i32`, `free(p)`. Pointer params: `ptr` (a raw pointer, `void*` → any `T*`); `*T` (deref a raw pointer, pass the struct by value); **`T*` inout** (pass a cstruct *variable* by pointer, writing the modified struct back). A `cstruct` **field** may be `ptr`, so you declare the struct and the C compiler lays it out. Mesh flow: `alloc`+`poke` the vertex/color arrays, then `mesh := Mesh{vcount, vcount/3, vbuf, cbuf, 0, 0}` with `cstruct Mesh { vertexCount i32 triangleCount i32 vertices ptr colors ptr vaoId u32 vboId ptr }` (field names match raylib's), `UploadMesh(mesh, false)` (inout `Mesh*`; writes vao/vbo back), `LoadModelFromMesh(mesh)` → `Model` (opaque), then `DrawModelEx` each frame. **Build once**, GPU-resident — vs. immediate mode which re-emits every frame. (see machin-game-demo-planet)
+
+**Procedural worlds + infinite terrain + fly camera** — see [machin-game-demo-cyberpunk](https://github.com/javimosch/machin-game-demo-cyberpunk). **Noise** (v0.49.0): `noise2(x,y)`/`noise3(x,y,z)` are deterministic Perlin, ~`[-1,1]`; layer them into **fbm** in MFL (`s += amp*noise2(x*fr,y*fr); amp*=0.5; fr*=2`) for terrain/placement. **Infinite streaming:** a small slot pool — pre-fill `[]Model` with zeroed `Model{}` (a zero opaque handle is a safe no-op for `DrawModel`/`UnloadModel`) + a `cused[]` flag + `ccx/ccz`; each frame unload chunks out of `RAD` and build in-range ones into free slots, so only the leading edge regenerates. Bake **world coords** into each chunk mesh and `DrawModel` at the origin. **Fly camera:** `forward=(cos(pitch)*sin(yaw), sin(pitch), cos(pitch)*cos(yaw))`, `right=normalize(cross(forward,up))=(-fz,0,fx)/len`, driven by `GetMouseDelta` (yaw/pitch) + `IsKeyDown` + `GetFrameTime`; call `DisableCursor()` for mouse-look. raylib takes ownership of an uploaded mesh's `alloc`'d buffers (frees them on `UnloadModel` — don't free yourself). **Budget chunk builds** (≤ a few mesh builds/frame) so flying never hitches the mouse.
+
+**Shaders / post-processing** (composition — no new machin feature; see machin-game-demo-cyberpunk). `Shader` is `{id u32, locs ptr}` (a pointer cstruct field), `RenderTexture2D` is `{id u32, texture Texture2D, depth Texture2D}` (nested cstructs); `LoadShaderFromMemory(vs, fs)` (GLSL as `\n`-escaped single-line strings; standard names `vertexPosition`/`vertexTexCoord`/`vertexColor`/`mvp`/`texture0`), `SetShaderValue(sh, loc, ptr, kind)` (`kind` 0/1/2 = float/vec2/vec3, value from a small `alloc`'d buffer), `SetShaderValueTexture` (bind a sampler). Post-process: `BeginTextureMode(rt)` → draw scene → `EndTextureMode`, then `BeginShaderMode(sh)` → `DrawTextureRec(rt.texture, Rectangle{0,0,W,-H}, ...)` (**negative height flips** the render target) → `EndShaderMode`. **Depth fog:** linearize `texture(depthTex,uv).r` with near/far and skip `depth>0.9995` (sky).
+
+**GPU instancing** (thousands of meshes in one `DrawMeshInstanced` — also composition; flora in machin-game-demo-cyberpunk). `Material` is a partial cstruct `{ shader Shader, maps ptr }` (the C `params[4]` array can't be a cstruct field, but it's left zeroed by marshaling — fine). Instancing VS declares `in mat4 instanceTransform` (`gl_Position = mvp*instanceTransform*vec4(pos,1)`). **raylib 5.0 has no `SHADER_LOC_VERTEX_INSTANCE_TX`** — it uses `SHADER_LOC_MATRIX_MODEL` (index **9**) for the instance attribute: `poke_i32(ish.locs, 36, GetShaderLocationAttrib(ish, "instanceTransform"))`. `md := LoadMaterialDefault(); imat := Material{ish, md.maps}`. Build the per-instance `Matrix[]` in raw memory: **translation @ byte 12/28/44, scale @ 0/20/40, 1.0 @ 60**, rest zero. Keep positions deterministic (world grid + `noise2`) so instances don't flicker. **Math:** machin has **native** math builtins (v0.46.0) — `sin cos tan asin acos atan atan2 sqrt cbrt pow exp log log2 log10 floor ceil round trunc abs fmod hypot` and `pi()` (numeric in, `float` out; `-lm` linked only when used). So an orbit is just `v3(R*cos(a), h, R*sin(a))`. (An `extern "m"` of the same name still shadows the builtin if you want a specific libm signature.)
+
+**Procedural skeletal animation** (fauna in machin-game-demo-cyberpunk — composition over the rlgl matrix stack, no new feature). Pose a bone hierarchy with **forward kinematics**: nest `rlPushMatrix`/`rlTranslatef`(to the joint)/`rlRotatef`(the joint angle)/draw-at-local-origin/`rlPopMatrix`. A leg is two segments — translate to the hip, rotate the whole leg, `DrawCube` the upper segment, `rlTranslatef` down to the knee, `rlRotatef` the shin, `DrawCube` the lower segment. Drive a **diagonal gait** from `sin`/`cos(t*speed)`: legs 0&3 share one phase, 1&2 the opposite (`+π`); `swing = sin(phase)*A` rotates the hip, a `lift` term (`cos(phase)` clamped `>0`) bends the knee on the forward stroke, and a body bob (`sin(t*speed*2)*h`) sells the weight shift. Wrap the whole creature in one more `rlPush`/`rlTranslatef`(world pos)/`rlRotatef`(heading)/`rlPop`. Snap to terrain height each frame. No skinned mesh needed — nested transforms over primitives carry it.
+
+**Pushing the draw distance past raylib's ~1 km clip.** raylib's auto perspective uses a fixed far plane (`rlSetClipPlanes` does **not** exist in 5.0). Override it with **`rlSetMatrixProjection`** (rlgl), passing a `Matrix` **by value** — declare `cstruct Matrix { m0 f32 m4 f32 m8 f32 m12 f32 m1 f32 m5 f32 m9 f32 m13 f32 m2 f32 m6 f32 m10 f32 m14 f32 m3 f32 m7 f32 m11 f32 m15 f32 }` (raylib's field order) and build a perspective matrix with your own far plane: `m0=f/aspect, m5=f` (`f=1/tan(fovy/2)`), `m10=-(far+near)/(far-near)`, `m14=-(2·far·near)/(far-near)`, `m11=-1`, rest 0. Call it **every frame right after `BeginMode3D`** (it flushes the batch and sets the projection). Gotcha: a `*Matrix` deref-param in a **headerless** extern emits invalid C (`extern void f(*Matrix)`) — pass the struct **by value** (`fn rlSetMatrixProjection(Matrix)`) instead; the cstruct must be declared in a **headered** block so the C type resolves. For a believable far horizon, pair it with a **coarse LOD underlay** — one big low-res terrain mesh recentered on the camera as it drifts a snap cell — under the fine chunks, the seam hidden by fog.
+
+Sprite tricks: a **sprite sheet** is one PNG; pick a frame with a source `Rectangle{float(frame*48), 0, 48, 48}` and rotate via `DrawTexturePro` around `origin = Vector2{w/2, h/2}`. **Flip** with a negative source height (`Rectangle{0,0,88,-600}`) — reuse one texture for both orientations. **Center text** with `MeasureText`.
+
+raylib codes used by the games: keys `SPACE 32`, arrows `LEFT 263 RIGHT 262 UP 265 DOWN 264`, `W 87 A 65 S 83 D 68`, digits `1..4 = 49..52`, `R 82`; mouse button `left = 0`. Esc is raylib's default window-close key (caught by `WindowShouldClose()`).
+
+**Verlet physics (position-based dynamics) — pure MFL, no C library.** The solar-system sim drove the math module; the physics demo ([machin-game-demo-physics](https://github.com/javimosch/machin-game-demo-physics)) drives the simulation layer on top of it. Core patterns:
+
+- **Implicit velocity via `old_pos`.** A `Particle` stores `pos` (current) and `old` (previous frame). Velocity = `pos - old`. Integration per substep: `new_pos = pos + (pos-old)*damping + gravity*dt²`. No Euler/Verlet distinction — one formula. (Matches MFL's value-semantic structs: you return a new `[]Particle` each tick — fine for ~100–300 particles.)
+- **Distance constraint relaxation.** A constraint holds two particle indices + a rest length. Each iteration projects both particles along the inter-particle axis: `delta = p2-p1; dist=len(delta); diff=(dist-rest_len)/(dist+ε); off=delta*diff*0.5; if !pinned: p1+=off; p2-=off`. Run 3–5 iterations per substep for stable convergence. The `*0.5` splits the correction equally (weight by inverse mass for non-uniform masses).
+- **Substeps decouple speed from stability.** The physics tick is always `1/60`; divide into 6–8 substeps of `dt/6`. Each substep runs integrate → constraint iterations → collision, so objects that move fast per frame don't tunnel.
+- **O(n²) sphere-sphere collision** is fine for ≤200 particles (~40k distance checks/substep). Check `len(pos[j]-pos[i]) < r_i+r_j`; push apart along the normalized delta by half the overlap each. Include the `ε = 0.0000001` to avoid division by zero when particles are exactly coincident.
+- **Ground collision** is a one-liner: `if pos.y < radius { pos.y = radius; old.y = pos.y + (old.y-pos.y)*bounce }` where `bounce=0.4` kills most of the rebound velocity.
+- **Velocity coloring** for live diagnostics: compute `speed = len(pos-old)/dt` and map it through a gradient (cold blue → cyan → yellow → hot red). One function, visualized instantly across all particles.
+
+**Ballistic physics (projectile simulation) — gravity + drag + wind.** The ballistics demo ([machin-game-demo-ballistics](https://github.com/javimosch/machin-game-demo-ballistics)) adds the projectile layer for Tier 4 combat sims. Core patterns:
+
+- **Euler integration at a fixed timestep.** `1/60s` per step: `v += a·dt; x += v·dt`. Three forces: gravity (constant downward), quadratic drag (`-drag_coeff · |v| · v` — realistic because it scales with velocity squared), and wind (constant horizontal). The same integrator is used for both the **predicted trajectory** (computed ahead of time, drawn as dots) and the **live projectile** (frame-by-frame during flight). This makes the prediction trustworthy — it IS the simulation.
+- **Phase-state machine for interactive flow.** A single `phase` int (0=aiming, 1=firing, 2=impact) controls which inputs are read and what is drawn. Phase 0 reads arrows (angle/power) + SPACE (fire). Phase 1 advances the projectile and appends to a trail slice. Phase 2 shows hit/miss feedback with a countdown timer, then auto-resets to 0.
+- **Trajectory prediction with `compute_traj()`.** A function that runs the full integrator for up to 500 steps and returns `([]Vec3, steps)`. Called every frame during aiming. The result is rendered sparsely (every 3rd step, dim sphere) to show the arc without visual clutter.
+- **Hit detection with radial check.** On ground impact (`y < 0`), compute `sqrt((px-tx)² + (pz-tz)²)` and compare to the target radius. Display "HIT" or "MISS by Xm" (the distance computed from the impact position).
+- **Smooth arrow-key controls.** Angle adjusts by `40°·dt` per frame (frame-rate independent), clamped to `[5°,85°]`. Power adjusts by `20·dt`, clamped to `[4,50]`. Using `IsKeyDown` for held-arrow adjustment and `IsKeyPressed` for the single-fire trigger (SPACE) keeps the controls feeling responsive.
+- **Trail as a growing slice.** Each frame during phase 1, `trail = append(trail, pos)`. The trail is drawn as small spheres (dimmer toward the start). Capped at 500 entries to prevent unbounded memory growth.
+
+**First-person player controller — walking, jumping, pushing.** The player demo ([machin-game-demo-player](https://github.com/javimosch/machin-game-demo-player)) adds the character controller that every interactive 3D game needs. Core patterns:
+
+- **Movement from camera yaw.** Horizontal movement direction is computed from `sin(yaw)` / `cos(yaw)` — the same `yaw` that controls mouse look. W always moves where the player is looking, even when pitched up/down. Compute the 2D direction vector, normalize, scale by speed.
+- **Smooth acceleration.** Instead of `vel = input_dir` (instant), interpolate toward it: `vel += (input - vel) * min(accel * dt, 1)`. For `accel=12`, this reaches 90% of target speed in ~0.2s. When no input, `vel` decays via friction `vel *= (1 - friction*dt*10)`. This gives natural-feeling movement with no explicit state machine.
+- **Gravity + ground collision per frame.** `pvy += GRAVITY*dt; pos += vel*dt`. After integration, if `foot_y < 0`, snap to 0, zero `pvy`, set `grounded=1`, apply horizontal friction. This runs before platform checks.
+- **Platform stepping.** For each platform, test `if foot_xz is within platform_xz bounds AND foot_y is near platform_top`: snap `foot` to platform top + eye height, set grounded. This naturally handles stepping up and walking off edges. Multiple platforms require iterating the list each frame and testing each one.
+- **Walk/fly mode toggle.** A single int `walk_mode` (0/1) and F key flips it. In walk mode, the player controller runs. In fly mode, the free camera from solar operates. On transition to walk, transfer the fly camera's position/orientation to the player — fly to a spot, press F, land there.
+- **Object pushing with collision physics.** Sphere-sphere collision between player and each object. The overlap is split: both player and object are pushed apart by half the overlap. Objects have their own gravity + ground collision + friction (separate from the player's). Multiple objects can be pushed simultaneously.
+
+## THE gotcha: no implicit int→float
+
+This bit every game. MFL does **not** implicitly convert `int`→`float`. Only a *flexible numeric literal* (`5`, `560`) promotes on contact with a float. A **concrete** int does **not**, and mixing it with a float is a hard `int vs float` compile error. Concrete ints come from: **a function return** (even `func GROUND_Y() { n = 560 }`), `byte_at`, `len`, a **typed parameter**, an **`int`-slice element**, and an `f32`/`f64` **cstruct field** also won't take a concrete int.
+
+Fixes (need `float()`, machin **v0.43.0**; `int()` goes the other way):
+- Make world-coordinate constants **floats**: `func GROUND_Y() { n = 560.0 }`.
+- Wrap concrete-int math entering float: `160.0 + float((byte_at(r,0) << 8 | byte_at(r,1)) % 260)`.
+- Concrete int into an `f32` field: `Rectangle{float(frame*48), 0, 48, 48}` (literals like `0`/`48` are fine).
+- Keep loop indices pure `int`: use a float **accumulator** (`x = x + SPACING()`), never `i * SPACING()` — multiplying the index by a float drags it to float and then `arr[i]` breaks.
+- Going to an FFI `i32` arg from a float: `int(GROUND_Y())`.
+
+Rule of thumb: keep each value in one numeric world; cross the boundary explicitly with `float(x)` / `int(x)`.
+
+## Terminal (TUI) games
+
+- **Real-time input** (machin **v0.41.0**): `raw_mode(1)` puts the tty in cbreak/no-echo; `read_key()` is a non-blocking single-key read (`""` if nothing waiting). Always `raw_mode(0)` before exit. `input()` is line-buffered and unusable for games.
+- **ANSI without `\x`:** MFL strings have no `\x1b`. Build ESC from hex: `ESC := bytes_str(from_hex("1b"))`, then `ESC+"[2J"` (clear), `ESC+"[H"` (home), `ESC+"[?25l"`/`[?25h"` (hide/show cursor), `ESC+"["+str(n)+"m"` (color).
+- **One `print` per frame** (build the whole frame string, then `flush()`); per-cell printing flickers.
+- Under a pipe/CI, `raw_mode` no-ops and `read_key` falls back to a `select` poll — handy for a smoke test (snake runs straight into the wall and exits).
+
+## Other caveats
+
+- **A GUI binary is not self-contained** — it links `libGL`/`libX11`/raylib/audio and needs a display (and an audio device for sound). machin's no-dependency-binary property holds for the headless domain only. Say so in the README.
+- **`str(bool)` works** as of machin **v0.42.0** (`"true"`/`"false"`); on older compilers it was a type error, so keep bools in control flow there.
+- **No slice ranges** (`s[1:]` doesn't parse) — rebuild with a loop (e.g. snake's `drop_first`).
+- **`a < -b` is a lexer trap.** `encode` tightens `< -` to `<-`, which lexes as the channel-receive token (`expected "{", got "<-"`). Write `a < 0.0 - b` or flip the comparison. (Common with negative thresholds: `if h < -0.7` → `if h < 0.0 - 0.7`.)
+- **Random:** there's no PRNG builtin; `byte_at(rand_bytes(1), 0) % N` picks a value (a second byte `< 26` ≈ a 10% branch).
+- **Frame timing:** immediate-mode means never `sleep` mid-game (it freezes the window). Drive animations/state with a per-frame tick counter and `SetTargetFPS`. (Terminal games *do* `sleep(ms)` per tick — they own the loop.)
+- **Mutating shared state:** slices are reference-ish — `f(board)` then `board[i] = v` is visible to the caller (return only summaries). Structs are value types (a copy), so a function can't mutate a caller's struct.
+- **cstruct types CANNOT be fields in MFL `type` structs.** A `cstruct` declared in an `extern` block (`Model`, `Color`, `Sound`, `Shader`, …) can be a local variable, passed to functions, or stored in a **slice** (`[]Model`, `[]Color`), but it **cannot** be a field of an MFL `type` struct. The C type map isn't available at the point the MFL struct's typedef generates. Workaround: use **parallel slices** — `bodies := []Body{}; models := []Model{}` — and index them together. (Discovered by machin-game-demo-solar.)
+- **Non-empty `[]struct` literals are not supported.** `xs := []S{a, b, c}` fails; build with `append`: `xs := []S{}; xs = append(xs, a); xs = append(xs, b); …`. (Empty `[]S{}` is fine.)
+
+## Each game drove a feature (the dogfood record)
+
+| game | exercises | drove into machin |
+|------|-----------|-------------------|
+| snake | terminal real-time input | `raw_mode` / `read_key` (v0.41.0) |
+| 2048 | raylib FFI: scalars + `Color` | (composed; no new builtin) |
+| flappy | textures/sprites, `f32` structs, struct-return | `float()` int→float (v0.43.0) |
+| simon | audio: pointer-bearing `Sound` by value | FFI **opaque handles** `cstruct Name {}` (v0.44.0) |
+| 3d demo | 3D: `Camera3D` (struct of `Vector3`s); per-object rotation (rlgl matrix stack, headerless extern) | FFI **nested cstructs** (v0.45.0); its libm orbit then drove **native math** builtins (v0.46.0); rotation = composition (no new feature) |
+| anim | 2D procedural flow field (sin/cos/atan2/hypot over time) | composition on native math + 2D FFI (no new feature) |
+| terrain | procedural mesh: per-vertex heights, flat-shaded, streamed via rlgl immediate mode | composition (no new feature); points at the **pointer/array FFI** gap for real GPU VBOs |
+| planet | static **GPU mesh**: vertex/color arrays in raw memory, `Mesh` as a cstruct, upload to VRAM | **pointer/array FFI** (v0.47.0): raw memory `alloc`/`poke_*`; then **pointer cstruct fields + inout `T*`** (v0.48.0) dropped the hard-coded offsets |
+| cyberpunk | **infinite** procedural world: fbm-noise terrain in GPU-mesh chunks, fly camera, grimy city districts, **GPU-instanced flora**, **shader depth fog**, **skeletal fauna**, **10 km draw distance** | **`noise2`/`noise3`** Perlin (v0.49.0); buildings/instancing/shaders/fog/skeleton-animation/far-clip all composition (rlgl matrix stack + by-value `Matrix` cstruct) |
+| solar | **3D solar-system sim**: 7 noise3-textured GPU-mesh planets, **fixed-timestep** orbital sim (60 Hz accumulator), 6DOF fly camera, **pure-MFL math3d module** (`Vec3` add/sub/scale/dot/cross/len/norm/lerp/dist) | composition (no new builtin); drives the **vector/math layer** (feature #2) and **fixed-timestep sim** (feature #6) from the north star; surfaced the cstruct-in-struct-field + slice-literal caveats |
+| physics | **verlet physics sandbox**: ~100 particles falling/colliding/stacking, chain pendulum, velocity coloring, noise3-based random scene population | composition (no new builtin); first constraint-based physics in pure MFL — verlet integration, distance constraint relaxation (iterations × substeps), O(n²) sphere-sphere collision, all over the `Vec3` module; drives Tier 4 physics patterns |
+| galaxy | **procedural spiral galaxy**: ~5000 stars in 4 logarithmic spiral arms (`θ = k·log(r)`), spectral OBAFGKM colors, rlgl point-cloud render (RL_POINTS, one batch), slow rotation, core bulge | composition (no new builtin); first demo to use **rlgl point rendering** (`rlBegin(0)` / `rlColor4ub` / `rlVertex3f` / `rlEnd()`); demonstrates procedural star placement, weighted spectral distribution, multi-pass point sizing, and the `v3_rot_y()` helper |
+| ballistics | **interactive cannon sim**: trajectory prediction with gravity + quadratic drag + wind, aim/power controls, live projectile with trail, hit/miss detection on a target | composition (no new builtin); demonstrates ballistic Euler integration, the prediction-vs-execution pattern (same integrator for both), phase-state machine (aim→fire→impact), interactive HUD with real-time angle/power feedback, and `IsKeyPressed` for single-fire controls |
+| player | **first-person 3D playground**: walking character with smooth acceleration, platform stepping (4 heights), 5 pushable spheres with gravity physics, walk/fly camera toggle (F) | composition (no new builtin); demonstrates the first-person player controller layer — WASD movement relative to camera yaw, smooth acceleration `vel += (input - vel)·min(accel·dt,1)`, gravity + ground + platform collision, walk/fly mode toggle, pushable-object physics (sphere-sphere collision with player, object gravity + friction), crosshair + HUD in screen space |
+
+When a new game hits a wall, that's the point: fill the gap in the language, release, and note it here.

--- a/plugins/machin/skills/machin-start/SKILL.md
+++ b/plugins/machin/skills/machin-start/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: machin-start
+description: Decide whether to build something in machin (MFL) and bootstrap it fast — the entry point that comes BEFORE the domain how-tos. Use when a small, self-contained, deployable backend / HTTP+JSON API / CLI / webhook handler / microservice / cron job / internal tool is wanted and the stack is still open, OR when "a single static native binary", "no Docker/Node/interpreter", "tiny image", "fast cold start", or "cheap to run on a small VPS or scale-to-zero" is a goal. Covers when machin wins (with measured numbers) vs Go/Node/Python, when NOT to reach for it, and a zero→running→shipped quickstart (install → a 12-line REST+SQLite service → static musl build → a 92.9 kB FROM-scratch image). Routes to the web / backend / gamedev / deploy skills. Read this first.
+---
+
+# Should I build this in machin? (and how to start)
+
+machin (MFL) compiles a Go-flavored, type-inferred language **through C** to one
+native binary. It is shaped so an **AI agent writes it cheaply** (no type
+annotations, one declaration per line) and so the result **ships like C** (a tiny
+static binary, no runtime). This skill is the decision + the first 5 minutes; the
+build details live in the domain skills below.
+
+## Reach for machin when…
+
+…you want a **small, self-contained service or tool you have to deploy**, and the
+stack is still open. The measured case (`bench/` in the repo — reproduce, don't
+trust):
+
+| axis | machin | vs the usual |
+|---|---|---|
+| **agent writes it** | a REST+SQLite API in ~390 tokens | **ties Python**, ~36 % fewer than Go |
+| **runs** | native, unboxed, no VM | **wins fib & integer loops vs Rust -O3 / Zig**, ties on float, ~1.4× behind on array-heavy |
+| **ships** | 92.9 kB image · 0.49 ms cold start · 0.1 MB RAM (pure compute; a **SQLite** app ships `FROM scratch` too via `--static`, ~1 MB; TLS still needs OpenSSL — see ship step) | **1916× smaller / 59× faster start / 477× less RAM than Node** |
+
+Concretely a fit for: a JSON/REST API, a CLI or filter, a webhook receiver, a cron
+/ daemon, an internal tool, a static-site or single-page app backend, a database
+client — anything where "one binary on a $4 VPS, no Docker, no `node_modules`, no
+`pip install`" is the point. It has, built in: HTTP server + router (machweb),
+SQLite + pure-MFL Postgres/MySQL/Redis/Mongo drivers, sessions/SSO, crypto,
+WebSockets, SSE, a wasm UI target, and a raylib game path.
+
+## Do NOT reach for machin when…
+
+Be honest, or you waste the user's time:
+- The app lives in an **existing ecosystem** (a Rails/Next/Django codebase, a
+  team's Go services) — fit the tools they have.
+- You need a **specific mature library** (Stripe SDK, pandas, a game engine, ML).
+  machin's stdlib is broad but shallow; there is no package registry.
+- It's **data-science / numeric-heavy** or needs **array-bound hot loops** —
+  machin trails ~1.4× there and lacks the libraries.
+- The team won't run an **unfamiliar language**. machin is young (one author).
+
+When it doesn't fit, say so and use the right tool. machin's pitch is narrow and
+real; don't oversell it.
+
+## Quickstart — zero → running → shipped
+
+```bash
+# 1. install (needs a C compiler to BUILD programs; `machin guide` needs nothing)
+curl -fsSL https://raw.githubusercontent.com/javimosch/machin/main/install.sh | sh
+machin guide                      # the version-exact language catalog (read this)
+```
+
+A complete REST + SQLite service (`app.src`) — create / list / get / delete:
+
+```go
+type Note struct { id int  title string  body string }
+
+func handle(db, req) (res) {
+    if req.method == "POST" {
+        if req.path == "/notes" {
+            n := parse(req.body, Note{})
+            sqlite_exec(db, "INSERT INTO notes(title,body) VALUES(?,?)", []string{n.title, n.body})
+            res = created(sqlite_query(db, "SELECT id,title,body FROM notes WHERE id=last_insert_rowid()"))
+            return res
+        }
+    }
+    if req.method == "GET" {
+        if req.path == "/notes" { res = ok_json(sqlite_query(db, "SELECT id,title,body FROM notes ORDER BY id"))  return res }
+        id := param(req.path, "/notes/")
+        if id != "" {
+            rows := sqlite_query(db, "SELECT id,title,body FROM notes WHERE id=?", []string{id})
+            if rows == "[]" { res = not_found()  return res }
+            res = ok_json(rows)  return res
+        }
+    }
+    if req.method == "DELETE" {
+        id := param(req.path, "/notes/")
+        if id != "" { sqlite_exec(db, "DELETE FROM notes WHERE id=?", []string{id})  res = ok_json("{\"deleted\":" + id + "}")  return res }
+    }
+    res = not_found()
+}
+
+func main() {
+    db := sqlite_open("notes.db")
+    sqlite_exec(db, "CREATE TABLE IF NOT EXISTS notes(id INTEGER PRIMARY KEY, title TEXT, body TEXT)")
+    serve(8080, func(req) { return handle(db, req) })
+}
+```
+
+```bash
+# 2. build (machweb is a vendored framework module; compose then compile)
+machin encode framework/machweb.src app.src > app.mfl
+machin build app.mfl -o app           # a small native binary (dynamic glibc, ~44 kB)
+./app                                  # serving on :8080
+
+# 3. ship it:
+#   (a) DEFAULT: the small dynamic binary above (~50 kB). Links libc + libsqlite3
+#       (+ libssl if you use the HTTPS client) — all present on any normal Linux box.
+#       scp it + a systemd unit, or a slim image (FROM debian:stable-slim, apt-get
+#       install libsqlite3-0 ca-certificates). The common case, plenty small.
+#   (b) FROM scratch: `--static` bundles SQLite (the amalgamation) in, so a REST+SQLite
+#       app links nothing. Pair with musl for a libc-free, zero-dep binary:
+printf '#!/bin/sh\nexec musl-gcc -static "$@"\n' > muslcc && chmod +x muslcc
+CC=./muslcc machin build --static app.mfl -o app   # statically linked -> FROM scratch (~1 MB)
+# Dockerfile:  FROM scratch / COPY app /app / ENTRYPOINT ["/app"]
+# (TLS apps using the HTTPS client still need OpenSSL — native TLS is tracked in #260.)
+```
+
+## Then read the domain skill for what you're building
+
+- `machin guide --skill backend` — JSON APIs, the five pooled DB drivers, sessions,
+  SSO, agent-first CLIs, daemons.
+- `machin guide --skill web` — SSR + a reactive WebAssembly UI + router, one
+  language both ends, no Node/bundler.
+- `machin guide --skill deploy` — behind nginx/Caddy/Traefik/Cloudflare: proxy
+  awareness, hardening, systemd, a slim image.
+- `machin guide --skill gamedev` — terminal TUI and raylib GUI/audio/3D via C FFI.
+
+## The contract, in one line
+
+machin tools are consumed by agents: **stdout = JSON answer, stderr = structured
+errors, semantic exit codes, non-interactive.** Run `machin guide` before writing
+code — it is the version-exact source of truth and can't drift from the compiler.

--- a/plugins/machin/skills/machin-web/SKILL.md
+++ b/plugins/machin/skills/machin-web/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: machin-web
+description: Build web apps in machin (MFL) — a native HTTP server, a JSON API, server-side rendering, and a reactive WebAssembly UI, all in one language with no Node/bundler. Use when writing or debugging a machin web app: a backend service, an SSR page, a wasm SPA, an isomorphic full-stack app, or a CRUD back-office. Covers the machweb/reactive/router/flags frameworks, cookies + signed sessions, OAuth2/OIDC SSO, the wasm bridge + host↔wasm marshaling, the generic JS host, the pure-MFL Postgres/MySQL/Mongo/Redis drivers, build-and-verify, and the hard-won gotchas. Distilled from the web + backend dogfood (machin v0.50–v0.73).
+---
+
+# Building web apps in machin
+
+machin compiles MFL to a **native binary** (the server) *and* to **WebAssembly**
+(the browser client). One language does both ends of the wire — server, API, SSR
+HTML, and a fine-grained reactive UI — with **no Node, no bundler, no
+`node_modules`**. The JS host is a fixed ~30 lines; everything else is MFL.
+
+> Run `machin guide` first — it's the version-exact language catalog (builtins,
+> idioms, gotchas), including a `reactive-runtime` note. This skill is the *web how-to*.
+
+## The fastest path: start from the boilerplate
+
+[`boilerplate-cli-ui-machin-isomorphic`](https://github.com/javimosch/boilerplate-cli-ui-machin-isomorphic)
+is a working single binary that is a **CLI + HTTP server + JSON API + reactive wasm
+UI** (SSR + hydration, shared model). Clone it and edit — it already wires up
+everything below. To build something new, copy its structure:
+
+```
+src/machweb.src  src/flags.src  src/reactive.src   # vendored frameworks (from machin/framework)
+src/models.src        # shared schema/render, compiled into BOTH server and client
+src/client.src        # the wasm UI (reactive)
+src/server.src        # machweb routes + CLI main; serves its own wasm + the API
+web/host.js           # the generic JS host, embedded into the binary at build time
+build.sh
+```
+
+`build.sh` does two compiles: the client to wasm, then the server (which embeds
+`web/host.js` and serves `app.wasm`):
+
+```sh
+machin encode src/reactive.src src/models.src src/client.src > client.mfl
+machin build  client.mfl --target wasm -o app.wasm                       # the SPA
+python3 -c "import json;print('func host_js() (s) { s = '+json.dumps(open('web/host.js').read())+' }')" > src/host_gen.src
+machin encode src/machweb.src src/flags.src src/models.src src/server.src src/host_gen.src > server.mfl
+machin build  server.mfl -o app                                          # the binary
+```
+
+Needs `machin` (v0.57.0+ for forms) and [`zig`](https://ziglang.org) (the C→wasm
+compiler — a single binary, no emscripten). The frameworks live in
+[`machin/framework`](../../framework); vendor copies into your repo.
+
+## The server — `framework/machweb.src`
+
+A handler is `func(Request) Response`. `serve(port, handler)` runs it (one
+goroutine per connection). `req.method` / `req.path` (path carries the query
+string) / `req.body` / `header(req, name)` / `cookie(req, name)`.
+
+Response builders: `ok_text` · `ok_html` · `ok_json` · `ok_bytes(ctype, b)` ·
+**`ok_wasm(b)`** · `created` · `bad_request` · `not_found`. Add any header with
+`with_header(res, name, value)` (e.g. `Content-Disposition` for a download filename).
+
+```go
+func handle(req) (res) {
+    if req.path == "/app.wasm" { return ok_wasm(read_file_bytes("app.wasm")) }  // serve your own SPA
+    if has_prefix(req.path, "/api/users") { return ok_json(users_json()) }
+    return ok_html(page())                                                       // SSR
+}
+func main() { serve(48080, func(req) { return handle(req) }) }
+```
+
+- **Serve your own wasm:** `ok_wasm(read_file_bytes("app.wasm"))` — `read_file_bytes`
+  is NUL-safe (a `.wasm` has NUL bytes a string body would truncate).
+- **File uploads (`multipart/form-data`):** requests are read binary-safe, so a browser
+  file upload survives intact. `multipart_file(req, "file")` → `(part, ok)` with
+  `part.filename` / `part.ctype` / `part.data` (raw bytes — store with
+  `write_file_bytes`); `multipart_field(req, "name")` reads a text field of the same form.
+  `parse_multipart(req)` returns every part. The raw binary body is `req.body_bytes`. See
+  [machin-share](https://github.com/javimosch/machin-share).
+- **Streaming / Server-Sent Events:** return `sse(func(conn) { ... })` instead of a whole
+  Response and write events over the open socket with `sse_data(conn, msg)` /
+  `sse_event(conn, name, msg)` / `sse_comment(conn, ping)` — for live logs, progress, or
+  LLM tokens. A write returns `< 0` once the client disconnects (break the loop). SIGPIPE
+  is ignored so a vanished client can't kill the server. For cross-goroutine fan-out
+  (one producer → many live subscribers) use a single hub goroutine that owns the
+  subscriber set (a `chan` field inside a struct, a `[]Sub` registry) — see
+  [machin-live](https://github.com/javimosch/machin-live).
+- **WebSockets (`framework/ws.src`):** compose `ws.src` after `machweb.src`, then a handler
+  returns `ws(req, func(c) { ... })`. machweb does the upgrade (via the generic
+  `hijack(fn)` response) and `c` is a `WSConn`: `ws_next_text(c)` → `(msg, ok)` reads the
+  next message (answering pings, stopping on close); `ws_send_text(c.fd, s)` /
+  `ws_send_bytes(c.fd, b)` send. A connection that also receives broadcasts wants **two
+  goroutines** — the handler loop reads, a spawned `go writer(c.fd, ch)` drains an outbound
+  channel (read + write are independent on the fd). Fan-out is the same hub-goroutine
+  pattern as SSE. See [machin-rooms](https://github.com/javimosch/machin-rooms).
+- **A database:** machin has SQLite builtins — `sqlite_open(path)` / `sqlite_exec(db,
+  sql)` / `sqlite_exec(db, sql, []string params)` (`?`-bind, injection-safe) /
+  `sqlite_query(db, sql[, params]) -> string` (a **JSON-array-of-rows string**) /
+  `sqlite_close(db)`. Perfect for a users table behind a JSON API. **Decode rows with
+  `parse`, not `json_get`:**
+  ```go
+  type User struct { id int  name string  email string }
+  rows  := sqlite_query(db, "SELECT id, name, email FROM users ORDER BY id")
+  users := parse(rows, []User{})            // a typed []User to range over — values decoded
+  ```
+  A **slice witness** (`[]User{}`) is the row-iteration idiom. Reach for `json_get(rows,
+  "[0].name")` only to pull ONE field — and note **it returns the raw JSON token, so a
+  string comes back quoted** (`"Ada"`); strip the quotes (`substr(s, 1, len(s)-1)`) or
+  just use `parse`. Always parameterize (`?`, `[]string{...}`); never concat user input.
+- **A networked database** (shared across instances): machin has pure-MFL drivers for
+  **PostgreSQL**, **MySQL/MariaDB**, **Redis**, and **MongoDB** (all connection-pooled,
+  no cgo) — each returns rows as JSON the same way, so `parse(rows, []T{})` decodes them.
+  See the `postgres-client` / `mysql-client` / `mongo-client` / `redis-client` /
+  `machweb-sessions` / `sso-oauth` idioms in `machin guide`, and
+  [`docs/NORTH-STAR-BACKEND.md`](../../docs/NORTH-STAR-BACKEND.md) for the full backend
+  story (sessions, SSO, pooling, and the worked MachNotes / machin-cms apps).
+- **A CLI:** compose `framework/flags.src` — `new_flags` / `flag_int` / `flag_str` /
+  `flag_bool` / `parse_flags(fs, args())` / `flag_int_val` / `flag_on(fs,"help")`
+  (auto `--help`).
+- **Cookies & login sessions:** `cookie(req, name)` reads a request cookie;
+  `set_cookie(res, name, value)` / `clear_cookie(res, name)` return a `Response` with
+  a `Set-Cookie` (safe defaults: `Path=/; HttpOnly; SameSite=Lax`). For login, use a
+  **signed** session the client can't forge: `set_session(res, secret, "sid", userID)`
+  stores `userID` + an HMAC tag, and `get_session(req, secret, "sid") -> (value, ok)`
+  returns `ok == 1` only if it verifies. `Response` is a value, so chain the helper:
+  ```go
+  func login(req) (res) {
+      // ...check credentials...
+      res = set_session(ok_html(dashboard()), secret, "sid", "user:42")
+  }
+  func page(req) (res) {
+      uid, ok := get_session(req, secret, "sid")
+      if ok == 0 { return set_cookie(not_found(), "x", "")  /* or redirect to /login */ }
+      res = ok_html(home(uid))
+  }
+  ```
+  Keep `secret` server-side (e.g. `env("SESSION_SECRET")`). The value is signed, not
+  encrypted — store an id/handle, not secrets.
+- **SSO — "log in with Google/Microsoft/…"** (`framework/sso.src`, OAuth2 + OIDC). Fill
+  an `OAuthProvider{auth_url, token_url, userinfo_url, client_id, client_secret,
+  redirect_uri, scope}`, then two routes: `GET /login` → `sso_begin(p, secret)` (302 to
+  the provider + a signed `oauth_state` cookie for CSRF); `GET /callback` →
+  `profile, ok := sso_complete(p, secret, req)` (verifies state, exchanges the code,
+  fetches the userinfo JSON). On `ok` read `json_get(profile, ".sub")`/`".email"` and
+  `set_session(...)` your own login cookie, then `redirect("/")`. Identity comes from the
+  provider's **userinfo endpoint** (so no JWT/RSA needed). Also uses `redirect(url)` and
+  `query(req, name)` (now in machweb). See `examples`/the SSO test for the full flow.
+
+## The client — `framework/reactive.src` (signals + a patch list)
+
+The Solid/Leptos model in MFL: state in **signals**, fine-grained updates. Only the
+reactions that read a changed signal recompute, and only changed text/keys touch
+the DOM (no `innerHTML` churn, no vdom diff).
+
+| call | what it does |
+|---|---|
+| `signal(v) -> id` | a state cell; `get(id)` reads (auto-tracks a dependency), `set(id, v)` writes (notifies dependents if changed) |
+| `computed(func(){ return … }) -> id` | a memoized derived signal; read with `get` like any signal |
+| `slot(name, compute) -> markup` | markup for a reactive text node (`<span data-s=name>`) + queues its binding |
+| `list(name, keys, item) -> markup` | markup for a keyed list + queues its reconciler. `keys()` returns the ordered keys as a **CSV string**; `item(key)` returns one item's HTML |
+| `mount(root, html)` | set the root's innerHTML once, then activate the queued slots/lists (client-side render) |
+| `hydrate(html)` | activate them against an **already-SSR'd DOM** (no re-render) — for isomorphic pages |
+
+**Multi-page (`framework/router.src`).** For an admin app with several pages, compose
+the router too. The active route is a signal (an int index): `router_init(0)`,
+`route(path)` registers pages in order, `link(path, label)` renders a nav anchor,
+`current_route()` reads the active index, and `outlet(id, render)` re-renders the
+active page (a reaction over a `dom_html` host import) and syncs the address bar.
+`page()` switches on `current_route()` and must be a **pure render** (read signals,
+never `set` — that loops). The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
+clicks to `nav(path)` (path in via `ptr_str`) + `popstate`, and a catch-all server
+serves the shell for any path (deep-links). See [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router).
+
+A whole component is one expression:
+
+```go
+export func start() {
+    n = signal(0)
+    total = computed(func() { get(ver)  return sum_of(items) })
+    mount("app",
+        "<h1>Items</h1>" +
+        slot("total", func() { return str(get(total)) }) +
+        list("items", func() { get(ver)  return csv(ids) }, func(id) { return row(id) }))
+}
+```
+
+The host supplies five DOM ops as imports: `dom_mount` · `dom_patch` ·
+`list_insert` · `list_remove` · `list_order` (see the host below).
+
+**Keyed lists only re-render an item on INSERT**, not when a kept item's content
+changes. To make a row update when its data changes, **encode the mutable state in
+the key** (`key = id*100 + done`); a change makes a new key → one remove+insert.
+
+## The wasm bridge & marshaling
+
+- **JS → machin:** `export func name(...)` becomes a wasm export the host calls
+  (`instance.exports.name`). A wasm module needs no `main`.
+- **machin → JS:** a headerless `extern "env" { fn dom_patch(string, string) }`
+  becomes a wasm import the host supplies.
+- **ints** cross both ways as **`BigInt`** (machin ints are i64).
+- **strings out:** machin returns a pointer into `memory`; the host decodes
+  NUL-terminated UTF-8 (`let e=p; while(b[e])e++; TextDecoder().decode(b.subarray(p,e))`).
+- **strings in (forms):** the host writes UTF-8 into a buffer the module `alloc`'d,
+  then machin reads it with **`ptr_str(ptr)`** (v0.57.0):
+  ```go
+  export func input_buf(n) (p) { p = alloc(n + 1) }       // host writes n bytes + NUL here
+  export func submit(p) { let t = ptr_str(p)  free(p)  /* …use t… */ }
+  ```
+
+## The generic JS host (reusable as-is)
+
+```js
+let mem; const dec = new TextDecoder(), enc = new TextEncoder();
+const cstr = p => { const b = new Uint8Array(mem.buffer); let e=p; while(b[e])e++; return dec.decode(b.subarray(p,e)); };
+const env = {
+  dom_mount:  (r,h) => { document.getElementById(cstr(r)).innerHTML = cstr(h); },
+  dom_patch:  (s,v) => { const el = document.querySelector('[data-s="'+cstr(s)+'"]'); if (el) el.textContent = cstr(v); },
+  list_insert:(c,k,h)=> { const li=document.createElement('li'); li.dataset.k=cstr(k); li.innerHTML=cstr(h); document.getElementById(cstr(c)).appendChild(li); },
+  list_remove:(c,k) => { const el=document.querySelector('#'+cstr(c)+' > [data-k="'+cstr(k)+'"]'); if (el) el.remove(); },
+  list_order: (c,csv)=> { const ct=document.getElementById(cstr(c)); for (const k of cstr(csv).split(',').filter(Boolean)) { const el=ct.querySelector('[data-k="'+k+'"]'); if (el) ct.appendChild(el); } },
+  // …your app's effect imports, e.g. api_vote, focus_input…
+};
+const wasi = { fd_write:()=>0, fd_seek:()=>0, fd_close:()=>0, fd_fdstat_get:()=>0 };  // no-op shim (see gotchas)
+const { instance } = await WebAssembly.instantiateStreaming(fetch('/app.wasm'), { env, wasi_snapshot_preview1: wasi });
+mem = instance.exports.memory; instance.exports._initialize?.();
+instance.exports.start();
+// write a string IN: const b=enc.encode(text); const p=Number(instance.exports.input_buf(BigInt(b.length))); new Uint8Array(mem.buffer).set(b,p); instance.exports.submit(BigInt(p));
+```
+
+## Build & verify (this environment)
+
+- `zig` is on PATH (`/snap/bin/zig`); `machin build --target wasm` uses it.
+- Serve over **http** (`python3 -m http.server`) — wasm won't load from `file://`.
+- **Screenshot** to verify rendering: `google-chrome --headless=new --screenshot=/tmp/x.png --window-size=W,H http://localhost:PORT/` then read the PNG. To exercise interaction, inject a small autopilot `<script>` (set an input's value + click) since there's no click injector.
+- Verify reactivity headlessly in **node**: instantiate `app.wasm` with stub imports that record `dom_patch`/`list_*` calls, drive the exports, and assert the patch list is minimal.
+
+## Gotchas (hard-won)
+
+- **No-op WASI stub:** the reactive runtime's indirect closure calls keep wasi-libc's
+  float-`snprintf` path, so the wasm imports `wasi_snapshot_preview1.{fd_write,fd_seek,fd_close,fd_fdstat_get}`. They're never *called* — provide the ~4 no-op stubs above.
+- **A function named like a builtin is a COMPILE ERROR** (`flush`/`keys`/`contains`/`len`/`str`/…). Rename it. (An `extern` may shadow — that's for FFI.)
+- **Lambdas have no named returns:** `func() (s) { s = x }` doesn't parse — use `func() { return x }`.
+- **Function scope, not block scope:** a variable used as two types across `if` branches conflicts; give each branch its own name.
+- **Package globals** (`var x = 0` at top level) hold a component's state across export calls (persist in the wasm instance); `=` assigns the global, `:=` shadows with a local.
+- **Closures over a loop variable** see its final value (captured by reference) — build per-item closures via a helper that takes the index as a *parameter* (fresh per call), not inside the loop.
+- **Two `extern "env"` blocks compose fine** (the runtime's DOM ops + your app's effect imports).
+- **Reactive signals are INT-only** — `reactive.src`'s `sval` is `[]int{}`, so `signal("")` fails to typecheck. Hold non-int state in globals; bump an int **version signal** (`set(ver, get(ver)+1)`) to trigger an outlet re-render.
+- **A NAMED function can't be passed as a value** — `route(r, "/", myHandler)` → "undefined variable". Wrap it in a closure: `route(r, "/", func(req){ return myHandler(req) })` (the router examples all pass inline closures for this reason).
+- **Slice literals must be `[]string{...}`**, not `[a,b]` — bare brackets parse as an *index* expression. Bound params to `sqlite_exec`/`sqlite_query` are `[]string{name, str(id)}`, never `[name, str(id)]`.
+- **`sqlite_query` returns a JSON ARRAY of rows** — `{"user":[{...}]}` not `{"user":{...}}`. And `json_get`'s path language does NOT compose `key[idx].field` (key → array index → field) — it returns err. For API responses use typed `parse(body, Struct{})` with a witness that mirrors the shape, e.g. `type Me struct { user []User }` → `parse(me, Me{})`.
+- **Returning values from `extern "env"` imports WORK** — `fn http_get(string) string` compiles *and* runs (first exercised by machin-wiki); the JS host returns a pointer into wasm linear memory. BUT the `alloc` builtin is NOT exported, so the host can't write the return string without a buffer-allocator export. See **Returning effect imports** below.
+- **SPA catch-all server routing** — `serve_router` does exact `METHOD PATH` match and 404s client-side routes (`/new`, `/page/slug`). Use `serve(port, handler)` with a catch-all instead: `if has_prefix(path,"/api/"){return dispatch(r,req)}`; `if path=="/app.wasm"{return wasm}`; `else return shell(req)` — so the wasm router hydrates the deep link.
+- **A trailing-slash API prefix** (`route(r,"/api/page/",…)`) won't exact-match `/api/page/home`. Handle the prefix path in the catch-all (`if has_prefix(path,"/api/page/"){return api_page(req)}`) *before* handing the rest to `dispatch`.
+- **Deep-link testing under headless Chrome** — `--dump-dom`/`--screenshot` return BEFORE the initial-navigation `setTimeout` fires; pass `--virtual-time-budget=2000` so the SPA's first navigate runs first, or you'll falsely see the home view.
+- **Host→wasm callbacks already work** — JS calling `instance.exports.on_event(ptr)` on any async event (SSE message, timer) is the SAME stack as a click handler; it is NOT the missing FFI-callback (Phase 4) gap. Composition, not a new feature.
+
+## Returning effect imports (HTTP from the wasm client)
+
+Existing demos never let the WASM client *initiate* a server call — JS caught the
+click, did the `fetch`, and fed the result back into MFL via a `load()` export. **Returning
+`extern "env"` imports invert that**: MFL says `data := http_get(url)` and uses the
+result inline (a synchronous XHR blocks under wasm). Two things must line up:
+
+```go
+// client.src — declare the imports to RETURN a value (never before exercised in a demo)
+extern "env" {
+    fn http_get(string) string          // returns response body as a string POINTER
+    fn http_post(string, string) string // (url, body) -> response body
+}
+
+// MUST export a buffer allocator: `alloc` is a builtin and is NOT exported by default,
+// so the JS host has nowhere to write the return string. Without this, returning
+// effect imports crash at runtime (instance.exports.alloc is not a function).
+export func alloc_export(n) (p) { p = alloc(n) }
+
+func fetch_page(slug) {
+    page_str = http_get("/api/page/" + slug)  // MFL drives the call, uses result inline
+    set(ver, get(ver) + 1)                     // int version signal bumps → outlet re-renders
+}
+```
+```js
+// host.js — the effect import writes the response into wasm memory and returns the pointer
+http_get: (urlPtr) => {
+  const b = enc.encode(cstr(urlPtr));  // sync XHR
+  const xhr = new XMLHttpRequest(); xhr.open('GET', cstr(urlPtr), false); xhr.send();
+  const r = enc.encode(xhr.responseText + '\0');
+  const p = Number(instance.exports.alloc_export(BigInt(r.length))); // ← the added export
+  new Uint8Array(mem.buffer).set(r, p); return p;
+},
+```
+This is the enabler for a wasm SPA that talks to its own server API — and the moment
+enough endpoints are hand-bridged, the boilerplate motivates a `machin gen-client`
+(typed RPC, the next north-star gap).
+
+## Recipe: a CRUD back-office (e.g. manage a users DB)
+
+1. **Schema** (`models.src`, shared): a `user_row(id, name, email) -> html` used by
+   both SSR and the client list item.
+2. **Server** (`server.src`): `sqlite_open("users.db")`, create the table; routes —
+   `GET /` SSR-renders the user list (matching `data-s` names so the client
+   hydrates), `GET /app.wasm` serves the client, `GET /api/users` returns rows as
+   JSON (`ok_json(json(parse(sqlite_query(...), []User{})))` or just the raw query
+   string), `POST /api/users` inserts (parse the body), `DELETE`/`POST /api/users/del`
+   removes. Use parameterized `sqlite_exec(db, sql, params)` — never string-concat SQL.
+   - **The POST body shape depends on the sender.** A `fetch` with a JSON body →
+     `parse(req.body, User{})` or `json_get`. A browser `<form>` (non-JS fallback, or
+     `Content-Type: application/x-www-form-urlencoded`) → the body is `name=Ada&email=a%40b`;
+     decode each field with the **`url_decode` builtin** (don't hand-roll it — a function
+     named `url_decode` is a compile error, it shadows the builtin). A tiny helper:
+     ```go
+     func form_field(body, key) (v) {           // body: "a=1&b=2"; key: "a"
+         for _, kv := range split(body, "&") {
+             eq := index(kv, "=")
+             if eq > 0 && substr(kv, 0, eq) == key { v = url_decode(substr(kv, eq+1, len(kv))) }
+         }
+     }
+     ```
+3. **Client** (`client.src`): signals hold the rows; `each` renders the table
+   (re-key on any mutable field); a **form** (`<input>` + `ptr_str`) adds a user and
+   `POST`s; row buttons toggle/delete and call the API. A `computed` shows the count.
+4. **Host** (`web/host.js`): the generic host + your `api_*` effect imports (each
+   does a `fetch`).
+5. **Build & screenshot** to verify.
+
+The state lives in machin; the server is the source of truth (SQLite); the client is
+reactive over the API. One binary, one language.
+
+> Worked implementation: [machin-web-demo-users](https://github.com/javimosch/machin-web-demo-users) — the exact app above, end to end. (For the *isomorphic* shape instead, see the boilerplate.)
+
+## Pointers
+
+- Runnable in-tree: [`examples/complex/sqlite_crud.mfl`](../../examples/complex/sqlite_crud.mfl) — the SQLite data layer end to end (open → parameterized insert → `parse([]User{})` → update/delete → JSON), no server, runs under `machin run`.
+- Frameworks: [`framework/machweb.src`](../../framework) · `reactive.src` · `router.src` · `flags.src`.
+- Boilerplate: [boilerplate-cli-ui-machin-isomorphic](https://github.com/javimosch/boilerplate-cli-ui-machin-isomorphic).
+- Focused demos: [machin-web-demo-wasm](https://github.com/javimosch/machin-web-demo-wasm) (the bridge) · [machin-web-demo-ssr](https://github.com/javimosch/machin-web-demo-ssr) (isomorphic SSR) · [machin-web-demo-reactive](https://github.com/javimosch/machin-web-demo-reactive) (signals/computed/lists/templating) · [machin-web-demo-todo](https://github.com/javimosch/machin-web-demo-todo) (forms / text input).
+- Direction & the dogfood record: [`docs/NORTH-STAR-WEB.md`](../../docs/NORTH-STAR-WEB.md).
+- The language itself: `machin guide`.

--- a/tools/sync-plugin-skills.sh
+++ b/tools/sync-plugin-skills.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Sync the Claude Code plugin's bundled skills from the canonical skills/ (which are
+# also embedded in the binary). Run after editing any skills/<name>/SKILL.md.
+set -e
+cd "$(dirname "$0")/.."
+for s in machin-start machin-web machin-backend machin-gamedev machin-deploy; do
+  mkdir -p "plugins/machin/skills/$s"
+  cp "skills/$s/SKILL.md" "plugins/machin/skills/$s/SKILL.md"
+done
+echo "synced 5 skills -> plugins/machin/skills/"


### PR DESCRIPTION
**Agent-native distribution at scale** — the move the signal readout pointed to (reach, not more supply).

Today machin's skills only fire where someone ran `machin skill install`. This makes the repo a **Claude Code plugin marketplace**, so *any* Claude Code user installs them in one command — an agent reaches for machin at the decision moment in any project.

## What

- `.claude-plugin/marketplace.json` (marketplace `machin`) + a `machin` plugin (`plugins/machin/`) bundling the 5 agent skills (machin-start + web/backend/gamedev/deploy).
- Install:
  ```
  /plugin marketplace add javimosch/machin
  /plugin install machin@machin
  ```
- Skills auto-activate by their `description` intent (same mechanism as personal `~/.claude/skills`).

## Correctness

- **`claude plugin validate .` → ✔ Validation passed** (the real Claude Code CLI), against the official manifest schema.
- Bundled skills are copies of the canonical `skills/` (the embedded source of truth); `tools/sync-plugin-skills.sh` resyncs them and **`TestPluginSkillsInSync`** fails the build if they drift.
- README documents the install. No version bump (Unreleased).

## Next (not in this PR)

Getting it *discoverable* — PRs to the community plugin/marketplace registries where people browse for Claude Code plugins, so this actually reaches agents/devs. And a v2 **MCP server** (executable `machin_run`/`scaffold`/`guide` tools) for non-Claude-Code agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)