### PR TITLE
Server-side TLS + STARTTLS — machweb terminates HTTPS itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+- **Server-side TLS + STARTTLS — machweb can terminate HTTPS itself, no reverse
+  proxy needed.** New builtins `tls_server_ctx(certfile, keyfile) -> int`,
+  `tls_accept(ctx, fd) -> int` (server handshake), `tls_client_fd(fd, hostname)
+  -> int` (the STARTTLS primitive — upgrade an already-connected, plaintext-
+  negotiated fd to verified TLS in place), and `tls_read[_bytes]`/
+  `tls_write[_bytes]`/`tls_close` (mirroring the plain fd read/write/close
+  builtins over a tls handle). New `framework/machweb.src` function
+  `serve_tls(port, certfile, keyfile, handler)` — `serve`'s TLS-terminating
+  sibling, reusing the same router/handler/Response machinery; v1 scope is
+  plain request/response only (`res.is_hijack`/`res.is_stream` get a 501 rather
+  than misbehaving over a tls handle — a documented, deliberate limitation, not
+  an oversight). Verified end-to-end: a real Go TLS client driving a full HTTP
+  round trip through `serve_tls` and a router, and a STARTTLS upgrade correctly
+  **rejecting** an untrusted/self-signed certificate (proving verification is
+  active on the upgrade path too, same discipline as `--static`'s CA bundle
+  work in v0.90.0). `tls_client_fd` shares `mfl_tls_dial_e`'s already-proven
+  handshake code — the dial-vs-upgrade split is just where the fd came from.
+  Closes the "you still need nginx in front of it" gap in the single-binary
+  pitch; see issue #260 (STARTTLS wiring into `machin-mail` is a follow-up in
+  that separate repo, not part of this change).
+
 ## v0.90.0
 
 - **`machin build --static` now works for TLS/crypto-using programs, FROM scratch.**

--- a/SPEC.md
+++ b/SPEC.md
@@ -337,6 +337,14 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 | `wss_send_bin` | `(int, bytes) -> int` | send a binary message (opcode `0x2`) — NUL-safe |
 | `wss_recv_bin` | `(int) -> bytes` | next message as `bytes` (blocks); empty `bytes` on close |
 | `wss_close` | `(int) -> int` | send close and tear down the connection |
+| `tls_server_ctx` | `(string, string) -> int` | load a cert+key (PEM files) → a server TLS context handle (0 on fail); for terminating HTTPS/TLS yourself, see `serve_tls` |
+| `tls_accept` | `(int, int) -> int` | `(ctx, fd)` — complete a server-side TLS handshake on an `accept()`'d fd → a tls handle (0 on fail) |
+| `tls_client_fd` | `(int, string) -> int` | `(fd, hostname)` — the STARTTLS primitive: upgrade an already-connected, plaintext-negotiated fd to a verified TLS handle in place (0 on fail) |
+| `tls_read` | `(int) -> string` | read one chunk from a tls handle (blocks; `""` at EOF/error) |
+| `tls_read_bytes` | `(int) -> bytes` | read one chunk from a tls handle as raw bytes, NUL-safe |
+| `tls_write` | `(int, string) -> int` | write to a tls handle |
+| `tls_write_bytes` | `(int, bytes) -> int` | write raw bytes to a tls handle, NUL-safe |
+| `tls_close` | `(int) -> int` | shut down a tls handle and close its underlying fd |
 
 ---
 

--- a/codegen.go
+++ b/codegen.go
@@ -1297,6 +1297,23 @@ static SSL_CTX* mfl_ssl_ctx(void) {
     return ctx;
 }
 
+/* the handshake half of a client dial: SNI + verified hostname on an already-
+   connected fd. Does NOT close fd on failure — used both by dial (which owns
+   the fd it just opened) and by tls_client_fd/STARTTLS (which upgrades a
+   caller-owned fd already in use for a plaintext exchange; the caller decides
+   whether to close it). On failure, *stage (if non-NULL) is set to "tls". */
+static SSL* mfl_tls_handshake_client(int fd, const char* host, const char** stage) {
+    SSL_CTX* ctx = mfl_ssl_ctx();
+    if (!ctx) { if (stage) *stage = "tls"; return NULL; }
+    SSL* ssl = SSL_new(ctx);
+    SSL_set_fd(ssl, fd);
+    SSL_set_tlsext_host_name(ssl, host);
+    SSL_set1_host(ssl, host);
+    SSL_set_verify(ssl, SSL_VERIFY_PEER, NULL);
+    if (SSL_connect(ssl) != 1) { if (stage) *stage = "tls"; SSL_free(ssl); return NULL; }
+    return ssl;
+}
+
 /* dial host:port and complete a verified TLS handshake (SNI + hostname).
    Returns a connected SSL* (fd retrievable via SSL_get_fd) or NULL. On failure,
    *stage (if non-NULL) is set to why: "dns", "connect", or "tls". */
@@ -1318,14 +1335,8 @@ static SSL* mfl_tls_dial_e(const char* host, int port, const char** stage) {
     }
     freeaddrinfo(res);
     if (fd < 0) { if (stage) *stage = "connect"; return NULL; }
-    SSL_CTX* ctx = mfl_ssl_ctx();
-    if (!ctx) { if (stage) *stage = "tls"; close(fd); return NULL; }
-    SSL* ssl = SSL_new(ctx);
-    SSL_set_fd(ssl, fd);
-    SSL_set_tlsext_host_name(ssl, host);
-    SSL_set1_host(ssl, host);
-    SSL_set_verify(ssl, SSL_VERIFY_PEER, NULL);
-    if (SSL_connect(ssl) != 1) { if (stage) *stage = "tls"; SSL_free(ssl); close(fd); return NULL; }
+    SSL* ssl = mfl_tls_handshake_client(fd, host, stage);
+    if (!ssl) { close(fd); return NULL; } /* dial owns fd: close it on handshake failure */
     return ssl;
 }
 
@@ -1338,6 +1349,73 @@ static void mfl_tls_hangup(SSL* ssl) {
     if (fd >= 0) close(fd);
     SSL_free(ssl);
 }
+
+/* tls_client_fd: the STARTTLS primitive — upgrade an already-connected,
+   plaintext-negotiated fd (from a plain dial()) to TLS in place. Does not close
+   fd on failure (caller owns it, e.g. to log/close/retry plaintext). */
+static int64_t mfl_tls_client_fd(int64_t fd, const char* host) {
+    SSL* ssl = mfl_tls_handshake_client((int)fd, host, NULL);
+    return ssl ? (int64_t)(intptr_t)ssl : 0;
+}
+
+/* tls_server_ctx/tls_accept: server-side TLS termination — serve_tls in
+   framework/machweb.src is the MFL-side consumer. No client-cert verification
+   (not mutual TLS) and one cert per ctx (no SNI multi-cert) — v1 scope. */
+static int64_t mfl_tls_server_ctx(const char* certfile, const char* keyfile) {
+    SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
+    if (!ctx) return 0;
+    if (SSL_CTX_use_certificate_file(ctx, certfile, SSL_FILETYPE_PEM) != 1 ||
+        SSL_CTX_use_PrivateKey_file(ctx, keyfile, SSL_FILETYPE_PEM) != 1) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
+    return (int64_t)(intptr_t)ctx;
+}
+static int64_t mfl_tls_accept(int64_t ctxHandle, int64_t fd) {
+    SSL_CTX* ctx = (SSL_CTX*)(intptr_t)ctxHandle;
+    if (!ctx) return 0;
+    SSL* ssl = SSL_new(ctx);
+    SSL_set_fd(ssl, (int)fd);
+    if (SSL_accept(ssl) != 1) { SSL_free(ssl); return 0; }
+    return (int64_t)(intptr_t)ssl;
+}
+
+/* generic read/write/close over a tls handle (an SSL*, from tls_accept or
+   tls_client_fd) — mirror mfl_read/mfl_read_bytes/mfl_write/mfl_write_bytes's
+   chunk semantics (one SSL_read's worth, up to 64K; a full-write loop) exactly,
+   just over SSL_read/SSL_write instead of read(2)/write(2). */
+static char* mfl_tls_read_str(int64_t h) {
+    SSL* ssl = (SSL*)(intptr_t)h;
+    char* buf = mfl_alloc(65536);
+    int n = ssl ? SSL_read(ssl, buf, 65535) : 0;
+    if (n < 0) n = 0;
+    buf[n] = 0;
+    return buf;
+}
+static mfl_bytes mfl_tls_read_bytes_h(int64_t h) {
+    SSL* ssl = (SSL*)(intptr_t)h;
+    mfl_bytes b; b.data = (uint8_t*)mfl_alloc(65536);
+    int n = ssl ? SSL_read(ssl, b.data, 65536) : 0;
+    if (n < 0) n = 0;
+    b.len = (int64_t)n;
+    return b;
+}
+static int64_t mfl_tls_write_str(int64_t h, const char* s) {
+    SSL* ssl = (SSL*)(intptr_t)h;
+    return ssl ? (int64_t)SSL_write(ssl, s, (int)strlen(s)) : -1;
+}
+static int64_t mfl_tls_write_bytes_h(int64_t h, mfl_bytes b) {
+    SSL* ssl = (SSL*)(intptr_t)h;
+    if (!ssl) return -1;
+    size_t off = 0;
+    while (off < (size_t)b.len) {
+        int w = SSL_write(ssl, b.data + off, (int)((size_t)b.len - off));
+        if (w <= 0) break;
+        off += (size_t)w;
+    }
+    return (int64_t)off;
+}
+static int64_t mfl_tls_close_h(int64_t h) { mfl_tls_hangup((SSL*)(intptr_t)h); return 0; }
 `
 
 // tlsRuntime is a minimal HTTPS/1.1 client built on tlsCoreRuntime. Emitted only
@@ -4504,6 +4582,30 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "wss_close":
 		g.usesWSS = true
 		return fmt.Sprintf("mfl_wss_close(%s)", args[0]), nil
+	case "tls_client_fd":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_client_fd(%s, %s)", args[0], args[1]), nil
+	case "tls_server_ctx":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_server_ctx(%s, %s)", args[0], args[1]), nil
+	case "tls_accept":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_accept(%s, %s)", args[0], args[1]), nil
+	case "tls_read":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_read_str(%s)", args[0]), nil
+	case "tls_read_bytes":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_read_bytes_h(%s)", args[0]), nil
+	case "tls_write":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_write_str(%s, %s)", args[0], args[1]), nil
+	case "tls_write_bytes":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_write_bytes_h(%s, %s)", args[0], args[1]), nil
+	case "tls_close":
+		g.usesTLS = true
+		return fmt.Sprintf("mfl_tls_close_h(%s)", args[0]), nil
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
 	}

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -544,6 +544,107 @@ func serve(port, handler) {
     }
 }
 
+// ---- native TLS termination (no reverse proxy) ----
+//
+// serve_tls is `serve`, but the process terminates HTTPS itself via tls_server_ctx
+// / tls_accept (issue #260) instead of expecting nginx/Caddy/Traefik in front of
+// it. v1 scope: plain request/response only — res.is_hijack (protocol upgrades,
+// e.g. a raw WebSocket handoff) and res.is_stream (SSE) are NOT supported here
+// yet (they hand the raw `conn` to a callback that does plain read/write; over
+// TLS that callback would need to be tls_read/tls_write-aware instead, which is
+// a separate follow-up) — such a handler gets a 501 rather than silently
+// misbehaving. Use `serve` behind a reverse proxy for hijack/stream endpoints
+// until that lands.
+
+// read_request_bytes_tls is read_request_bytes, over a tls handle instead of a
+// raw fd.
+func read_request_bytes_tls(tls) (raw) {
+    raw = tls_read_bytes(tls)
+    sep := bytes_index(raw, bytes("\r\n\r\n"), 0)
+    if sep >= 0 {
+        clen := content_length(bytes_str(bytes_sub(raw, 0, sep)))
+        if machweb_max_body == 0 || clen <= machweb_max_body {
+            body_start := sep + 4
+            for len(raw) - body_start < clen {
+                chunk := tls_read_bytes(tls)
+                if len(chunk) == 0 { break }
+                raw = bytes_concat(raw, chunk)
+            }
+        }
+    }
+}
+
+// machweb_handle_tls is machweb_handle, over a tls handle for the HTTP
+// read/write (fd is still the raw socket, used only for socket_timeout/peer_addr
+// — TLS framing doesn't change what those mean).
+func machweb_handle_tls(fd, tls, handler) {
+    started := now_ms()
+    if machweb_read_timeout > 0 { t := socket_timeout(fd, machweb_read_timeout) }
+    raw := read_request_bytes_tls(tls)
+    req := parse_request_bytes(raw)
+    req.remote = peer_addr(fd)
+    if machweb_max_body > 0 && parse_int(header(req, "content-length")) > machweb_max_body {
+        body := "request body exceeds the limit"
+        out := "HTTP/1.1 413 Payload Too Large\r\nContent-Type: text/plain\r\nContent-Length: " + str(len(body)) + "\r\nConnection: close\r\n\r\n" + body
+        tls_write(tls, out)
+        tls_close(tls)
+        if machweb_access_log == 1 { access_log(req, "413 Payload Too Large", len(body), now_ms() - started) }
+        return
+    }
+    res := handler(req)
+    if res.is_hijack == 1 || res.is_stream == 1 {
+        body := "hijack/stream responses are not yet supported over serve_tls"
+        out := "HTTP/1.1 501 Not Implemented\r\nContent-Type: text/plain\r\nContent-Length: " + str(len(body)) + "\r\nConnection: close\r\n\r\n" + body
+        tls_write(tls, out)
+        tls_close(tls)
+        if machweb_access_log == 1 { access_log(req, "501 Not Implemented (hijack/stream)", len(body), now_ms() - started) }
+        return
+    }
+    nbytes := 0
+    if res.is_bin == 1 {
+        head := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.bin)) + "\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n"
+        tls_write(tls, head)
+        tls_write_bytes(tls, res.bin)
+        nbytes = len(res.bin)
+    } else {
+        out := "HTTP/1.1 " + res.status + "\r\nContent-Type: " + res.ctype + "\r\nContent-Length: " + str(len(res.body)) + "\r\n" + cookie_lines(res) + "Connection: close\r\n\r\n" + res.body
+        tls_write(tls, out)
+        nbytes = len(res.body)
+    }
+    tls_close(tls)
+    if machweb_access_log == 1 { access_log(req, res.status, nbytes, now_ms() - started) }
+}
+
+// machweb_accept_tls completes the server-side handshake for one connection,
+// then hands off to machweb_handle_tls. A handshake failure just drops the fd
+// (matches a browser hitting a plaintext port with https:// — no valid response
+// is possible before a handshake completes).
+func machweb_accept_tls(ctx, fd, handler) {
+    tls := tls_accept(ctx, fd)
+    if tls == 0 {
+        close(fd)
+        return
+    }
+    machweb_handle_tls(fd, tls, handler)
+}
+
+// serve_tls runs the HTTPS server directly — no reverse proxy needed. certfile/
+// keyfile are PEM paths (see tls_server_ctx). Each connection is handled (handshake
+// + request + response) in its own goroutine, same concurrency shape as serve.
+func serve_tls(port, certfile, keyfile, handler) {
+    ctx := tls_server_ctx(certfile, keyfile)
+    if ctx == 0 {
+        println("serve_tls: failed to load " + certfile + " / " + keyfile)
+        return
+    }
+    server := listen(port)
+    println("machweb on https://localhost:" + str(port))
+    for {
+        fd := accept(server)
+        go machweb_accept_tls(ctx, fd, handler)
+    }
+}
+
 // ---- map-based router ----
 //
 // A router maps "METHOD PATH" to a handler closure func(Request) Response.

--- a/guide.go
+++ b/guide.go
@@ -343,6 +343,14 @@ func machinGuide() guideCatalog {
 			{"wss_send_bin", "(int, bytes) -> int", "send a binary message (opcode 0x2) — NUL-safe, for binary protocols", "ws"},
 			{"wss_recv_bin", "(int) -> bytes", "next message as bytes (blocks; empty bytes on close; NUL-safe)", "ws"},
 			{"wss_close", "(int) -> int", "send close and tear down", "ws"},
+			{"tls_server_ctx", "(string, string) -> int", "load a cert+key (PEM files) -> a server TLS context handle (0 on fail) — for terminating HTTPS/TLS yourself (no reverse proxy). See serve_tls in framework/machweb.src", "tls"},
+			{"tls_accept", "(int, int) -> int", "(ctx, fd) — complete a server-side TLS handshake on an accept()'d fd -> a tls handle (0 on fail)", "tls"},
+			{"tls_client_fd", "(int, string) -> int", "(fd, hostname) — the STARTTLS primitive: upgrade an already-connected, plaintext-negotiated fd to a verified TLS handle in place (0 on fail) — e.g. SMTP: dial, EHLO/STARTTLS in plaintext, then upgrade", "tls"},
+			{"tls_read", "(int) -> string", "read one chunk from a tls handle (blocks; \"\" at EOF/error) — mirrors read(fd)", "tls"},
+			{"tls_read_bytes", "(int) -> bytes", "read one chunk from a tls handle as raw bytes, NUL-safe — mirrors read_bytes(fd)", "tls"},
+			{"tls_write", "(int, string) -> int", "write to a tls handle — mirrors write(fd, s)", "tls"},
+			{"tls_write_bytes", "(int, bytes) -> int", "write raw bytes to a tls handle, NUL-safe — mirrors write_bytes(fd, b)", "tls"},
+			{"tls_close", "(int) -> int", "shut down a tls handle (from tls_accept or tls_client_fd) AND close its underlying fd — the connection is fully torn down, don't also call close(fd) on it", "tls"},
 		},
 		Idioms: []guideIdiom{
 			{"hello", `func main() { println("hello") }`},
@@ -389,6 +397,15 @@ func main() { priv := rand_bytes(32)  pub := secp256k1_pubkey(priv)
 	digest := eip712_digest(domainSeparator, structHash)
 	sig := secp256k1_sign_recoverable(priv, digest)
 	println(to_hex(secp256k1_recover(digest, sig)) == to_hex(pub)) }`},
+			{"tls-server", `func main() { ctx := tls_server_ctx("server.crt", "server.key")
+	if ctx == 0 { println("bad cert/key")  exit(1) }
+	srv := listen(8443)
+	for { fd := accept(srv)  go handle_one(ctx, fd) } }
+func handle_one(ctx, fd) { tls := tls_accept(ctx, fd)
+	if tls == 0 { close(fd)  return }
+	req := tls_read(tls)
+	tls_write(tls, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
+	tls_close(tls) }`},
 		},
 		Gotchas: []guideNote{
 			{"struct-value-semantics", "Structs are VALUE types: passing or assigning one copies it, so a function cannot mutate a caller's struct (and a builder must return the updated struct). For shared mutable state use a map — a reference type, so m[k]=v survives the holder being passed by value (see framework/flags.src)."},
@@ -412,6 +429,7 @@ func main() { priv := rand_bytes(32)  pub := secp256k1_pubkey(priv)
 			{"channels-cross-goroutine", "Values sent over a channel are deep-copied across the goroutine/arena boundary (strings fast; slices/maps/structs via JSON), so they survive the sender goroutine. Channels of closures/funcs are not deep-copied."},
 			{"select-closed", "A closed channel makes its select receive case ready, firing repeatedly (with ok==false if you wrote `case v, ok := <-ch:`). Detect close and stop selecting on it."},
 			{"no-tls-without-https", "There is no raw TLS socket; use https_get/https_post (REST) and wss_* (WebSocket). Plain dial/listen are TCP without TLS."},
+			{"server-tls-v1", "tls_server_ctx/tls_accept let machweb terminate HTTPS itself (serve_tls in framework/machweb.src) — no reverse proxy needed for a simple/internal service. v1 scope: one cert per tls_server_ctx (no SNI multi-cert virtual hosting), no client-cert verification (not mutual TLS), no ACME/auto-renewal (bring your own cert+key, renew it yourself), and serve_tls does NOT support res.is_hijack/res.is_stream (protocol upgrades, SSE) yet — those get a 501 rather than misbehaving; use serve behind a reverse proxy for those endpoints. tls_client_fd is the STARTTLS primitive (upgrade an already-connected, plaintext-negotiated fd to TLS in place, e.g. after SMTP EHLO/STARTTLS) — it verifies the remote cert exactly like https_get does, so an untrusted/self-signed cert is rejected, not silently accepted."},
 			{"eip712-uint256", "keccak256/secp256k1_pubkey/secp256k1_sign_recoverable/secp256k1_recover give the primitives for Ethereum-style signing (EIP-712 typed data, eth_sign, raw tx signing), but a full EIP-712 ABI encoder is NOT a builtin — you assemble domainSeparator/structHash by hand from keccak256 + bytes_concat (see the eip712-sign idiom). The real gap: Solidity `uint256` struct fields (token IDs, amounts, salts) routinely exceed MFL's 64-bit `int`, so encode them as 32-byte big-endian `bytes` (from a hex string the caller already has, e.g. from an API) rather than as `int` — MFL has no builtin decimal-string-to-bytes32 bignum conversion. An Ethereum address is the last 20 bytes of keccak256(pub[1:]) (pub is the 65-byte uncompressed key, so skip its 0x04 prefix first — bytes_sub(pub, 1, 65))."},
 			{"floats-over-chan-json", "A slice/map channel element round-trips through JSON, which formats floats with %g (not bit-exact for pathological doubles)."},
 			{"memory", "Per-goroutine arena, reclaimed in bulk when the goroutine returns; wrap a hot allocating loop in `arena { ... }` to keep peak memory flat. Build with --safe for bounds/overflow/div-zero checks."},

--- a/plugins/machin/skills/machin-deploy/SKILL.md
+++ b/plugins/machin/skills/machin-deploy/SKILL.md
@@ -12,6 +12,15 @@ Traefik, or Cloudflare. You do **not** need machin to speak TLS itself; the prox
 HTTPS and forwards plain HTTP to your app. This skill is about making the app *correct and
 safe* in that setup.
 
+`serve_tls(port, certfile, keyfile, handler)` (`framework/machweb.src`) lets machweb
+terminate HTTPS itself with no proxy in front — for a simple/internal service where you
+already have a cert+key file and don't want another moving part. It's **not yet a
+replacement for the proxy setup below** for anything public-facing: no ACME/Let's Encrypt
+auto-renewal (bring your own cert, renew it yourself), and `res.is_hijack`/`res.is_stream`
+(protocol upgrades, SSE) aren't supported over it yet — use `serve` behind a proxy for
+those. Reach for `serve_tls` when you want zero infra for a small/internal HTTPS service;
+reach for the reverse-proxy shape below for anything public production-facing.
+
 > Build the app with the [`machin-web`](web) / [`machin-backend`](backend) skills; this is
 > the *operate it in production* how-to.
 

--- a/skills/machin-deploy/SKILL.md
+++ b/skills/machin-deploy/SKILL.md
@@ -12,6 +12,15 @@ Traefik, or Cloudflare. You do **not** need machin to speak TLS itself; the prox
 HTTPS and forwards plain HTTP to your app. This skill is about making the app *correct and
 safe* in that setup.
 
+`serve_tls(port, certfile, keyfile, handler)` (`framework/machweb.src`) lets machweb
+terminate HTTPS itself with no proxy in front — for a simple/internal service where you
+already have a cert+key file and don't want another moving part. It's **not yet a
+replacement for the proxy setup below** for anything public-facing: no ACME/Let's Encrypt
+auto-renewal (bring your own cert, renew it yourself), and `res.is_hijack`/`res.is_stream`
+(protocol upgrades, SSE) aren't supported over it yet — use `serve` behind a proxy for
+those. Reach for `serve_tls` when you want zero infra for a small/internal HTTPS service;
+reach for the reverse-proxy shape below for anything public production-facing.
+
 > Build the app with the [`machin-web`](web) / [`machin-backend`](backend) skills; this is
 > the *operate it in production* how-to.
 

--- a/tls_server_test.go
+++ b/tls_server_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// genSelfSignedCert writes a throwaway self-signed cert+key (PEM) for cn/ip to
+// dir, returning their paths. Used both as the server-side cert for TestServerTLS
+// and as the deliberately-untrusted cert for TestSTARTTLS's negative case.
+func genSelfSignedCert(t *testing.T, dir, cn string) (certPath, keyPath string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{cn},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	certOut, err := os.Create(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	certOut.Close()
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyOut, err := os.Create(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	keyOut.Close()
+	return certPath, keyPath
+}
+
+// TestServerTLS: an MFL program terminates TLS itself (tls_server_ctx + accept +
+// tls_accept), no reverse proxy — issue #260's core case. A real Go TLS client
+// (InsecureSkipVerify — this is the TEST HARNESS trusting a throwaway cert, not
+// the code under test relaxing verification) drives it end-to-end: handshake,
+// write a request, read the response.
+func TestServerTLS(t *testing.T) {
+	const port = 47660
+	dir := t.TempDir()
+	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
+
+	src := `func main() {
+	ctx := tls_server_ctx(` + quoteGo(certPath) + `, ` + quoteGo(keyPath) + `)
+	if ctx == 0 { println("ctx fail") exit(1) }
+	srv := listen(` + itoa(port) + `)
+	fd := accept(srv)
+	tls := tls_accept(ctx, fd)
+	if tls == 0 { println("handshake fail") exit(1) }
+	req := tls_read(tls)
+	println(str(len(req)))
+	tls_write(tls, "pong")
+	tls_close(tls)
+}`
+	bin, err := os.CreateTemp("", "mfl-tls-srv-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: parseFuncs(t, src)}, bin.Name(), false); err != nil {
+		t.Fatalf("server-TLS program failed to compile: %v", err)
+	}
+
+	cmd := exec.Command(bin.Name())
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	var conn *tls.Conn
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		c, dialErr := tls.DialWithDialer(&net.Dialer{Timeout: 200 * time.Millisecond}, "tcp", "127.0.0.1:"+itoa(port),
+			&tls.Config{InsecureSkipVerify: true})
+		if dialErr == nil {
+			conn = c
+			break
+		}
+		err = dialErr
+		time.Sleep(50 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("could not connect to the MFL TLS server: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write to server: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 64)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read from server: %v", err)
+	}
+	if got := string(buf[:n]); got != "pong" {
+		t.Fatalf("round trip: got %q, want \"pong\"", got)
+	}
+}
+
+// TestSTARTTLS: tls_client_fd upgrades an already-connected, plaintext fd to
+// TLS in place. A local Go server accepts a plain connection, waits for a
+// trigger line (the STARTTLS negotiation), then upgrades the SAME net.Conn to
+// TLS with tls.Server — the exact STARTTLS shape (SMTP dial -> EHLO/STARTTLS in
+// plaintext -> upgrade). Its cert is self-signed and untrusted, so
+// tls_client_fd — which verifies, same as https_get — must REJECT it. This
+// proves the upgrade path's verification is genuinely active (mirrors the
+// negative-case discipline in TestStaticBuildBundlesCACerts); a positive case
+// against a real trusted cert isn't automated here for the same reason
+// https_get's isn't (see #283's PR description for that manual verification —
+// tls_client_fd shares mfl_tls_dial_e's already-proven handshake code exactly).
+func TestSTARTTLS(t *testing.T) {
+	const port = 47661
+	dir := t.TempDir()
+	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:"+itoa(port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 64)
+		conn.Read(buf) // the plaintext STARTTLS trigger line
+		conn.Write([]byte("OK\n"))
+		tconn := tls.Server(conn, &tls.Config{Certificates: []tls.Certificate{cert}})
+		tconn.Handshake() // expected to fail: the MFL client won't trust this cert
+	}()
+
+	src := `func main() {
+	fd := dial("127.0.0.1", ` + itoa(port) + `)
+	if fd < 0 { println("dial fail") exit(1) }
+	write(fd, "STARTTLS\r\n")
+	read(fd)
+	tls := tls_client_fd(fd, "localhost")
+	if tls == 0 { println("REJECTED") exit(0) }
+	println("ACCEPTED (should not happen: untrusted cert)")
+}`
+	bin, err := os.CreateTemp("", "mfl-starttls-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: parseFuncs(t, src)}, bin.Name(), false); err != nil {
+		t.Fatalf("STARTTLS program failed to compile: %v", err)
+	}
+
+	out, err := exec.Command(bin.Name()).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running the STARTTLS program failed: %v\n%s", err, out)
+	}
+	if got := string(out); got != "REJECTED\n" {
+		t.Fatalf("expected the untrusted STARTTLS cert to be rejected, got: %q", got)
+	}
+}
+
+func quoteGo(s string) string { return `"` + s + `"` }
+
+// TestServeTLS: framework/machweb.src's serve_tls (the actual issue #260
+// deliverable — a router served over native TLS, no reverse proxy), not just the
+// raw builtins TestServerTLS already covers. A real Go TLS client drives a full
+// HTTP round trip through the router.
+func TestServeTLS(t *testing.T) {
+	data, err := os.ReadFile("framework/machweb.src")
+	if err != nil {
+		t.Skip("framework/machweb.src not found")
+	}
+	const port = 47662
+	dir := t.TempDir()
+	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
+
+	app := `func main() {
+	r := new_router()
+	route(r, "GET", "/hi", func(req) { return ok_text("hello from serve_tls") })
+	serve_tls(` + itoa(port) + `, ` + quoteGo(certPath) + `, ` + quoteGo(keyPath) + `, func(req) { return dispatch(r, req) })
+}`
+	prog, perr := progFromSrcErr(string(data) + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+
+	bin, err := os.CreateTemp("", "mfl-serve-tls-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(prog, bin.Name(), false); err != nil {
+		t.Fatalf("serve_tls app failed to compile: %v", err)
+	}
+
+	cmd := exec.Command(bin.Name())
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	var resp *http.Response
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r, getErr := client.Get("https://127.0.0.1:" + itoa(port) + "/hi")
+		if getErr == nil {
+			resp = r
+			break
+		}
+		err = getErr
+		time.Sleep(50 * time.Millisecond)
+	}
+	if resp == nil {
+		t.Fatalf("could not reach serve_tls: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 || string(body) != "hello from serve_tls" {
+		t.Fatalf("got status=%d body=%q, want 200 \"hello from serve_tls\"", resp.StatusCode, body)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -2419,6 +2419,59 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cInt)
 		return c.cInt, nil
+	case "tls_client_fd":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("tls_client_fd: 2 args (fd int, hostname string)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cString)
+		return c.cInt, nil
+	case "tls_server_ctx":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("tls_server_ctx: 2 args (certfile, keyfile — both string)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		c.addPair(argSlots[1], c.cString)
+		return c.cInt, nil
+	case "tls_accept":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("tls_accept: 2 args (ctx int, fd int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cInt, nil
+	case "tls_read":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("tls_read: 1 arg (tls int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cString, nil
+	case "tls_read_bytes":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("tls_read_bytes: 1 arg (tls int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cBytes, nil
+	case "tls_write":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("tls_write: 2 args (tls int, data string)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cString)
+		return c.cInt, nil
+	case "tls_write_bytes":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("tls_write_bytes: 2 args (tls int, data bytes)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cBytes)
+		return c.cInt, nil
+	case "tls_close":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("tls_close: 1 arg (tls int)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		return c.cInt, nil
 	case "write":
 		if len(argSlots) != 2 {
 			return 0, fmt.Errorf("write: 2 args")


### PR DESCRIPTION
## Summary
- New builtins: `tls_server_ctx(certfile, keyfile) -> int`, `tls_accept(ctx, fd) -> int` (server handshake), `tls_client_fd(fd, hostname) -> int` (the STARTTLS primitive — upgrade an already-connected, plaintext-negotiated fd to verified TLS in place), and `tls_read[_bytes]`/`tls_write[_bytes]`/`tls_close` mirroring the plain fd builtins over a tls handle.
- Turned out `serve()`/`machweb_handle()` (`framework/machweb.src`) are pure MFL — no Go-side server plumbing to touch. So this didn't need to touch machweb's routing/response logic at all: new `serve_tls(port, certfile, keyfile, handler)` is `serve`'s TLS-terminating sibling, reusing the same router/handler/`Response` machinery via a deliberate near-duplicate of `machweb_handle` rather than threading a protocol-polymorphic abstraction through every call site.
- **v1 scope** (documented in the guide's `server-tls-v1` gotcha): one cert per `tls_server_ctx` (no SNI multi-cert), no client-cert verification (not mutual TLS), no ACME/auto-renewal, and `res.is_hijack`/`res.is_stream` get a 501 over `serve_tls` rather than misbehaving — a deliberate, documented limitation, not an oversight.
- Closes the "you still need nginx in front of it" gap in the single-binary pitch — extends the honesty work from v0.90.0's static-TLS CA bundle to the server side.
- See issue #260 — STARTTLS wiring into `machin-mail` (a separate repo) is a follow-up dogfood step, not part of this change, so the issue stays open for that.

## Test plan
- [x] `go build ./...` clean
- [x] `go test .` full suite passes
- [x] `TestServerTLS` — a real Go TLS client drives a full handshake + request/response round trip against the raw `tls_accept` builtins
- [x] `TestServeTLS` — the actual `serve_tls` framework function, with a router, driven by a real Go `http.Client` over TLS
- [x] `TestSTARTTLS` — `tls_client_fd` correctly **rejects** an untrusted/self-signed cert (proves verification is active on the upgrade path, not silently disabled)
- [x] Manually verified with `curl -k` against a `serve_tls` router app (full round trip)
- [x] `machin guide` / `--text` render the new `tls` category and idiom correctly; `TestGuideBuiltinsRecognized`/`TestGuideIdiomsCompile` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)