### PR TITLE
builtin: exec(cmd) -> (exit_code, stdout, stderr) — capture subprocess output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **New builtin `exec(cmd) -> (exit_code, stdout, stderr)`** — run a shell command and
+  capture its output (unlike `system`, which returns only the exit code). Runs via
+  `/bin/sh` in a subshell with stdout/stderr redirected to temp files (no pipe-buffer
+  deadlock); multi-assign only (`code, out, err := exec(...)`). Unblocks SSH / mongodump
+  / gzip pipelines and any tool whose output you need — the gap from #277 (port
+  mongo-vault to MFL). Captured text is NUL-terminated; redirect binary output to a file
+  in the command.
+
 - **Claude Code plugin marketplace.** The repo is now a Claude Code marketplace
   (`.claude-plugin/marketplace.json`) shipping a `machin` plugin that bundles the 5
   agent skills (machin-start + web/backend/gamedev/deploy). Install in any project:

--- a/codegen.go
+++ b/codegen.go
@@ -941,6 +941,30 @@ static int64_t mfl_system(const char* cmd) {
     if (r == -1) return -1;
     return (int64_t)WEXITSTATUS(r);
 }
+/* run a shell command and capture its output: returns (exit_code, stdout, stderr).
+   The command runs via /bin/sh in a subshell with stdout/stderr redirected to temp
+   files (so there is no pipe-buffer deadlock), then both are read back. Captured
+   text is NUL-terminated — a command producing binary output should redirect it to
+   a file itself (e.g. mongodump --archive piped to gzip > out.gz). */
+typedef struct { int64_t code; char* out; char* err; } mfl_exec_result;
+static mfl_exec_result mfl_exec(const char* cmd) {
+    mfl_exec_result R; R.code = -1; R.out = mfl_dup(""); R.err = mfl_dup("");
+    char op[] = "/tmp/mfl-exec-XXXXXX", ep[] = "/tmp/mfl-exec-XXXXXX";
+    int fo = mkstemp(op); if (fo < 0) return R; close(fo);
+    int fe = mkstemp(ep); if (fe < 0) { unlink(op); return R; } close(fe);
+    size_t n = strlen(cmd) + strlen(op) + strlen(ep) + 16;
+    char* full = (char*)malloc(n);
+    if (full) {
+        snprintf(full, n, "( %s ) >%s 2>%s", cmd, op, ep);
+        int r = system(full);
+        R.code = (r == -1) ? -1 : (int64_t)WEXITSTATUS(r);
+        R.out = mfl_read_file(op);
+        R.err = mfl_read_file(ep);
+        free(full);
+    }
+    unlink(op); unlink(ep);
+    return R;
+}
 #endif
 
 /* copy n bytes into a fresh NUL-terminated arena string */
@@ -2799,6 +2823,8 @@ func multiRetBuiltinC(name string) (cfn, ctype string, fields []string, needsTLS
 		return "mfl_http_request", "mfl_http_result", []string{"status", "body", "err"}, true, true
 	case "json_get":
 		return "mfl_json_get", "mfl_json_result", []string{"value", "err"}, false, true
+	case "exec":
+		return "mfl_exec", "mfl_exec_result", []string{"code", "out", "err"}, false, true
 	}
 	return "", "", nil, false, false
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// exec(cmd) -> (exit_code, stdout, stderr): captures both streams separately and the
+// exit status. The dogfood gap from issue #277 (port mongo-vault to MFL).
+func TestExecBuiltin(t *testing.T) {
+	bin, err := os.CreateTemp("", "mfl-exec-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	src := `func main() {
+		code, out, err := exec("echo OUT; echo ERR 1>&2; exit 7")
+		println("c=" + str(code) + " o=" + trim(out) + " e=" + trim(err))
+	}`
+	if err := BuildBinary(&Program{Funcs: parseFuncs(t, src)}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	out, err := exec.Command(bin.Name()).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "c=7 o=OUT e=ERR" {
+		t.Fatalf("exec capture wrong: got %q, want %q", got, "c=7 o=OUT e=ERR")
+	}
+}

--- a/guide.go
+++ b/guide.go
@@ -142,6 +142,7 @@ func machinGuide() guideCatalog {
 			{"env", "(string) -> string", "environment variable (\"\" if unset)", "cli"},
 			{"exit", "(int) ->", "terminate the process with a status code", "cli"},
 			{"system", "(string) -> int", "run a shell command, return its exit code (-1 if unlaunchable). For process orchestration, e.g. spawning a detached daemon: system(\"./app serve >log 2>&1 &\")", "cli"},
+			{"exec", "(string) -> (int, string, string)", "run a shell command and CAPTURE its output -> (exit_code, stdout, stderr). MULTI-ASSIGN ONLY: code, out, err := exec(\"ssh host mongodump ...\"). Captured text is NUL-terminated (redirect binary output to a file in the command). For SSH/mongodump/gzip pipelines and any tool whose output you need", "cli"},
 			// time
 			{"now", "() -> int", "wall-clock Unix seconds", "time"},
 			{"now_ms", "() -> int", "wall-clock milliseconds", "time"},

--- a/types.go
+++ b/types.go
@@ -1508,6 +1508,8 @@ func (c *Checker) multiRetBuiltin(name string) (args []int, rets []int, ok bool)
 		return []int{c.cString, c.cString, newSliceSlot(c, c.cString), c.cString}, []int{c.cInt, c.cString, c.cString}, true
 	case "json_get":
 		return []int{c.cString, c.cString}, []int{c.cString, c.cString}, true
+	case "exec":
+		return []int{c.cString}, []int{c.cInt, c.cString, c.cString}, true
 	}
 	return nil, nil, false
 }
@@ -2377,6 +2379,8 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		return 0, fmt.Errorf("http_request returns 3 values; use: status, body, err := http_request(method, url, headers, body)")
 	case "json_get":
 		return 0, fmt.Errorf("json_get returns 2 values; use: value, err := json_get(json, path)")
+	case "exec":
+		return 0, fmt.Errorf("exec returns 3 values; use: code, out, err := exec(cmd)")
 	case "wss_open":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("wss_open: 1 arg (url string)")


### PR DESCRIPTION
Treats the blocking gap in **#277** (port [mongo-vault](https://github.com/javimosch/mongo-vault) to MFL).

`system()` returns only an exit code. **`exec(cmd) -> (exit_code, stdout, stderr)`** captures both streams *separately* + the exit status — which unblocks the entire backup pipeline (SSH + mongodump + gzip), and any tool whose output you need.

## Implementation
- Runs via `/bin/sh` in a **subshell with stdout/stderr redirected to temp files** (`( cmd ) >out 2>err`), then reads both back (reusing `mfl_read_file`). Temp files instead of pipes = no pipe-buffer deadlock on large/dual streams.
- Multi-assign only (`code, out, err := exec(...)`), wired like `http_get`/`json_get`. Single-value use is a clear typecheck error.
- **wasm-gated** alongside `system` (no subprocess in wasm).
- Captured text is NUL-terminated — a command producing binary output should redirect it to a file itself (the mongo-vault pattern: `mongodump --archive | gzip > out.gz`).

## Verified
`exec("echo OUT; echo ERR 1>&2; exit 7")` → `code=7, out="OUT", err="ERR"`; pipelines; missing command → 127 with stderr; single-value rejected. New `TestExecBuiltin`; full `go test .` green.

## Scope / next (per #277)
`exec` is the priority-1 gap and unblocks a clean-room **machin-db-vault** (db-agnostic). The tier-B `exec_stream` (for streaming 200 MB+ in memory) is *not* needed for the vault, since the binary dump is redirected to a file by the command — leaving only small status text to capture. Gzip/logging are polish. No version bump (Unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `exec` builtin for running shell commands and capturing the exit code, standard output, and standard error separately.
  * Supports multi-assignment usage like `code, out, err := exec(cmd)`.

* **Bug Fixes**
  * Improved command output handling to avoid deadlocks when capturing output.
  * Added clearer feedback when `exec` is used without destructuring its three return values.

* **Tests**
  * Added coverage to verify exit codes and separated stdout/stderr capture work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->