### PR TITLE
release: v0.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.83.0
 
 - **New builtin `exec(cmd) -> (exit_code, stdout, stderr)`** — run a shell command and
   capture its output (unlike `system`, which returns only the exit code). Runs via
@@ -18,6 +18,12 @@
   `machin skill install` was run. Bundled skills are kept identical to the canonical
   `skills/` (the embedded source of truth) by `tools/sync-plugin-skills.sh`, guarded by
   a test; manifest validated with `claude plugin validate`.
+
+- **wasm: unbuffer stdout/stderr.** A `wasm32-wasi` reactor module has no `exit()` to
+  flush stdio, so output from an exported function was lost on return (only the first of
+  several `println`s came through). A constructor now sets stdout/stderr unbuffered for
+  the wasm target at `_initialize`; native keeps normal buffering. Surfaced building the
+  browser playground.
 
 ## v0.82.0
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.82.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.83.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.82.0"
+const machinVersion = "0.83.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
## v0.83.0

**Headline — new builtin `exec(cmd) -> (exit_code, stdout, stderr)`** (#278): run a shell command and capture its output (unlike `system`, which returns only the exit code). Multi-assign only (`code, out, err := exec(...)`); runs via `/bin/sh` in a subshell with stdout/stderr redirected to temp files (no pipe-buffer deadlock). Unblocks SSH / mongodump / pg_dump / gzip pipelines (the gap from #277) — and is the builtin **machin-vault** is built on.

Also rolled in since v0.82.0:
- **Claude Code plugin marketplace** (#276) — the repo is a marketplace shipping a `machin` plugin bundling the 5 agent skills.
- **wasm: unbuffer stdout/stderr** (#274) — reactor modules now flush every `println` (output was lost on export return).

Bumps `machinVersion` 0.82.0 → 0.83.0 and the README badge; rolls CHANGELOG Unreleased into v0.83.0. `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)