### PR TITLE
fix: a < -b failed to parse after its own canonical form (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+- **Fixed: `a < -b` failed to parse after its own canonical form (issue #208).**
+  `machin encode` tightens whitespace around operators, so `x < -1` becomes
+  byte-adjacent `x<-1` — and the lexer greedily merged that into a single
+  channel-receive `<-` token, so a valid comparison against a negative literal
+  failed to parse *after* the round trip through canonical form (the exact
+  loop-integrity contract — generate, canonicalize, re-ingest — an agent runs
+  constantly). Since `ch <- v` (a genuine channel send) is lexically the
+  identical shape (an identifier immediately followed by `<-`), this couldn't
+  be fixed at the lexer: whether `IDENT <- ...` means "send" or "less-than,
+  then negate" depends on grammatical position, not local token context. Fixed
+  in the parser instead: the one call site that recognizes send statements
+  (a simple statement's leading expression) still stops at a bare `<-` as
+  before; everywhere else (`if`/`while` conditions, assignment/return values,
+  call arguments, nested sub-expressions) now reinterprets an unexpected `<-`
+  found while precedence-climbing as `<` followed by unary `-` on the next
+  operand — exactly how the un-tightened source already parsed. Verified:
+  the reported case, operator-precedence preservation (`a && b < -1` parses as
+  `a && (b < -1)`, not `(a && b) < -1`), composition with further arithmetic
+  (`c < -1 + 10`), and non-regression on channel send/receive/select (the
+  exact same ambiguous token shape, still correctly recognized). New
+  `TestLessThanNegative` / `TestLessThanNegativeChannelSendUnaffected`.
+  **Follow-up, not done here:** the self-hosted parser (`selfhost/parse.src`)
+  has its own independent precedence-climbing implementation with the same
+  `<-` handling shape, so it likely has the identical bug — left for a
+  separate change to avoid colliding with the in-flight self-hosted
+  concurrency-parity work (issue #280).
+
 ## v0.93.0
 
 - **`machin guide`'s `proof` section gains a 5th entry: data-race safety —

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -922,6 +922,46 @@ func TestBitwise(t *testing.T) {
 	}
 }
 
+// issue #208: `encode` tightens whitespace, so `x < -1` becomes byte-adjacent
+// `x<-1` in canonical form — and the lexer used to greedily merge `<` and `-`
+// into a single channel-receive token there, so a valid comparison against a
+// negative literal failed to parse AFTER the round trip through canonical
+// form. buildRun exercises the real pipeline (loose source -> tighten -> lex
+// -> parse -> compile -> run), the same path that broke.
+func TestLessThanNegative(t *testing.T) {
+	main := `func main() {
+	x := 5
+	if x < -1 { println("neg") } else { println("ok") }
+	h := 0.5
+	if h < -0.7 { println("below") } else { println("above") }
+	// precedence: && binds looser than <, so this must parse as a && (b < -1)
+	a := true
+	b := 10
+	if a && b < -1 { println("wrong") } else { println("precedence-ok") }
+	// the implicit unary minus still composes with what follows it
+	c := 5
+	if c < -1 + 10 { println("chain-ok") } else { println("chain-wrong") }
+}`
+	out, _ := buildRun(t, main)
+	want := "ok\nabove\nprecedence-ok\nchain-ok\n"
+	if out != want {
+		t.Fatalf("x < -1 after tightening: got %q, want %q", out, want)
+	}
+}
+
+// Same fix, non-regression: `ch <- v` (channel send) is lexically the exact
+// same ambiguous shape (IDENT immediately followed by `<-`) as `x < -1` in
+// canonical form, and must still be recognized as a send, not split into a
+// comparison.
+func TestLessThanNegativeChannelSendUnaffected(t *testing.T) {
+	out := runNative(t,
+		`func recv(ch) { v := <-ch  println("got " + str(v)) }`,
+		`func main() { ch := make(chan int)  go recv(ch)  ch <- 42  sleep(50) }`)
+	if out != "got 42\n" {
+		t.Fatalf("channel send regressed: got %q", out)
+	}
+}
+
 // Opaque FFI handles: `cstruct Name {}` (empty body) wraps a by-value C struct
 // machin can hold and pass back without naming its fields — for APIs whose
 // structs contain pointers (raylib Sound/Music, ...). Codegen-level (no link).

--- a/parser.go
+++ b/parser.go
@@ -570,8 +570,11 @@ func (p *Parser) parseStmt() (Stmt, error) {
 		}
 		return &AssignStmt{Name: name, Op: ":=", Val: val}, nil
 	}
-	// expression, possibly an assignment target (ident = / slice[i] =)
-	x, err := p.parseExpr()
+	// expression, possibly an assignment target (ident = / slice[i] =), or the
+	// channel of a send statement (ch <- v) — parseExprForStmt (unlike parseExpr)
+	// does NOT reinterpret a trailing `<-` as `<` + unary `-`, so it's left
+	// here for the send-statement check below to claim.
+	x, err := p.parseExprForStmt()
 	if err != nil {
 		return nil, err
 	}
@@ -876,25 +879,75 @@ var precedence = map[string]int{
 }
 
 func (p *Parser) parseExpr() (Expr, error) {
-	return p.parseBinary(1)
-}
-
-func (p *Parser) parseBinary(minPrec int) (Expr, error) {
 	left, err := p.parseUnary()
 	if err != nil {
 		return nil, err
 	}
+	return p.parseBinaryFrom(left, 1)
+}
+
+// parseExprForStmt is parseExpr for the ONE context where a bare `<-`
+// immediately after the parsed expression must NOT be reinterpreted: the
+// leading expression of a simple statement, which may turn out to be the
+// channel of a send (ch <- v). Every other caller (if/while conditions,
+// assignment/return values, call arguments, nested sub-expressions, ...) uses
+// parseExpr, which does reinterpret it — see parseBinaryFrom.
+func (p *Parser) parseExprForStmt() (Expr, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().Val == "<-" {
+		// don't split: this may be a channel send (ch <- v) — leave `<-`
+		// for parseSimpleStmt's send-statement check to claim.
+		return left, nil
+	}
+	return p.parseBinaryFrom(left, 1)
+}
+
+// parseBinaryFrom is precedence-climbing from an already-parsed left operand.
+func (p *Parser) parseBinaryFrom(left Expr, minPrec int) (Expr, error) {
 	for {
 		t := p.peek()
 		if t.Kind != TOp {
 			break
+		}
+		// `x < -1`: machin's canonical form tightens whitespace, so `< -1`
+		// becomes byte-adjacent and the lexer greedily merges it into one
+		// `<-` token — indistinguishable, at the lexer, from a channel
+		// receive/send marker. `<-` is never a valid infix operator, so if
+		// we're looking for one and see it, the only sensible reading is `<`
+		// followed by unary `-` on the next operand (issue #208). A genuine
+		// channel send's `<-` is never reached here: parseExprForStmt (used
+		// only for a statement's leading expression) stops at it before
+		// calling this method, leaving it for the send-statement check.
+		if t.Val == "<-" {
+			ltPrec := precedence["<"]
+			if ltPrec < minPrec {
+				break
+			}
+			p.next() // consume the merged `<-`
+			operand, err := p.parseUnary()
+			if err != nil {
+				return nil, err
+			}
+			right, err := p.parseBinaryFrom(&Unary{Op: "-", X: operand}, ltPrec+1)
+			if err != nil {
+				return nil, err
+			}
+			left = &Binary{Op: "<", L: left, R: right}
+			continue
 		}
 		prec, ok := precedence[t.Val]
 		if !ok || prec < minPrec {
 			break
 		}
 		op := p.next().Val
-		right, err := p.parseBinary(prec + 1)
+		rightOperand, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		right, err := p.parseBinaryFrom(rightOperand, prec+1)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- `machin encode` tightens whitespace around operators, so `x < -1` becomes byte-adjacent `x<-1` in canonical form — and the lexer greedily merged that into a single channel-receive `<-` token, so a valid comparison against a negative literal failed to parse *after* the round trip through canonical form (the generate → canonicalize → re-ingest loop an agent runs constantly).
- Root cause is slightly different from either fix the issue sketched: `ch <- v` (a genuine channel send) is lexically the **identical** shape to `x < -1` after tightening (an identifier immediately followed by `<-`), so a lexer-only fix can't disambiguate them — it depends on grammatical position (statement-start vs. mid-expression), which only the parser knows.
- Fixed in the parser: `parseExprForStmt` (used only for a simple statement's leading expression, which may turn out to be a channel send) still stops at a bare `<-`, exactly as before. Every other caller (`if`/`while` conditions, assignment/return values, call arguments, nested sub-expressions) now goes through `parseExpr` → `parseBinaryFrom`, which reinterprets an unexpected `<-` found while precedence-climbing as `<` followed by unary `-` on the next operand.
- **Not fixed here** (flagged as a follow-up on #208): `selfhost/parse.src` has its own independent precedence-climbing implementation with the same `<-`-handling shape, so it likely has the identical bug — left alone to avoid colliding with the in-flight self-hosted concurrency-parity work (#280).

## Test plan
- [x] `go build ./...` clean
- [x] `go test .` full suite passes (`-count=1`, no cache)
- [x] New `TestLessThanNegative`: the reported case, plus operator-precedence preservation (`a && b < -1` parses as `a && (b < -1)`, not `(a && b) < -1`) and composition with further arithmetic (`c < -1 + 10`)
- [x] New `TestLessThanNegativeChannelSendUnaffected`: the exact same ambiguous token shape (`ch <- v`) still correctly recognized as a send, not split
- [x] Manually verified round-trip idempotency (re-encoding the canonical form is a no-op) and `select { case <-done: }` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)