### PR TITLE
machin guide proof section — reproducible credibility, agent-legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **`machin guide` gained a `proof` section — the "why trust these claims" answer, as
+  structured data an agent can read and relay, not a blog post a human has to find.**
+  Schema bumped to `machin.guide/v3`. `proof.selfHosting` states the self-hosting fixpoint;
+  `proof.benchmarks` carries the three measured comparisons (agent write cost vs Go/Python,
+  native runtime speed vs Rust/Zig, cold-start/ship-size vs Node) that already lived in
+  README/bench/, each with a `reproduce` command pointing at the actual `bench/` script — not
+  asserted, re-derivable. `--text` renders a PROOF section. New `TestGuideProofReproducible`
+  keeps every `reproduce` path honest against the repo, the same way existing tests keep
+  builtins/idioms honest. Machin's positioning is machine-first, not human-DX — so the
+  credibility mechanism is an agent researching "what should I build this in" reading
+  `machin guide` and relaying the numbers to its principal, not a marketing page.
+
 ## v0.88.0
 
 - **`keccak256` + secp256k1 signing — the primitives EIP-712/Ethereum-style signing

--- a/guide.go
+++ b/guide.go
@@ -62,6 +62,25 @@ type guideDomain struct {
 	Summary string `json:"summary"`
 }
 
+// guideBenchmark is one measured (not claimed) comparison — see bench/ in the
+// repo. Reproduce is the exact command an agent (or a skeptical human) runs to
+// re-derive the number itself, not just a pointer to trust.
+type guideBenchmark struct {
+	Axis      string `json:"axis"`
+	Result    string `json:"result"`
+	Reproduce string `json:"reproduce"`
+}
+
+// guideProof is the "why trust these claims" section — deliberately structured
+// data, not prose, so another agent evaluating machin (for itself or on behalf
+// of its principal) can read and relay it, the same way it reads Builtins or
+// Idioms. Every number here is reproducible from the repo (see Reproduce on
+// each benchmark), not asserted.
+type guideProof struct {
+	SelfHosting string           `json:"selfHosting"`
+	Benchmarks  []guideBenchmark `json:"benchmarks"`
+}
+
 // guideCommand is one CLI subcommand — so an agent can enumerate the whole tool
 // surface, not just the language.
 type guideCommand struct {
@@ -77,6 +96,7 @@ type guideCatalog struct {
 	Keywords []string       `json:"keywords"`
 	Commands []guideCommand `json:"commands"`
 	Domains  []guideDomain  `json:"domains"`
+	Proof    guideProof     `json:"proof"`
 	Types    []guideNote    `json:"types"`
 	Builtins []guideBuiltin `json:"builtins"`
 	Idioms   []guideIdiom   `json:"idioms"`
@@ -110,7 +130,7 @@ func isBuiltinName(n string) bool {
 func machinGuide() guideCatalog {
 	return guideCatalog{
 		Version: machinVersion,
-		Schema:  "machin.guide/v2",
+		Schema:  "machin.guide/v3",
 		Tagline: "Go-flavored, type-inferred, machine-first language; MFL compiles through C to a single native binary. Plain-text source, one declaration per line.",
 		Keywords: []string{
 			"func", "return", "if", "else", "while", "for", "range", "break", "continue",
@@ -128,6 +148,26 @@ func machinGuide() guideCatalog {
 			{"skill", "machin skill install", "register the agent skills where coding agents look (~/.agents/skills + detected editor dirs)"},
 		},
 		Domains: guideDomains,
+		Proof: guideProof{
+			SelfHosting: "The compiler is written in machin: it compiles its own source (lex -> parse -> typecheck -> codegen) and the result reproduces itself byte-for-byte — a full bootstrap fixpoint, zero Go in the toolchain. See CHANGELOG v0.84.0 (compiles itself) and v0.85.0 (the no-Go bootstrap).",
+			Benchmarks: []guideBenchmark{
+				{
+					Axis:      "agent write cost",
+					Result:    "a REST+SQLite API: 388 tokens to author (ties Python's 383, ~36% fewer than Go's 527), ships as a 44 KB dependency-free static binary",
+					Reproduce: "bench/rest-sqlite: ./run.sh (build+smoke-test); python3 measure.py (token counts, needs tiktoken)",
+				},
+				{
+					Axis:      "native runtime speed",
+					Result:    "vs Rust -O3 / Zig ReleaseFast on 4 kernels with byte-identical output: wins fib(40) and a 10^9 integer-sum loop by ~20-25%, ties a float-heavy mandelbrot within 2%, trails an array-heavy sieve by ~1.4x",
+					Reproduce: "bench/native-speed: ./run.sh (needs machin, cc, rustc, zig, python3)",
+				},
+				{
+					Axis:      "cold start & ship size",
+					Result:    "92.9 kB static binary, 0.49 ms cold start, 108 kB resident memory serving the same HTTP hello endpoint as Node (178 MB / 28.9 ms / 51 MB) — 1916x smaller, 59x faster start, 477x less RAM",
+					Reproduce: "bench/cold-start: ./build.sh (sizes); python3 measure.py (cold-start + RSS); ./images.sh (Docker image sizes, needs Docker)",
+				},
+			},
+		},
 		Types: []guideNote{
 			{"int", "64-bit signed"},
 			{"float", "double"},
@@ -435,6 +475,13 @@ func renderGuideText(g guideCatalog) string {
 	for _, d := range g.Domains {
 		fmt.Fprintf(&b, "  %-8s %s\n           %s\n", d.Name, d.Howto, d.Summary)
 	}
+
+	b.WriteString("\nPROOF — measured, not claimed; reproduce any of it yourself:\n")
+	fmt.Fprintf(&b, "  self-hosting: %s\n", g.Proof.SelfHosting)
+	for _, bm := range g.Proof.Benchmarks {
+		fmt.Fprintf(&b, "  [%s] %s\n      reproduce: %s\n", bm.Axis, bm.Result, bm.Reproduce)
+	}
+
 	b.WriteString("\nTYPES\n")
 	for _, t := range g.Types {
 		fmt.Fprintf(&b, "  %-10s %s\n", t.Topic, t.Note)

--- a/guide_test.go
+++ b/guide_test.go
@@ -35,6 +35,31 @@ func TestGuideCatalog(t *testing.T) {
 	if _, err := json.Marshal(g); err != nil {
 		t.Fatalf("guide JSON: %v", err)
 	}
+	if g.Proof.SelfHosting == "" || len(g.Proof.Benchmarks) == 0 {
+		t.Fatal("guide missing the proof section (selfHosting / benchmarks)")
+	}
+	for _, bm := range g.Proof.Benchmarks {
+		if bm.Axis == "" || bm.Result == "" || bm.Reproduce == "" {
+			t.Fatalf("benchmark %q missing axis/result/reproduce", bm.Axis)
+		}
+	}
+}
+
+// The proof section's whole point is "reproducible, not asserted" — so each
+// benchmark's Reproduce path must point at a real directory in the repo, the
+// same way TestGuideBuiltinsRecognized keeps builtins honest and
+// TestGuideIdiomsCompile keeps idioms honest.
+func TestGuideProofReproducible(t *testing.T) {
+	for _, bm := range machinGuide().Proof.Benchmarks {
+		path := bm.Reproduce
+		if i := strings.Index(path, ":"); i >= 0 {
+			path = path[:i]
+		}
+		path = strings.TrimSpace(path)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("benchmark %q: reproduce path %q does not exist: %v", bm.Axis, path, err)
+		}
+	}
 }
 
 // The catalog version is the toolchain version; it must match the README badge,


### PR DESCRIPTION
## Summary
- Adds a `proof` section to `machin guide`'s JSON catalog (schema bumped `v2` -> `v3`): `selfHosting` (the bootstrap-fixpoint claim) and `benchmarks` (the three measured comparisons — agent write cost vs Go/Python, native runtime speed vs Rust/Zig, cold-start/ship-size vs Node — that already live in README/bench/), each with a `reproduce` command pointing at the real `bench/` script.
- This is the "next big move" landed the agent-first way: instead of a human-facing writeup (LinkedIn/founder-narrative, which was the first idea and got explicitly overridden — machin's positioning is machine-first, not human-DX), the credibility mechanism is an agent running `machin guide` while researching what to build with, and relaying the numbers to its principal.
- `--text` gets a PROOF section rendered alongside COMMANDS/DOMAINS/TYPES/etc.
- New `TestGuideProofReproducible` asserts every `reproduce` path is a real directory in the repo, matching how `TestGuideBuiltinsRecognized`/`TestGuideIdiomsCompile` already keep the rest of the catalog honest — "reproducible, not asserted" stays true as the repo evolves.

## Test plan
- [x] `go build ./...` clean
- [x] `go test .` full suite passes (incl. new `TestGuideProofReproducible`)
- [x] `machin guide` JSON and `machin guide --text` both render the new section correctly
- [x] `TestGuideCatalog` extended to assert the proof section is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)