### PR TITLE
keccak256 + secp256k1 signing — EIP-712's missing primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- **`keccak256` + secp256k1 signing — the primitives EIP-712/Ethereum-style signing
+  needs.** New builtins: `keccak256(bytes) -> bytes` (Ethereum's hash — a self-contained
+  Keccak-f[1600] sponge, distinct from NIST SHA3-256's padding), `secp256k1_pubkey(bytes)
+  -> bytes` (65-byte uncompressed pubkey from a 32-byte private key), `secp256k1_sign_recoverable(bytes,
+  bytes) -> bytes` (priv32, hash32 -> 65-byte r||s||v, EIP-2 canonical low-S, v as 27/28),
+  and `secp256k1_recover(bytes, bytes) -> bytes` (hash32, sig65 -> the recovered pubkey,
+  same math as Solidity's `ecrecover`). Implemented over OpenSSL's generic EC API
+  (`NID_secp256k1`, already linked via `-lcrypto` — no new dependency); OpenSSL has no
+  recoverable-ECDSA entry point, so the recovery id is derived by testing both y-parities
+  of R and matching the resulting candidate pubkey, the standard technique for signers
+  that don't link a dedicated secp256k1 library. Verified against the known-vector G point
+  (priv=1), the two published Keccak-256 test vectors, and a signature produced
+  independently by Python's `coincurve` (a real libsecp256k1 binding — a different
+  codebase than OpenSSL, ruling out curve/recovery-math bugs a self-consistent
+  OpenSSL-only round trip could hide). New `eip712-sign` guide idiom; a full EIP-712 ABI
+  encoder is not a builtin (see the `eip712-uint256` gotcha — MFL's 64-bit `int` can't
+  hold Solidity `uint256` fields, encode those as 32-byte `bytes` by hand). Driven by
+  javika-machin's `printer`, whose Polymarket order signer was blocked on exactly this
+  (MFL had `sha256`/`hmac_sha256` but no keccak/secp256k1).
+
 ## v0.87.0
 
 - **`machin guide` now enumerates the CLI — a structured `commands` section.** The catalog

--- a/SPEC.md
+++ b/SPEC.md
@@ -306,6 +306,10 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 | `aes_cbc_decrypt` | `(bytes, bytes, bytes) -> bytes` | AES-CBC decrypt → plaintext (empty on bad padding) |
 | `xeddsa_sign` | `(bytes, bytes, bytes) -> bytes` | XEdDSA signature over Curve25519 `(priv32, msg, random64)` → 64 bytes (Signal/WhatsApp identity signatures); links libsodium |
 | `xeddsa_verify` | `(bytes, bytes, bytes) -> bool` | XEdDSA verify `(curve25519 pub32, msg, sig64)`; links libsodium |
+| `keccak256` | `(bytes) -> bytes` | Keccak-256 (Ethereum's hash — NOT NIST SHA3-256, different padding) → 32-byte digest |
+| `secp256k1_pubkey` | `(bytes) -> bytes` | secp256k1 public key from a 32-byte private key → 65-byte uncompressed point (`0x04‖X‖Y`) |
+| `secp256k1_sign_recoverable` | `(bytes, bytes) -> bytes` | secp256k1 ECDSA sign `(priv32, hash32)` → 65-byte `r‖s‖v` (EIP-2 canonical low-S; `v` is 27/28) |
+| `secp256k1_recover` | `(bytes, bytes) -> bytes` | secp256k1 ECDSA recover `(hash32, sig65)` → the 65-byte uncompressed pubkey (empty `bytes` if invalid); same math as Solidity's `ecrecover` |
 | `url_encode` | `(string) -> string` | percent-encode for URLs (RFC 3986: keeps `A-Za-z0-9-._~`, encodes the rest, space → `%20`) |
 | `url_decode` | `(string) -> string` | percent-decode a URL component (lenient: `+` → space, malformed `%XX` passes through) |
 | `sha256` | `(string) -> string` | SHA-256 of text, lowercase hex |

--- a/codegen.go
+++ b/codegen.go
@@ -1970,6 +1970,10 @@ const cryptoRuntime = `#include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
 #include <openssl/kdf.h>
+#include <openssl/ec.h>
+#include <openssl/ecdsa.h>
+#include <openssl/obj_mac.h>
+#include <string.h>
 
 static mfl_bytes mfl_crypto_buf(int64_t n) {
     mfl_bytes b; b.len = n < 0 ? 0 : n; b.data = (uint8_t*)mfl_alloc(b.len ? b.len : 1); return b;
@@ -2126,6 +2130,223 @@ static mfl_bytes mfl_crypto_aes_cbc_dec(mfl_bytes key, mfl_bytes iv, mfl_bytes c
         if (EVP_DecryptFinal_ex(c, out.data + t, &l) > 0) out.len = t + l;  /* else 0: bad pad */
     }
     if (c) EVP_CIPHER_CTX_free(c);
+    return out;
+}
+
+/* Keccak-256 (Ethereum's hash; NOT the NIST SHA3-256 final standard — the
+   sponge padding domain byte differs: 0x01 here vs SHA3's 0x06). Compact
+   Keccak-f[1600] permutation + sponge construction, little-endian hosts only
+   (x86_64/arm64 — the only targets machin builds for). */
+static const uint64_t mfl_keccakf_rndc[24] = {
+    0x0000000000000001ULL, 0x0000000000008082ULL, 0x800000000000808aULL,
+    0x8000000080008000ULL, 0x000000000000808bULL, 0x0000000080000001ULL,
+    0x8000000080008081ULL, 0x8000000000008009ULL, 0x000000000000008aULL,
+    0x0000000000000088ULL, 0x0000000080008009ULL, 0x000000008000000aULL,
+    0x000000008000808bULL, 0x800000000000008bULL, 0x8000000000008089ULL,
+    0x8000000000008003ULL, 0x8000000000008002ULL, 0x8000000000000080ULL,
+    0x000000000000800aULL, 0x800000008000000aULL, 0x8000000080008081ULL,
+    0x8000000000008080ULL, 0x0000000080000001ULL, 0x8000000080008008ULL
+};
+static const int mfl_keccakf_rotc[24] = {
+    1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14,
+    27, 41, 56, 8, 25, 43, 62, 18, 39, 61, 20, 44
+};
+static const int mfl_keccakf_piln[24] = {
+    10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4,
+    15, 23, 19, 13, 12, 2, 20, 14, 22, 9, 6, 1
+};
+static uint64_t mfl_rotl64(uint64_t x, int y) { return (x << y) | (x >> (64 - y)); }
+static void mfl_keccakf(uint64_t st[25]) {
+    int i, j, r;
+    uint64_t t, bc[5];
+    for (r = 0; r < 24; r++) {
+        for (i = 0; i < 5; i++) bc[i] = st[i] ^ st[i+5] ^ st[i+10] ^ st[i+15] ^ st[i+20];
+        for (i = 0; i < 5; i++) {
+            t = bc[(i+4)%5] ^ mfl_rotl64(bc[(i+1)%5], 1);
+            for (j = 0; j < 25; j += 5) st[j+i] ^= t;
+        }
+        t = st[1];
+        for (i = 0; i < 24; i++) {
+            j = mfl_keccakf_piln[i];
+            bc[0] = st[j];
+            st[j] = mfl_rotl64(t, mfl_keccakf_rotc[i]);
+            t = bc[0];
+        }
+        for (j = 0; j < 25; j += 5) {
+            for (i = 0; i < 5; i++) bc[i] = st[j+i];
+            for (i = 0; i < 5; i++) st[j+i] ^= (~bc[(i+1)%5]) & bc[(i+2)%5];
+        }
+        st[0] ^= mfl_keccakf_rndc[r];
+    }
+}
+static void mfl_keccak256_raw(const uint8_t* in, size_t inlen, uint8_t out[32]) {
+    uint64_t st[25];
+    const size_t rate = 136; /* 1088-bit rate for a 256-bit Keccak (512-bit capacity) */
+    uint8_t* stb = (uint8_t*)st;
+    size_t i;
+    memset(st, 0, sizeof(st));
+    while (inlen >= rate) {
+        for (i = 0; i < rate; i++) stb[i] ^= in[i];
+        mfl_keccakf(st);
+        in += rate; inlen -= rate;
+    }
+    {
+        uint8_t tmp[136];
+        memset(tmp, 0, rate);
+        memcpy(tmp, in, inlen);
+        tmp[inlen] |= 0x01;      /* Keccak domain byte (SHA3 final uses 0x06) */
+        tmp[rate - 1] |= 0x80;   /* pad10*1 end bit; ORs into the same byte when inlen==rate-1 */
+        for (i = 0; i < rate; i++) stb[i] ^= tmp[i];
+        mfl_keccakf(st);
+    }
+    memcpy(out, stb, 32);
+}
+static mfl_bytes mfl_crypto_keccak256(mfl_bytes m) {
+    mfl_bytes out = mfl_crypto_buf(32);
+    mfl_keccak256_raw(m.data, (size_t)m.len, out.data);
+    return out;
+}
+
+/* secp256k1 (Ethereum signing) over OpenSSL's generic EC API (NID_secp256k1).
+   OpenSSL has no recoverable-ECDSA entry point, so the recovery id (v) is
+   derived by trying both y-parities of R and matching the resulting candidate
+   public key against the real one — the standard technique for signers that
+   don't link a dedicated secp256k1 library. Signatures are EIP-2 canonical
+   (low-S); v is returned as 27/28 (ecrecover convention). */
+static EC_POINT* mfl_secp256k1_recover_point(const EC_GROUP* group, BN_CTX* ctx, const BIGNUM* order,
+                                              const BIGNUM* r, const BIGNUM* s, const uint8_t* hash32, int recId) {
+    if (BN_is_zero(r) || BN_cmp(r, order) >= 0 || BN_is_zero(s) || BN_cmp(s, order) >= 0) return NULL;
+    EC_POINT* R = EC_POINT_new(group);
+    if (!R) return NULL;
+    if (EC_POINT_set_compressed_coordinates(group, R, r, recId & 1, ctx) != 1 ||
+        EC_POINT_is_on_curve(group, R, ctx) != 1) {
+        EC_POINT_free(R);
+        return NULL;
+    }
+    BIGNUM* z = BN_bin2bn(hash32, 32, NULL);
+    BIGNUM* rInv = z ? BN_mod_inverse(NULL, r, order, ctx) : NULL;
+    BIGNUM* tmp = BN_new();
+    BIGNUM* zero = BN_new();
+    BIGNUM* u1 = BN_new();
+    BIGNUM* u2 = BN_new();
+    EC_POINT* Q = EC_POINT_new(group);
+    int ok = 0;
+    if (z && rInv && tmp && zero && u1 && u2 && Q) {
+        BN_zero(zero);
+        ok = BN_mod_mul(tmp, z, rInv, order, ctx) == 1 &&      /* tmp = z*r^-1 mod n      */
+             BN_mod_sub(u1, zero, tmp, order, ctx) == 1 &&     /* u1  = -z*r^-1 mod n     */
+             BN_mod_mul(u2, s, rInv, order, ctx) == 1 &&       /* u2  = s*r^-1 mod n      */
+             EC_POINT_mul(group, Q, u1, R, u2, ctx) == 1;      /* Q   = u1*G + u2*R       */
+    }
+    EC_POINT_free(R);
+    if (z) BN_free(z);
+    if (rInv) BN_free(rInv);
+    if (tmp) BN_free(tmp);
+    if (zero) BN_free(zero);
+    if (u1) BN_free(u1);
+    if (u2) BN_free(u2);
+    if (!ok) { if (Q) EC_POINT_free(Q); return NULL; }
+    return Q;
+}
+static mfl_bytes mfl_crypto_secp256k1_pubkey(mfl_bytes priv) {
+    mfl_bytes out = mfl_crypto_buf(65); out.len = 0;
+    if (priv.len != 32) return out;
+    EC_GROUP* group = EC_GROUP_new_by_curve_name(NID_secp256k1);
+    BN_CTX* ctx = BN_CTX_new();
+    BIGNUM* d = BN_bin2bn(priv.data, 32, NULL);
+    EC_POINT* Q = group ? EC_POINT_new(group) : NULL;
+    if (group && ctx && d && Q && EC_POINT_mul(group, Q, d, NULL, NULL, ctx) == 1) {
+        size_t n = EC_POINT_point2oct(group, Q, POINT_CONVERSION_UNCOMPRESSED, out.data, 65, ctx);
+        if (n == 65) out.len = 65;
+    }
+    if (Q) EC_POINT_free(Q);
+    if (d) BN_free(d);
+    if (ctx) BN_CTX_free(ctx);
+    if (group) EC_GROUP_free(group);
+    return out;
+}
+static mfl_bytes mfl_crypto_secp256k1_sign_recoverable(mfl_bytes priv, mfl_bytes hash) {
+    mfl_bytes out = mfl_crypto_buf(65); out.len = 0;
+    if (priv.len != 32 || hash.len != 32) return out;
+    EC_GROUP* group = EC_GROUP_new_by_curve_name(NID_secp256k1);
+    BN_CTX* ctx = BN_CTX_new();
+    EC_KEY* eckey = EC_KEY_new();
+    BIGNUM* d = BN_bin2bn(priv.data, 32, NULL);
+    BIGNUM* order = BN_new();
+    EC_POINT* Qreal = group ? EC_POINT_new(group) : NULL;
+    ECDSA_SIG* sig = NULL;
+
+    if (group && ctx && eckey && d && order && Qreal &&
+        EC_KEY_set_group(eckey, group) == 1 &&
+        EC_KEY_set_private_key(eckey, d) == 1 &&
+        EC_GROUP_get_order(group, order, ctx) == 1 &&
+        EC_POINT_mul(group, Qreal, d, NULL, NULL, ctx) == 1 &&
+        EC_KEY_set_public_key(eckey, Qreal) == 1) {
+        sig = ECDSA_do_sign(hash.data, 32, eckey);
+    }
+    if (sig) {
+        const BIGNUM *r0, *s0;
+        ECDSA_SIG_get0(sig, &r0, &s0);
+        BIGNUM* r = BN_dup(r0);
+        BIGNUM* s = BN_dup(s0);
+        BIGNUM* half = BN_new();
+        if (r && s && half) {
+            BN_rshift1(half, order);
+            if (BN_cmp(s, half) > 0) BN_sub(s, order, s); /* EIP-2 canonical low-S */
+            EC_POINT* Qmatch = NULL;
+            int cand;
+            for (cand = 0; cand < 2 && !Qmatch; cand++) {
+                EC_POINT* Qtry = mfl_secp256k1_recover_point(group, ctx, order, r, s, hash.data, cand);
+                if (!Qtry) continue;
+                if (EC_POINT_cmp(group, Qtry, Qreal, ctx) == 0) {
+                    Qmatch = Qtry;
+                    if (BN_bn2binpad(r, out.data, 32) == 32 && BN_bn2binpad(s, out.data + 32, 32) == 32) {
+                        out.data[64] = (uint8_t)(27 + cand);
+                        out.len = 65;
+                    }
+                } else {
+                    EC_POINT_free(Qtry);
+                }
+            }
+            if (Qmatch) EC_POINT_free(Qmatch);
+        }
+        if (half) BN_free(half);
+        if (r) BN_free(r);
+        if (s) BN_free(s);
+        ECDSA_SIG_free(sig);
+    }
+    if (Qreal) EC_POINT_free(Qreal);
+    if (order) BN_free(order);
+    if (d) BN_free(d);
+    if (eckey) EC_KEY_free(eckey);
+    if (ctx) BN_CTX_free(ctx);
+    if (group) EC_GROUP_free(group);
+    return out;
+}
+static mfl_bytes mfl_crypto_secp256k1_recover(mfl_bytes hash, mfl_bytes sig) {
+    mfl_bytes out = mfl_crypto_buf(65); out.len = 0;
+    if (hash.len != 32 || sig.len != 65) return out;
+    int v = sig.data[64];
+    int recId = (v == 27 || v == 28) ? v - 27 : v;
+    if (recId != 0 && recId != 1) return out;
+    EC_GROUP* group = EC_GROUP_new_by_curve_name(NID_secp256k1);
+    BN_CTX* ctx = BN_CTX_new();
+    BIGNUM* order = BN_new();
+    BIGNUM* r = BN_bin2bn(sig.data, 32, NULL);
+    BIGNUM* s = BN_bin2bn(sig.data + 32, 32, NULL);
+    if (group && ctx && order && r && s && EC_GROUP_get_order(group, order, ctx) == 1) {
+        EC_POINT* Q = mfl_secp256k1_recover_point(group, ctx, order, r, s, hash.data, recId);
+        if (Q) {
+            size_t n = EC_POINT_point2oct(group, Q, POINT_CONVERSION_UNCOMPRESSED, out.data, 65, ctx);
+            if (n == 65) out.len = 65;
+            EC_POINT_free(Q);
+        }
+    }
+    if (r) BN_free(r);
+    if (s) BN_free(s);
+    if (order) BN_free(order);
+    if (ctx) BN_CTX_free(ctx);
+    if (group) EC_GROUP_free(group);
     return out;
 }
 `
@@ -3990,6 +4211,18 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "xeddsa_verify":
 		g.usesXEdDSA = true
 		return fmt.Sprintf("mfl_xeddsa_verify(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "keccak256":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_keccak256(%s)", args[0]), nil
+	case "secp256k1_pubkey":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_secp256k1_pubkey(%s)", args[0]), nil
+	case "secp256k1_sign_recoverable":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_secp256k1_sign_recoverable(%s, %s)", args[0], args[1]), nil
+	case "secp256k1_recover":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_secp256k1_recover(%s, %s)", args[0], args[1]), nil
 	case "has":
 		ik, sk := g.mapKeyArgs(ex.Args[0], args[1])
 		return fmt.Sprintf("mfl_map_has(%s, %s, %s)", args[0], ik, sk), nil

--- a/guide.go
+++ b/guide.go
@@ -257,6 +257,10 @@ func machinGuide() guideCatalog {
 			{"aes_cbc_decrypt", "(bytes, bytes, bytes) -> bytes", "AES-CBC decrypt (key, iv, ciphertext) -> plaintext (empty on bad padding)", "crypto"},
 			{"xeddsa_sign", "(bytes, bytes, bytes) -> bytes", "XEdDSA sign over Curve25519 (priv32, msg, random64) -> 64-byte sig (Signal/WhatsApp identity sigs); needs libsodium", "crypto"},
 			{"xeddsa_verify", "(bytes, bytes, bytes) -> bool", "XEdDSA verify (curve25519 pub32, msg, sig64); needs libsodium", "crypto"},
+			{"keccak256", "(bytes) -> bytes", "Keccak-256 (Ethereum's hash — NOT NIST SHA3-256, different padding) -> 32-byte digest; for EIP-712/tx hashing", "crypto"},
+			{"secp256k1_pubkey", "(bytes) -> bytes", "secp256k1 public key from a 32-byte private key -> 65-byte uncompressed point (0x04||X||Y); an Ethereum address is the last 20 bytes of keccak256(pub[1:])", "crypto"},
+			{"secp256k1_sign_recoverable", "(bytes, bytes) -> bytes", "secp256k1 ECDSA sign (priv32, hash32) -> 65-byte r||s||v (EIP-2 canonical low-S; v is 27/28) — the primitive behind eth_sign/EIP-712/raw tx signing", "crypto"},
+			{"secp256k1_recover", "(bytes, bytes) -> bytes", "secp256k1 ECDSA recover (hash32, sig65 r||s||v) -> the 65-byte uncompressed public key (empty bytes if invalid) — same math Solidity's ecrecover uses, for self-checking a signature before broadcasting it", "crypto"},
 			// sqlite (libsqlite3, linked only when used)
 			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
 			{"sqlite_exec", "(int, string[, []string]) -> int", "run SQL with no result; optional []string binds the ? params (injection-safe); 0 ok", "db"},
@@ -334,6 +338,12 @@ func main() { println(str(id(42)) + " " + id("hi")) }`},
 	println(str(total)) }`},
 			{"ffi-extern", `extern "m" { cflags "-lm" header "math.h" fn sqrt(float) float }
 func main() { println(str(sqrt(2.0))) }`},
+			{"eip712-sign", `func eip712_digest(domainSeparator, structHash) (h) { prefix := from_hex("1901")  h = keccak256(bytes_concat(bytes_concat(prefix, domainSeparator), structHash)) }
+func main() { priv := rand_bytes(32)  pub := secp256k1_pubkey(priv)
+	domainSeparator := keccak256(bytes("name:MyApp,chainId:1"))  structHash := keccak256(bytes("Mail(string contents)hello"))
+	digest := eip712_digest(domainSeparator, structHash)
+	sig := secp256k1_sign_recoverable(priv, digest)
+	println(to_hex(secp256k1_recover(digest, sig)) == to_hex(pub)) }`},
 		},
 		Gotchas: []guideNote{
 			{"struct-value-semantics", "Structs are VALUE types: passing or assigning one copies it, so a function cannot mutate a caller's struct (and a builder must return the updated struct). For shared mutable state use a map — a reference type, so m[k]=v survives the holder being passed by value (see framework/flags.src)."},
@@ -357,6 +367,7 @@ func main() { println(str(sqrt(2.0))) }`},
 			{"channels-cross-goroutine", "Values sent over a channel are deep-copied across the goroutine/arena boundary (strings fast; slices/maps/structs via JSON), so they survive the sender goroutine. Channels of closures/funcs are not deep-copied."},
 			{"select-closed", "A closed channel makes its select receive case ready, firing repeatedly (with ok==false if you wrote `case v, ok := <-ch:`). Detect close and stop selecting on it."},
 			{"no-tls-without-https", "There is no raw TLS socket; use https_get/https_post (REST) and wss_* (WebSocket). Plain dial/listen are TCP without TLS."},
+			{"eip712-uint256", "keccak256/secp256k1_pubkey/secp256k1_sign_recoverable/secp256k1_recover give the primitives for Ethereum-style signing (EIP-712 typed data, eth_sign, raw tx signing), but a full EIP-712 ABI encoder is NOT a builtin — you assemble domainSeparator/structHash by hand from keccak256 + bytes_concat (see the eip712-sign idiom). The real gap: Solidity `uint256` struct fields (token IDs, amounts, salts) routinely exceed MFL's 64-bit `int`, so encode them as 32-byte big-endian `bytes` (from a hex string the caller already has, e.g. from an API) rather than as `int` — MFL has no builtin decimal-string-to-bytes32 bignum conversion. An Ethereum address is the last 20 bytes of keccak256(pub[1:]) (pub is the 65-byte uncompressed key, so skip its 0x04 prefix first — bytes_sub(pub, 1, 65))."},
 			{"floats-over-chan-json", "A slice/map channel element round-trips through JSON, which formats floats with %g (not bit-exact for pathological doubles)."},
 			{"memory", "Per-goroutine arena, reclaimed in bulk when the goroutine returns; wrap a hot allocating loop in `arena { ... }` to keep peak memory flat. Build with --safe for bounds/overflow/div-zero checks."},
 			{"wasm-target", "`machin build app.mfl --target wasm` compiles to a WebAssembly reactor module (needs `zig` as the C->wasm compiler; override with ZIG=). Mark host-callable functions `export func name(...)` — they become wasm exports under their clean name (and are reachability roots, so a wasm module needs no main). A headerless `extern \"env\" { fn dom_set(string) }` becomes a wasm IMPORT the JS host supplies (the `extern \"<lib>\"` name is the import module). Marshaling host-side: machin ints are i64 -> pass/return BigInt; strings are a pointer into the exported `memory` (decode NUL-terminated UTF-8). App state can live in machin via package globals (`var count = 0`), which persist across export calls. See docs/NORTH-STAR-WEB.md."},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -822,6 +822,63 @@ func TestCrypto(t *testing.T) {
 	}
 }
 
+// Keccak-256 (Ethereum's hash, distinct from NIST SHA3-256) against the two
+// canonical published test vectors.
+func TestKeccak256(t *testing.T) {
+	main := `func main() {
+	println(to_hex(keccak256(bytes(""))))
+	println(to_hex(keccak256(bytes("abc"))))
+}`
+	out, _ := buildRun(t, main)
+	want := "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\n" +
+		"4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45\n"
+	if out != want {
+		t.Fatalf("keccak256: got %q, want %q", out, want)
+	}
+}
+
+// secp256k1 (Ethereum signing): pubkey derivation against the well-known
+// generator-point vector (priv=1 -> pub=G), a cross-check against a signature
+// independently produced by Python's coincurve (a real libsecp256k1 binding —
+// a different codebase than OpenSSL, so this catches curve/recovery-math bugs
+// a self-consistent OpenSSL-only round trip could hide), and a self round-trip
+// (sign then recover reproduces the signer's own pubkey).
+func TestSecp256k1(t *testing.T) {
+	main := `func main() {
+	// priv=1 -> pub is the secp256k1 generator point G (a public constant)
+	g := secp256k1_pubkey(from_hex("0000000000000000000000000000000000000000000000000000000000000001"))
+	println(to_hex(g))
+
+	// cross-check vs a signature generated independently by Python coincurve/libsecp256k1
+	priv := from_hex("307fb3b1869f707a2ca5136904ed3c1de1d5ce097b493de4f303d9adcf07b748")
+	expectedPub := "042a9d3210951b9765dbab10f8e846b4d1835053c2e58dfcf41cfe437d03e7ca0740289a468bbb05ec363aeafd881a3b2ba9d38d37f402366993d9ddb026ea4887"
+	println(to_hex(secp256k1_pubkey(priv)) == expectedPub)
+	hash := from_hex("da8f53d107c2678f816c59ae65d92a666e1aa8377fb97ba3854607860e80bc7f")
+	rs := from_hex("36878653aa09d6e72d2cd43574b1e4324268765645d9b7393888d72f8c69d93f28e99499d061809b07adcd0bb75491ea7dac64851705053315af742ce46b35b4")
+	sig := bytes_concat(rs, from_hex("1b"))
+	println(to_hex(secp256k1_recover(hash, sig)) == expectedPub)
+
+	// self round-trip: sign with a fresh random key, recover reproduces the pubkey
+	p2 := rand_bytes(32)
+	pub2 := secp256k1_pubkey(p2)
+	msg := keccak256(bytes("machin eip712 self-test"))
+	sig2 := secp256k1_sign_recoverable(p2, msg)
+	println(str(len(sig2)))
+	v := byte_at(sig2, 64)
+	println(v == 27 || v == 28)
+	println(to_hex(secp256k1_recover(msg, sig2)) == to_hex(pub2))
+
+	// a bad signature must not recover (empty bytes, not a garbage point)
+	println(str(len(secp256k1_recover(msg, from_hex("00")))))
+}`
+	out, _ := buildRun(t, main)
+	want := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8\n" +
+		"true\ntrue\n65\ntrue\ntrue\n0\n"
+	if out != want {
+		t.Fatalf("secp256k1: got %q, want %q", out, want)
+	}
+}
+
 // XEdDSA (Curve25519 signatures) is gated like the other external runtimes:
 // emitted only when xeddsa_* is used. Compile-level (linking needs libsodium-dev,
 // so the behavioral check lives in machin-signal/machin-wapair, not the suite).

--- a/types.go
+++ b/types.go
@@ -1793,13 +1793,13 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return c.cBytes, nil
-	case "sha256_bytes", "sha1_bytes", "x25519_pub", "ed25519_pub":
+	case "sha256_bytes", "sha1_bytes", "x25519_pub", "ed25519_pub", "keccak256", "secp256k1_pubkey":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("%s: 1 arg (bytes)", ex.Callee)
 		}
 		c.addPair(argSlots[0], c.cBytes)
 		return c.cBytes, nil
-	case "hmac_sha256_bytes", "x25519_shared", "ed25519_sign":
+	case "hmac_sha256_bytes", "x25519_shared", "ed25519_sign", "secp256k1_sign_recoverable", "secp256k1_recover":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("%s: 2 args (bytes, bytes)", ex.Callee)
 		}


### PR DESCRIPTION
## Summary
- Adds `keccak256(bytes) -> bytes`, `secp256k1_pubkey(bytes) -> bytes`, `secp256k1_sign_recoverable(bytes, bytes) -> bytes`, and `secp256k1_recover(bytes, bytes) -> bytes` — the primitives Ethereum-style signing (EIP-712 typed data, `eth_sign`, raw tx signing) needs.
- Keccak-256 is a self-contained Keccak-f[1600] sponge (Ethereum's variant, distinct from NIST SHA3-256's padding domain byte). secp256k1 is implemented over OpenSSL's generic EC API (`NID_secp256k1`) — reuses the existing `-lcrypto` dependency, no new library. OpenSSL has no recoverable-ECDSA entry point, so the recovery id is derived by testing both y-parities of R and matching the candidate pubkey against the real one (the standard technique for signers that don't link a dedicated secp256k1 library). Signatures are EIP-2 canonical (low-S); `v` is returned as 27/28.
- Motivated by `javika-machin`'s `printer` (Phase 1 order execution), whose Polymarket CLOB signer was explicitly blocked on this: MFL had `sha256`/`hmac_sha256` (enough for API auth headers) but not keccak/secp256k1, so it couldn't produce the EIP-712 signature in pure MFL.
- New `eip712-sign` guide idiom + `eip712-uint256` gotcha (MFL's 64-bit `int` can't hold Solidity `uint256` struct fields — a full ABI encoder is a follow-up, not this PR).

## Test plan
- [x] `go build ./...` clean
- [x] `go test .` full suite passes (incl. new `TestKeccak256`/`TestSecp256k1`)
- [x] `keccak256` matches the two published Keccak-256 test vectors ("" and "abc")
- [x] `secp256k1_pubkey(priv=1)` matches the well-known secp256k1 generator point G
- [x] Cross-checked against a signature produced independently by Python's `coincurve` (a real libsecp256k1 binding, not OpenSSL) — pubkey derivation and recovery both match exactly
- [x] Self round-trip (sign → recover reproduces the signer's own pubkey) with a random key
- [x] `TestGuideBuiltinsRecognized` / `TestGuideIdiomsCompile` pass (catalog + new idiom stay honest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)