### PR TITLE
feat: self-hosted concurrency — go/chan/select codegen + the data-race pass, in MFL (#280)

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,12 @@ func main() {
 			os.Exit(1)
 		}
 		return
+	case "racetest":
+		if err := cmdRaceTest(os.Args[2:]); err != nil { // self-hosting oracle: dump race findings canonically
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
 	case "uftest":
 		if err := cmdUFTest(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "error:", err)

--- a/racetest.go
+++ b/racetest.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// cmdRaceTest is the self-hosting oracle for the data-race pass:
+//
+//	machin racetest --program <file.mfl>
+//
+// It runs parse → liftClosures → check → detectRaces and dumps every finding in a
+// canonical, escaping-free form (one per line, fields hex-encoded, in detectRaces'
+// stable sort order) so the MFL port can be byte-diffed against it.
+func cmdRaceTest(args []string) error {
+	if len(args) < 2 || args[0] != "--program" {
+		return fmt.Errorf("usage: machin racetest --program <file.mfl>")
+	}
+	data, err := os.ReadFile(args[1])
+	if err != nil {
+		return err
+	}
+	var decls []string
+	for _, ln := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(ln) != "" {
+			decls = append(decls, ln)
+		}
+	}
+	prog, err := ParseProgram(decls)
+	if err != nil {
+		fmt.Println("(parse-error)")
+		return nil
+	}
+	liftClosures(prog)
+	c, err := Check(prog)
+	if err != nil {
+		fmt.Println("(check-error)")
+		return nil
+	}
+	var b strings.Builder
+	for _, f := range detectRaces(prog, c) {
+		hx := func(s string) string { return hex.EncodeToString([]byte(s)) }
+		ws := make([]string, len(f.Writers))
+		for i, w := range f.Writers {
+			ws[i] = hx(w)
+		}
+		b.WriteString(hx(f.Decl) + "|" + hx(f.Kind) + "|" + hx(f.Root) + "|" + strings.Join(ws, ",") + "\n")
+	}
+	os.Stdout.WriteString(b.String())
+	return nil
+}

--- a/selfhost/cgagg.src
+++ b/selfhost/cgagg.src
@@ -224,8 +224,19 @@ func cg_range(iid, idx, depth) {
         if haskey == 1 { indent(depth + 2)  cemit(var_ref(iid, n.s) + " = _k" + ids + ";\n") }
         if hasval == 1 { indent(depth + 2)  cemit(vct + " _v" + ids + "; mfl_map_get(_m" + ids + ", " + ik + ", " + sk + ", &_v" + ids + "); " + var_ref(iid, n.s2) + " = _v" + ids + ";\n") }
     } else {
-        g_cg_unsup = 1   // range over channel: later part
-    }}}
+    if bk == 9 {   // channel: receive into the key var each iteration; stop when
+                   // the channel is closed and drained (mfl_chan_recv2 -> 0).
+        ect := elem_ctype(iid, n.a)
+        indent(depth + 1)  cemit("mfl_chan* _ch" + ids + " = " + x + ";\n")
+        indent(depth + 1)
+        if haskey == 1 {
+            cemit("while (mfl_chan_recv2(_ch" + ids + ", &" + var_ref(iid, n.s) + ")) {\n")
+        } else {
+            cemit(ect + " _cd" + ids + "; while (mfl_chan_recv2(_ch" + ids + ", &_cd" + ids + ")) {\n")
+        }
+    } else {
+        g_cg_unsup = 1   // (no other rangeable kinds)
+    }}}}
     for _, s := range n.kids { cg_stmt(iid, s, depth + 2) }
     indent(depth + 1)  cemit("}\n")
     indent(depth)  cemit("}\n")

--- a/selfhost/cgagg.src
+++ b/selfhost/cgagg.src
@@ -30,6 +30,48 @@ func struct_def_idx(name) (i) {
     for j < len(g_structdefs) { if g_structdefs[j].name == name && g_structdefs[j].cstruct == 0 { i = j  return i }  j = j + 1 }
 }
 
+// chan_needs_json: does a channel element of type-name `tn` reach a slice or map (by
+// value)? Those can't be deep-copied by the flat string-offset path and instead go
+// through a JSON round-trip (a later slice) -> deferred here.
+func chan_needs_json(tn) (b) {
+    b = 0
+    if has_prefix(tn, "[]") || has_prefix(tn, "map[") { b = 1  return b }
+    di := struct_def_idx(tn)
+    if di < 0 { return b }
+    d := g_structdefs[di]
+    j := 0
+    for j < len(d.fnames) {
+        if chan_needs_json(d.ftypes[j]) == 1 { b = 1  return b }
+        j = j + 1
+    }
+}
+
+// chan_str_offsets: the byte offsets (as offsetof() C expressions) of every string
+// field reachable in a channel element of type-name `tn` — the fast in-place
+// string-copy path. A plain string element sits at `base`+0.
+func chan_str_offsets(tn, base) (offs) {
+    offs = []string{}
+    if tn == "string" { offs = append(offs, base + "0")  return offs }
+    di := struct_def_idx(tn)
+    if di < 0 { return offs }
+    d := g_structdefs[di]
+    cs := "mfl_" + tn
+    j := 0
+    for j < len(d.fnames) {
+        fo := base + "offsetof(" + cs + ", f_" + d.fnames[j] + ")"
+        if d.ftypes[j] == "string" {
+            offs = append(offs, fo)
+        } else {
+            if struct_def_idx(d.ftypes[j]) >= 0 {
+                sub := chan_str_offsets(d.ftypes[j], fo + " + ")
+                k := 0
+                for k < len(sub) { offs = append(offs, sub[k])  k = k + 1 }
+            }
+        }
+        j = j + 1
+    }
+}
+
 // element/map accessors from a node's slot
 func elem_kind_of(iid, idx) (k) {
     r := node_slot_of(iid, idx)

--- a/selfhost/cgen.src
+++ b/selfhost/cgen.src
@@ -212,6 +212,10 @@ func cg_expr(iid, idx) (out) {
             out = "mfl_make_chan(sizeof(" + elem_ctype(iid, idx) + "), 0, 0, 0)"
             return out
         }
+        if ek == 5 {   // string element: one string-offset at byte 0 (fast in-place copy)
+            out = "mfl_make_chan(sizeof(" + elem_ctype(iid, idx) + "), 0, 0, 1, (int)(0))"
+            return out
+        }
         g_cg_unsup = 1  out = "0"  return out
     }
     if k == K_RECV {

--- a/selfhost/cgen.src
+++ b/selfhost/cgen.src
@@ -201,11 +201,35 @@ func cg_expr(iid, idx) (out) {
     if k == K_INDEX { out = cg_index(iid, idx)  return out }
     if k == K_FIELD { out = cg_field(iid, idx)  return out }
     if k == K_MAKEMAP { out = cg_makemap(iid, idx)  return out }
-    g_cg_unsup = 1  out = "0"    // makechan / recv / funclit / closure / callvalue: later parts
+    if k == K_MAKECHAN {
+        // scalar element (int/float/bool): mfl_make_chan(sizeof(T), 0, 0, 0). String /
+        // slice / map / struct elements (JSON round-trip or string-offset copy) are
+        // later slices.
+        r := node_slot_of(iid, idx)
+        ek := 0 - 1
+        if r >= 0 { if g_elem[r] >= 0 { ek = kind_of(g_elem[r]) } }
+        if ek == 1 || ek == 2 || ek == 3 || ek == 4 {
+            out = "mfl_make_chan(sizeof(" + elem_ctype(iid, idx) + "), 0, 0, 0)"
+            return out
+        }
+        g_cg_unsup = 1  out = "0"  return out
+    }
+    if k == K_RECV {
+        out = "({ " + node_ctype(iid, idx) + " _r; mfl_chan_recv(" + cg_expr(iid, n.a) + ", &_r); _r; })"
+        return out
+    }
+    g_cg_unsup = 1  out = "0"    // funclit / closure / callvalue: later parts
 }
 
 // ---- side-effect ordering (port of seqExprs) ----
 var g_tmpid = 0
+
+// goroutine trampolines: each `go f(args)` emits an arg-struct + a trampoline
+// function into g_tramp (spliced BEFORE the function bodies in cg_program), then a
+// detached pthread_create at the call site.
+var g_goid = 0
+var g_tramp = []string{}
+func tramp_emit(s) { g_tramp = append(g_tramp, s) }
 
 func expr_has_side_effect(idx) (b) {
     n := nodes[idx]
@@ -369,7 +393,55 @@ func cg_stmt(iid, idx, depth) {
     if k == K_FLDASSIGN { cg_field_assign(iid, idx)  return }
     if k == K_RANGE { cg_range(iid, idx, depth)  return }
     if k == K_ARENA { cg_arena(iid, idx, depth)  return }
-    g_cg_unsup = 1  cemit("0;\n")   // send / select / go: later parts
+    if k == K_SEND {
+        ch := cg_expr(iid, n.a)
+        val := cg_expr(iid, n.b)
+        ect := elem_ctype(iid, n.a)
+        cemit("mfl_chan_send(" + ch + ", &((" + ect + "[1]){" + val + "})[0]);\n")
+        return
+    }
+    if k == K_GO { cg_go(iid, idx)  return }
+    g_cg_unsup = 1  cemit("0;\n")   // select: later parts
+}
+
+// cg_go: `go f(args)` -> an arg struct + trampoline function into g_tramp, and a
+// detached pthread_create at the call site (the leading indent is already emitted).
+func cg_go(iid, idx) {
+    n := nodes[idx]
+    callnode := n.a
+    cinst := callee_inst_of(iid, callnode)
+    cn := g_insts[cinst].cname
+    cargs := nodes[callnode].kids
+    id := g_goid
+    g_goid = g_goid + 1
+    ids := str(id)
+    // arg struct (a leading dummy field avoids an empty struct)
+    sline := "struct mfl_go_" + ids + " { char _;"
+    i := 0
+    for i < len(cargs) {
+        sline = sline + " " + ctype_slot(g_insts[cinst].pslots[i]) + " a" + str(i) + ";"
+        i = i + 1
+    }
+    tramp_emit(sline + " };\n")
+    // trampoline function
+    rline := "static void* mfl_go_run_" + ids + "(void* p) { mfl_arena _a = {0}; mfl_arena_cur = &_a; struct mfl_go_" + ids + "* s = (struct mfl_go_" + ids + "*)p; " + cn + "("
+    i = 0
+    for i < len(cargs) {
+        if i > 0 { rline = rline + ", " }
+        rline = rline + "s->a" + str(i)
+        i = i + 1
+    }
+    tramp_emit(rline + "); free(s); mfl_arena_free(&_a); return NULL; }\n")
+    // call site
+    cemit("{\n")
+    cemit("        struct mfl_go_" + ids + "* s = malloc(sizeof(*s));\n")
+    i = 0
+    for i < len(cargs) {
+        cemit("        s->a" + str(i) + " = (" + cg_expr(iid, cargs[i]) + ");\n")
+        i = i + 1
+    }
+    cemit("        pthread_t t; pthread_create(&t, NULL, mfl_go_run_" + ids + ", s); pthread_detach(t);\n")
+    cemit("    }\n")
 }
 
 func emit_named_return(iid) {

--- a/selfhost/cgen.src
+++ b/selfhost/cgen.src
@@ -140,6 +140,22 @@ func elem_ctype(iid, idx) (s) {
     }
     s = "int64_t"
 }
+
+// chan_elem_typename: the MFL type-NAME of a channel node's element ("string", a
+// struct name, or a []/map[ form for slice/map elements; any scalar -> "int", which
+// carries no strings/structs so the string-offset walk is a no-op).
+func chan_elem_typename(iid, idx) (tn) {
+    tn = "int"
+    r := node_slot_of(iid, idx)
+    if r < 0 { return tn }
+    if g_elem[r] < 0 { return tn }
+    er := find(g_elem[r])
+    ek := g_kind[er]
+    if ek == 5 { tn = "string"  return tn }
+    if ek == 8 { tn = g_sname[er]  return tn }
+    if ek == 7 { tn = "[]x"  return tn }      // slice element -> chan_needs_json (defer)
+    if ek == 10 { tn = "map[x]x"  return tn }  // map element -> chan_needs_json (defer)
+}
 // map_key_args: (ik, sk) for a map op — string keys pass ("0", key), else (key, "NULL").
 func map_key_args(iid, map_idx, keyexpr) (ik, sk) {
     r := node_slot_of(iid, map_idx)
@@ -202,21 +218,22 @@ func cg_expr(iid, idx) (out) {
     if k == K_FIELD { out = cg_field(iid, idx)  return out }
     if k == K_MAKEMAP { out = cg_makemap(iid, idx)  return out }
     if k == K_MAKECHAN {
-        // scalar element (int/float/bool): mfl_make_chan(sizeof(T), 0, 0, 0). String /
-        // slice / map / struct elements (JSON round-trip or string-offset copy) are
-        // later slices.
-        r := node_slot_of(iid, idx)
-        ek := 0 - 1
-        if r >= 0 { if g_elem[r] >= 0 { ek = kind_of(g_elem[r]) } }
-        if ek == 1 || ek == 2 || ek == 3 || ek == 4 {
-            out = "mfl_make_chan(sizeof(" + elem_ctype(iid, idx) + "), 0, 0, 0)"
+        // scalar: mfl_make_chan(sizeof(T), 0, 0, 0). string / struct-with-strings: the
+        // fast string-offset copy path (offsetof of each string field). slice/map (or a
+        // struct reaching one): a JSON round-trip -> deferred to a later slice.
+        ect := elem_ctype(iid, idx)
+        tn := chan_elem_typename(iid, idx)
+        if chan_needs_json(tn) == 1 { g_cg_unsup = 1  out = "0"  return out }
+        offs := chan_str_offsets(tn, "")
+        if len(offs) == 0 {
+            out = "mfl_make_chan(sizeof(" + ect + "), 0, 0, 0)"
             return out
         }
-        if ek == 5 {   // string element: one string-offset at byte 0 (fast in-place copy)
-            out = "mfl_make_chan(sizeof(" + elem_ctype(iid, idx) + "), 0, 0, 1, (int)(0))"
-            return out
-        }
-        g_cg_unsup = 1  out = "0"  return out
+        casted := []string{}
+        j := 0
+        for j < len(offs) { casted = append(casted, "(int)(" + offs[j] + ")")  j = j + 1 }
+        out = "mfl_make_chan(sizeof(" + ect + "), 0, 0, " + str(len(offs)) + ", " + join(casted, ", ") + ")"
+        return out
     }
     if k == K_RECV {
         out = "({ " + node_ctype(iid, idx) + " _r; mfl_chan_recv(" + cg_expr(iid, n.a) + ", &_r); _r; })"

--- a/selfhost/cgen.src
+++ b/selfhost/cgen.src
@@ -405,7 +405,76 @@ func cg_stmt(iid, idx, depth) {
         return
     }
     if k == K_GO { cg_go(iid, idx)  return }
-    g_cg_unsup = 1  cemit("0;\n")   // select: later parts
+    if k == K_SELECT { cg_select(iid, idx, depth)  return }
+    g_cg_unsup = 1  cemit("0;\n")
+}
+
+// cg_select: the poll loop over cases (port of selectStmt). Pre-evaluates each
+// channel op into temps, spins trying each case in source order (default, if any,
+// always fires last; otherwise mfl_sleep(1) and retry), then dispatches the winning
+// case body. The leading indent is already emitted by cg_stmt.
+func cg_select(iid, idx, depth) {
+    n := nodes[idx]
+    id := g_tmpid
+    g_tmpid = g_tmpid + 1
+    ids := str(id)
+    cemit("{\n")
+    // setup: pre-evaluate operands into _sc/_sv/_sok temps
+    i := 0
+    for i < len(n.kids) {
+        scn := nodes[n.kids[i]]
+        cis := str(i)
+        indent(depth + 1)
+        ch := cg_expr(iid, scn.a)
+        et := elem_ctype(iid, scn.a)
+        if scn.ival == 0 {
+            cemit("mfl_chan* _sc" + ids + "_" + cis + " = " + ch + "; " + et + " _sv" + ids + "_" + cis + "; int _sok" + ids + "_" + cis + " = 0;\n")
+        } else {
+            cemit("mfl_chan* _sc" + ids + "_" + cis + " = " + ch + "; " + et + " _sv" + ids + "_" + cis + " = " + cg_expr(iid, scn.b) + ";\n")
+        }
+        i = i + 1
+    }
+    indent(depth + 1)  cemit("int _sel" + ids + " = -1;\n")
+    indent(depth + 1)  cemit("for (;;) {\n")
+    i = 0
+    for i < len(n.kids) {
+        scn := nodes[n.kids[i]]
+        cis := str(i)
+        indent(depth + 2)
+        if scn.ival == 0 {
+            cemit("if (mfl_chan_tryrecv2(_sc" + ids + "_" + cis + ", &_sv" + ids + "_" + cis + ", &_sok" + ids + "_" + cis + ")) { _sel" + ids + " = " + cis + "; break; }\n")
+        } else {
+            cemit("{ mfl_chan_send(_sc" + ids + "_" + cis + ", &_sv" + ids + "_" + cis + "); _sel" + ids + " = " + cis + "; break; }\n")
+        }
+        i = i + 1
+    }
+    indent(depth + 2)
+    if n.ival == 1 {
+        cemit("{ _sel" + ids + " = " + str(len(n.kids)) + "; break; }\n")
+    } else {
+        cemit("mfl_sleep(1);\n")
+    }
+    indent(depth + 1)  cemit("}\n")
+    // dispatch the winning case
+    i = 0
+    for i < len(n.kids) {
+        scn := nodes[n.kids[i]]
+        cis := str(i)
+        indent(depth + 1)  cemit("if (_sel" + ids + " == " + cis + ") {\n")
+        if scn.ival == 0 {
+            if scn.s != "" && scn.s != "_" { indent(depth + 2)  cemit(var_ref(iid, scn.s) + " = _sv" + ids + "_" + cis + ";\n") }
+            if scn.s2 != "" && scn.s2 != "_" { indent(depth + 2)  cemit(var_ref(iid, scn.s2) + " = _sok" + ids + "_" + cis + ";\n") }
+        }
+        for _, s := range scn.kids { cg_stmt(iid, s, depth + 2) }
+        indent(depth + 1)  cemit("}\n")
+        i = i + 1
+    }
+    if n.ival == 1 {
+        indent(depth + 1)  cemit("if (_sel" + ids + " == " + str(len(n.kids)) + ") {\n")
+        for _, s := range n.kids2 { cg_stmt(iid, s, depth + 2) }
+        indent(depth + 1)  cemit("}\n")
+    }
+    indent(depth)  cemit("}\n")
 }
 
 // cg_go: `go f(args)` -> an arg struct + trampoline function into g_tramp, and a

--- a/selfhost/cgprog.src
+++ b/selfhost/cgprog.src
@@ -132,8 +132,18 @@ func cg_program() {
     // 4. function prototypes
     for _, rid := range g_reps { cemit(cg_signature(rid) + ";\n") }
     cemit("\n")
-    // 5. function bodies
+    // 5. function bodies — generated into a temp buffer so goroutine trampolines
+    //    (populated during body codegen via g_tramp) can be spliced BEFORE the
+    //    bodies, matching the reference compiler's tramp/buf split.
+    g_goid = 0
+    g_tramp = []string{}
+    saved := g_out
+    g_out = []string{}
     for _, rid := range g_reps { cg_function(rid) }
+    bodies := g_out
+    g_out = saved
+    for _, t := range g_tramp { cemit(t) }
+    for _, b := range bodies { cemit(b) }
     // 6. package-global initializers run in a C constructor (declaration order)
     if len(g_global_names) > 0 {
         cemit("__attribute__((constructor)) static void mfl_globals_init(void) {\n")

--- a/selfhost/checkgen.src
+++ b/selfhost/checkgen.src
@@ -917,7 +917,28 @@ func gen_stmt(idx) {
         gen_expr(n.a)
         return
     }
-    g_unsupported = 1   // select (later); funclit/closure bodies
+    if k == K_SELECT {
+        // n.kids = selcase nodes; n.kids2 = default body. Per case: constrain the
+        // channel op (recv binds the case var to the elem type + ok-name to bool;
+        // send unifies the value with the elem type), then check the body.
+        ci := 0
+        for ci < len(n.kids) {
+            scn := nodes[n.kids[ci]]
+            cs := gen_expr(scn.a)
+            eslot := chan_elem(cs)
+            if scn.ival == 0 {
+                if scn.s != "" && scn.s != "_" { add_pair(range_bind(scn.s), eslot) }
+                if scn.s2 != "" && scn.s2 != "_" { add_pair(range_bind(scn.s2), c_bool) }
+            } else {
+                add_pair(gen_expr(scn.b), eslot)
+            }
+            gen_block(scn.kids)
+            ci = ci + 1
+        }
+        gen_block(n.kids2)
+        return
+    }
+    g_unsupported = 1   // funclit/closure bodies
 }
 
 // range_bind: "" or "_" -> a throwaway slot (not named); else reuse/declare a local.

--- a/selfhost/racecheck.src
+++ b/selfhost/racecheck.src
@@ -1,0 +1,436 @@
+// selfhost/racecheck.src — the inferred data-race pass, ported from racecheck.go.
+//
+// Slice A: LOCAL parameter races (write/write + read/write) across goroutines,
+// type-aware (reachability). Happens-before precision, package globals, and
+// move-on-send are later slices; the self-hosted checker doesn't lift closures, so
+// closure-capture races are out of scope here.
+//
+// A place's access PATH is encoded as a string: "#" = an index step, ".field" = a
+// field step (field names are identifiers, so the encoding is unambiguous).
+
+// ---- place decomposition ----
+func place_root(idx) (root, ok) {
+    n := nodes[idx]
+    if n.kind == K_ID { root = n.s  ok = 1  return root, ok }
+    if n.kind == K_INDEX { root, ok = place_root(n.a)  return root, ok }
+    if n.kind == K_FIELD { root, ok = place_root(n.a)  return root, ok }
+    ok = 0
+}
+func place_path(idx) (p) {
+    n := nodes[idx]
+    p = ""
+    if n.kind == K_INDEX { p = place_path(n.a) + "#" }
+    if n.kind == K_FIELD { p = place_path(n.a) + "." + n.s }
+}
+
+// ---- stage 1: per-function parameter access summary (fixed-point) ----
+// Parallel arrays: for each recorded access, the function name, the parameter
+// index, the access-path string, and write(1)/read(0).
+var g_ac_fn = []string{}
+var g_ac_pi = []int{}
+var g_ac_path = []string{}
+var g_ac_w = []int{}
+
+func ac_has(fn, pi, path, w) (b) {
+    b = 0
+    i := 0
+    for i < len(g_ac_fn) {
+        if g_ac_fn[i] == fn && g_ac_pi[i] == pi && g_ac_path[i] == path && g_ac_w[i] == w { b = 1  return b }
+        i = i + 1
+    }
+}
+func ac_add(fn, pi, path, w) (changed) {
+    changed = 0
+    if ac_has(fn, pi, path, w) == 1 { return changed }
+    g_ac_fn = append(g_ac_fn, fn)
+    g_ac_pi = append(g_ac_pi, pi)
+    g_ac_path = append(g_ac_path, path)
+    g_ac_w = append(g_ac_w, w)
+    changed = 1
+}
+
+// param_index: the index of `name` among function `fn`'s parameters, or -1.
+func param_index(fnroot, name) (pi) {
+    pi = 0 - 1
+    ps := nodes[fnroot].names
+    i := 0
+    for i < len(ps) { if ps[i] == name { pi = i  return pi }  i = i + 1 }
+}
+
+// record a place access of `fn`'s param (if the place is rooted in one).
+func ac_record_place(fn, fnroot, placeIdx, w) (changed) {
+    changed = 0
+    root, ok := place_root(placeIdx)
+    if ok == 0 { return changed }
+    pi := param_index(fnroot, root)
+    if pi < 0 { return changed }
+    changed = ac_add(fn, pi, place_path(placeIdx), w)
+}
+
+// ac_visit_reads: record every element/field READ in an expression.
+func ac_visit_reads(fn, fnroot, idx) (changed) {
+    changed = 0
+    n := nodes[idx]
+    k := n.kind
+    if k == K_INDEX {
+        if ac_record_place(fn, fnroot, idx, 0) == 1 { changed = 1 }
+        if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+        if ac_visit_reads(fn, fnroot, n.b) == 1 { changed = 1 }
+        return changed
+    }
+    if k == K_FIELD {
+        if ac_record_place(fn, fnroot, idx, 0) == 1 { changed = 1 }
+        if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+        return changed
+    }
+    if k == K_CALL {
+        if ac_prop_call(fn, fnroot, n.s, n.kids) == 1 { changed = 1 }
+        for _, a := range n.kids { if ac_visit_reads(fn, fnroot, a) == 1 { changed = 1 } }
+        return changed
+    }
+    if k == K_BIN { if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }  if ac_visit_reads(fn, fnroot, n.b) == 1 { changed = 1 }  return changed }
+    if k == K_UNARY { changed = ac_visit_reads(fn, fnroot, n.a)  return changed }
+    if k == K_SLICE || k == K_STRUCT { for _, e := range n.kids { if ac_visit_reads(fn, fnroot, e) == 1 { changed = 1 } }  return changed }
+}
+
+// ac_prop_call: re-root each callee param access onto our matching argument.
+func ac_prop_call(fn, fnroot, callee, argidxs) (changed) {
+    changed = 0
+    j := 0
+    for j < len(argidxs) {
+        root, ok := place_root(argidxs[j])
+        if ok == 1 {
+            pi := param_index(fnroot, root)
+            if pi >= 0 {
+                pfx := place_path(argidxs[j])
+                i := 0
+                for i < len(g_ac_fn) {
+                    if g_ac_fn[i] == callee && g_ac_pi[i] == j {
+                        if ac_add(fn, pi, pfx + g_ac_path[i], g_ac_w[i]) == 1 { changed = 1 }
+                    }
+                    i = i + 1
+                }
+            }
+        }
+        j = j + 1
+    }
+}
+
+// ac_visit_stmts: walk a body accumulating param accesses.
+func ac_visit_stmts(fn, fnroot, kids) (changed) {
+    changed = 0
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_IDXASSIGN || k == K_FLDASSIGN {
+            if ac_record_place(fn, fnroot, n.a, 1) == 1 { changed = 1 }
+            if ac_visit_reads(fn, fnroot, n.b) == 1 { changed = 1 }
+        } else { if k == K_ASSIGN {
+            if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+        } else { if k == K_EXPRSTMT {
+            if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+        } else { if k == K_RETURN || k == K_MULTI {
+            for _, e := range n.kids { if ac_visit_reads(fn, fnroot, e) == 1 { changed = 1 } }
+        } else { if k == K_SEND {
+            if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+            if ac_visit_reads(fn, fnroot, n.b) == 1 { changed = 1 }
+        } else { if k == K_GO {
+            gc := nodes[n.a]
+            if ac_prop_call(fn, fnroot, gc.s, gc.kids) == 1 { changed = 1 }
+        } else { if k == K_IF {
+            if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+            if ac_visit_stmts(fn, fnroot, n.kids) == 1 { changed = 1 }
+            if ac_visit_stmts(fn, fnroot, n.kids2) == 1 { changed = 1 }
+        } else { if k == K_WHILE {
+            if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+            if ac_visit_stmts(fn, fnroot, n.kids) == 1 { changed = 1 }
+        } else { if k == K_RANGE {
+            if ac_visit_reads(fn, fnroot, n.a) == 1 { changed = 1 }
+            if ac_visit_stmts(fn, fnroot, n.kids) == 1 { changed = 1 }
+        } else { if k == K_ARENA {
+            if ac_visit_stmts(fn, fnroot, n.kids) == 1 { changed = 1 }
+        }}}}}}}}}}
+    }
+}
+
+func build_access_summary() {
+    run := 1
+    for run == 1 {
+        run = 0
+        fi := 0
+        for fi < len(g_func_names) {
+            fn := g_func_names[fi]
+            fr := g_func_roots[fi]
+            if ac_visit_stmts(fn, fr, nodes[fr].kids) == 1 { run = 1 }
+            fi = fi + 1
+        }
+    }
+}
+
+// ---- type reachability (does a path reach shared heap?) ----
+// slot_type_name: MFL type-name of a slot ("string", struct name, "[]..", "map[..",
+// else "int" scalar placeholder).
+func slot_type_name(slot) (s) {
+    r := find(slot)
+    k := g_kind[r]
+    if k == 5 { s = "string"  return s }
+    if k == 8 { s = g_sname[r]  return s }
+    if k == 7 { s = "[]" + slot_type_name(g_elem[r])  return s }
+    if k == 10 { s = "map[x]x"  return s }
+    s = "int"
+}
+
+// path_shared: walk the encoded path against type-name tn; shared once it crosses a
+// slice/map indirection (the shared backing), staying private through struct fields.
+func path_shared(tn, path) (b) {
+    b = 0
+    cur := tn
+    i := 0
+    for i < len(path) {
+        c := substr(path, i, i + 1)
+        if c == "#" {
+            if has_prefix(cur, "[]") { b = 1  cur = substr(cur, 2, len(cur)) } else {
+                if has_prefix(cur, "map[") { b = 1  cur = "int" } else { return b }
+            }
+            i = i + 1
+        } else {
+            // ".field": read the field name up to the next "#" or "." delimiter
+            j := i + 1
+            done := 0
+            for j < len(path) && done == 0 {
+                cc := substr(path, j, j + 1)
+                if cc == "#" || cc == "." { done = 1 } else { j = j + 1 }
+            }
+            fld := substr(path, i + 1, j)
+            di := struct_def_idx(cur)
+            if di < 0 { return b }
+            d := g_structdefs[di]
+            fi := 0
+            found := 0
+            for fi < len(d.fnames) { if d.fnames[fi] == fld { cur = d.ftypes[fi]  found = 1  fi = len(d.fnames) } else { fi = fi + 1 } }
+            if found == 0 { return b }
+            i = j
+        }
+    }
+}
+
+// ---- instance variable slot by name ----
+func inst_var_slot(iid, name) (slot) {
+    slot = 0 - 1
+    ins := g_insts[iid]
+    i := 0
+    for i < len(ins.pnames) { if ins.pnames[i] == name { slot = ins.pslots[i]  return slot }  i = i + 1 }
+    i = 0
+    for i < len(ins.lnames) { if ins.lnames[i] == name { slot = ins.lslots[i]  return slot }  i = i + 1 }
+}
+
+// ---- stage 2: race detection per representative instance ----
+// Accessors for the current instance's roots (parallel arrays, reset per instance).
+var g_x_root = []string{}
+var g_x_write = []int{}
+var g_x_go = []int{}
+var g_x_desc = []string{}
+
+func rc_note(iid, root, path, write, byGo, desc) {
+    slot := inst_var_slot(iid, root)
+    if slot < 0 { return }
+    if path_shared(slot_type_name(slot), path) == 0 { return }
+    g_x_root = append(g_x_root, root)
+    g_x_write = append(g_x_write, write)
+    g_x_go = append(g_x_go, byGo)
+    g_x_desc = append(g_x_desc, desc)
+}
+
+// rc_reads: this-thread element/field reads in an expression.
+func rc_reads(iid, fnroot, idx) {
+    n := nodes[idx]
+    k := n.kind
+    if k == K_INDEX {
+        root, ok := place_root(idx)
+        if ok == 1 { rc_note(iid, root, place_path(idx), 0, 0, "this thread reads `" + root + "`") }
+        rc_reads(iid, fnroot, n.a)
+        rc_reads(iid, fnroot, n.b)
+        return
+    }
+    if k == K_FIELD {
+        root, ok := place_root(idx)
+        if ok == 1 { rc_note(iid, root, place_path(idx), 0, 0, "this thread reads `" + root + "`") }
+        rc_reads(iid, fnroot, n.a)
+        return
+    }
+    if k == K_CALL { for _, a := range n.kids { rc_reads(iid, fnroot, a) }  return }
+    if k == K_BIN { rc_reads(iid, fnroot, n.a)  rc_reads(iid, fnroot, n.b)  return }
+    if k == K_UNARY { rc_reads(iid, fnroot, n.a)  return }
+    if k == K_SLICE || k == K_STRUCT { for _, e := range n.kids { rc_reads(iid, fnroot, e) }  return }
+}
+
+// rc_walk: collect this-thread + goroutine accessors over a body.
+func rc_walk(iid, fnroot, kids) {
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_GO {
+            gc := nodes[n.a]
+            g := gc.s
+            j := 0
+            for j < len(gc.kids) {
+                root, ok := place_root(gc.kids[j])
+                if ok == 1 {
+                    pfx := place_path(gc.kids[j])
+                    i := 0
+                    for i < len(g_ac_fn) {
+                        if g_ac_fn[i] == g && g_ac_pi[i] == j {
+                            verb := "reads"
+                            if g_ac_w[i] == 1 { verb = "writes" }
+                            rc_note(iid, root, pfx + g_ac_path[i], g_ac_w[i], 1, "goroutine `go " + g + "(...)` " + verb + " `" + root + "`")
+                        }
+                        i = i + 1
+                    }
+                }
+                j = j + 1
+            }
+        } else { if k == K_IDXASSIGN || k == K_FLDASSIGN {
+            root, ok := place_root(n.a)
+            if ok == 1 { rc_note(iid, root, place_path(n.a), 1, 0, "this thread writes `" + root + "`") }
+        } else { if k == K_EXPRSTMT { rc_reads(iid, fnroot, n.a)
+        } else { if k == K_ASSIGN { rc_reads(iid, fnroot, n.a)
+        } else { if k == K_RETURN || k == K_MULTI { for _, e := range n.kids { rc_reads(iid, fnroot, e) }
+        } else { if k == K_IF {
+            rc_reads(iid, fnroot, n.a)
+            rc_walk(iid, fnroot, n.kids)
+            rc_walk(iid, fnroot, n.kids2)
+        } else { if k == K_WHILE {
+            rc_reads(iid, fnroot, n.a)
+            rc_walk(iid, fnroot, n.kids)
+        } else { if k == K_RANGE {
+            rc_reads(iid, fnroot, n.a)
+            rc_walk(iid, fnroot, n.kids)
+        } else { if k == K_ARENA {
+            rc_walk(iid, fnroot, n.kids)
+        }}}}}}}}}
+    }
+}
+
+// ---- findings ----
+var g_rf_decl = []string{}
+var g_rf_kind = []string{}
+var g_rf_root = []string{}
+var g_rf_writers = []string{}   // comma-joined sorted writer descriptions
+
+// sort_strings: ascending byte order (matches Go sort.Strings), insertion sort.
+func sort_strings(xs) (out) {
+    out = xs
+    i := 1
+    for i < len(out) {
+        j := i
+        for j > 0 {
+            if str_lt(out[j], out[j - 1]) == 1 {
+                tmp := out[j]  out[j] = out[j - 1]  out[j - 1] = tmp
+                j = j - 1
+            } else { j = 0 }
+        }
+        i = i + 1
+    }
+}
+func str_lt(a, b) (r) {
+    r = 0
+    i := 0
+    na := len(a)
+    nb := len(b)
+    for i < na {
+        if i >= nb { return r }
+        ca := byte_at(bytes(a), i)
+        cb := byte_at(bytes(b), i)
+        if ca < cb { r = 1  return r }
+        if ca > cb { return r }
+        i = i + 1
+    }
+    if nb > na { r = 1 }
+}
+
+func detect_races() {
+    build_access_summary()
+    ri := 0
+    for ri < len(g_insts) {
+        iid := ri
+        ins := g_insts[iid]
+        fnroot := func_root(ins.src)
+        if fnroot < 0 { ri = ri + 1  continue }
+        g_x_root = []string{}
+        g_x_write = []int{}
+        g_x_go = []int{}
+        g_x_desc = []string{}
+        rc_walk(iid, fnroot, nodes[fnroot].kids)
+        // group accessors by distinct root; a root with >=2 accessors, >=1 write and
+        // >=1 goroutine is a race.
+        seen := []string{}
+        ai := 0
+        for ai < len(g_x_root) {
+            root := g_x_root[ai]
+            already := 0
+            si := 0
+            for si < len(seen) { if seen[si] == root { already = 1  si = len(seen) } else { si = si + 1 } }
+            if already == 0 {
+                seen = append(seen, root)
+                total := 0
+                writes := 0
+                gos := 0
+                descs := []string{}
+                bi := 0
+                for bi < len(g_x_root) {
+                    if g_x_root[bi] == root {
+                        total = total + 1
+                        if g_x_write[bi] == 1 { writes = writes + 1 }
+                        if g_x_go[bi] == 1 { gos = gos + 1 }
+                        descs = append(descs, g_x_desc[bi])
+                    }
+                    bi = bi + 1
+                }
+                if gos >= 1 && total >= 2 && writes >= 1 {
+                    kind := "read/write"
+                    if writes >= 2 { kind = "write/write" }
+                    descs = sort_strings(descs)
+                    g_rf_decl = append(g_rf_decl, ins.src)
+                    g_rf_kind = append(g_rf_kind, kind)
+                    g_rf_root = append(g_rf_root, root)
+                    g_rf_writers = append(g_rf_writers, join(descs, "\x01"))
+                }
+            }
+            ai = ai + 1
+        }
+        ri = ri + 1
+    }
+}
+
+// dump_races: findings sorted by (decl, root), one hex-encoded line each — the exact
+// canonical form of `machin racetest --program` (the Go-reference oracle).
+func dump_races() (out) {
+    out = ""
+    keys := []string{}
+    lines := []string{}
+    k := 0
+    for k < len(g_rf_decl) {
+        ws := split(g_rf_writers[k], "\x01")
+        hws := []string{}
+        wi := 0
+        for wi < len(ws) { hws = append(hws, to_hex(bytes(ws[wi])))  wi = wi + 1 }
+        line := to_hex(bytes(g_rf_decl[k])) + "|" + to_hex(bytes(g_rf_kind[k])) + "|" + to_hex(bytes(g_rf_root[k])) + "|" + join(hws, ",") + "\n"
+        keys = append(keys, g_rf_decl[k] + "\x00" + g_rf_root[k])
+        lines = append(lines, line)
+        k = k + 1
+    }
+    i := 1
+    for i < len(lines) {
+        j := i
+        for j > 0 {
+            if str_lt(keys[j], keys[j - 1]) == 1 {
+                tk := keys[j]  keys[j] = keys[j - 1]  keys[j - 1] = tk
+                tl := lines[j]  lines[j] = lines[j - 1]  lines[j - 1] = tl
+                j = j - 1
+            } else { j = 0 }
+        }
+        i = i + 1
+    }
+    i = 0
+    for i < len(lines) { out = out + lines[i]  i = i + 1 }
+}

--- a/selfhost/racecheck.src
+++ b/selfhost/racecheck.src
@@ -655,3 +655,423 @@ func dump_races() (out) {
     i = 0
     for i < len(lines) { out = out + lines[i]  i = i + 1 }
 }
+
+// ── package globals (a `var` is one shared cell -> unconditional sharing) ──
+var g_gd_fn = []string{}
+var g_gd_g = []string{}
+var g_gd_r = []int{}
+var g_gd_w = []int{}
+var g_gall_fn = []string{}
+var g_gall_g = []string{}
+var g_gall_r = []int{}
+var g_gall_w = []int{}
+var g_nc_fn = []string{}
+var g_nc_ce = []string{}
+var g_go_ce = []string{}
+var g_go_loop = []int{}
+var g_mc_g = []string{}
+var g_mc_r = []int{}
+var g_mc_w = []int{}
+
+func is_global_name(name) (b) {
+    _, f := global_lookup(name)
+    b = f
+}
+func name_in(name, xs) (b) {
+    b = 0
+    i := 0
+    for i < len(xs) { if xs[i] == name { b = 1  return b }  i = i + 1 }
+}
+func is_gaccess(name, locals) (b) {
+    b = 0
+    if is_global_name(name) == 1 && name_in(name, locals) == 0 { b = 1 }
+}
+
+func gd_merge(dst, fn, g, r, w) (changed) {
+    // dst==0 -> g_gd_*, dst==1 -> g_gall_*
+    changed = 0
+    if dst == 0 {
+        i := 0
+        for i < len(g_gd_fn) { if g_gd_fn[i] == fn && g_gd_g[i] == g { if r == 1 { g_gd_r[i] = 1 }  if w == 1 { g_gd_w[i] = 1 }  return changed }  i = i + 1 }
+        g_gd_fn = append(g_gd_fn, fn)  g_gd_g = append(g_gd_g, g)  g_gd_r = append(g_gd_r, r)  g_gd_w = append(g_gd_w, w)
+        changed = 1
+        return changed
+    }
+    i := 0
+    for i < len(g_gall_fn) {
+        if g_gall_fn[i] == fn && g_gall_g[i] == g {
+            if r == 1 && g_gall_r[i] == 0 { g_gall_r[i] = 1  changed = 1 }
+            if w == 1 && g_gall_w[i] == 0 { g_gall_w[i] = 1  changed = 1 }
+            return changed
+        }
+        i = i + 1
+    }
+    g_gall_fn = append(g_gall_fn, fn)  g_gall_g = append(g_gall_g, g)  g_gall_r = append(g_gall_r, r)  g_gall_w = append(g_gall_w, w)
+    changed = 1
+}
+
+// gd_rd: record global element/field/bare-ident READS in an expression.
+func gd_rd(fn, locals, idx) {
+    n := nodes[idx]
+    k := n.kind
+    if k == K_ID { if is_gaccess(n.s, locals) == 1 { gd_merge(0, fn, n.s, 1, 0) }  return }
+    if k == K_INDEX {
+        root, ok := place_root(idx)
+        if ok == 1 { if is_gaccess(root, locals) == 1 { gd_merge(0, fn, root, 1, 0) } }
+        gd_rd(fn, locals, n.a)  gd_rd(fn, locals, n.b)
+        return
+    }
+    if k == K_FIELD {
+        root, ok := place_root(idx)
+        if ok == 1 { if is_gaccess(root, locals) == 1 { gd_merge(0, fn, root, 1, 0) } }
+        gd_rd(fn, locals, n.a)
+        return
+    }
+    if k == K_CALL { for _, a := range n.kids { gd_rd(fn, locals, a) }  return }
+    if k == K_BIN { gd_rd(fn, locals, n.a)  gd_rd(fn, locals, n.b)  return }
+    if k == K_UNARY { gd_rd(fn, locals, n.a)  return }
+    if k == K_SLICE || k == K_STRUCT { for _, e := range n.kids { gd_rd(fn, locals, e) }  return }
+}
+
+// gd_walk: direct global accesses (writes + reads) + normal-callee/go edges.
+func gd_walk(fn, locals, kids) {
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_ASSIGN {
+            if n.s2 == "=" { if is_gaccess(n.s, locals) == 1 { gd_merge(0, fn, n.s, 0, 1) } }
+            gd_rd(fn, locals, n.a)
+        } else { if k == K_MULTI {
+            for _, e := range n.kids { gd_rd(fn, locals, e) }
+        } else { if k == K_IDXASSIGN {
+            root, ok := place_root(n.a)
+            if ok == 1 { if is_gaccess(root, locals) == 1 { gd_merge(0, fn, root, 0, 1) } }
+            gd_rd(fn, locals, nodes[n.a].b)
+            gd_rd(fn, locals, n.b)
+        } else { if k == K_FLDASSIGN {
+            root, ok := place_root(n.a)
+            if ok == 1 { if is_gaccess(root, locals) == 1 { gd_merge(0, fn, root, 0, 1) } }
+            gd_rd(fn, locals, n.b)
+        } else { if k == K_EXPRSTMT {
+            cn := nodes[n.a]
+            if cn.kind == K_CALL { g_nc_fn = append(g_nc_fn, fn)  g_nc_ce = append(g_nc_ce, cn.s) }
+            gd_rd(fn, locals, n.a)
+        } else { if k == K_SEND {
+            gd_rd(fn, locals, n.a)  gd_rd(fn, locals, n.b)
+        } else { if k == K_RETURN {
+            for _, e := range n.kids { gd_rd(fn, locals, e) }
+        } else { if k == K_GO {
+            gc := nodes[n.a]
+            g_go_ce = append(g_go_ce, gc.s)  g_go_loop = append(g_go_loop, 0)
+            for _, a := range gc.kids { gd_rd(fn, locals, a) }
+        } else { if k == K_IF {
+            gd_rd(fn, locals, n.a)  gd_walk(fn, locals, n.kids)  gd_walk(fn, locals, n.kids2)
+        } else { if k == K_WHILE {
+            gd_rd(fn, locals, n.a)  gd_walk_loop(fn, locals, n.kids)
+        } else { if k == K_RANGE {
+            gd_rd(fn, locals, n.a)  gd_walk_loop(fn, locals, n.kids)
+        } else { if k == K_ARENA {
+            gd_walk(fn, locals, n.kids)
+        }}}}}}}}}}}}
+    }
+}
+// gd_walk_loop: like gd_walk but go sites inside are loop-spawned (multiplicity).
+func gd_walk_loop(fn, locals, kids) {
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_GO {
+            gc := nodes[n.a]
+            g_go_ce = append(g_go_ce, gc.s)  g_go_loop = append(g_go_loop, 1)
+            for _, a := range gc.kids { gd_rd(fn, locals, a) }
+        } else { if k == K_EXPRSTMT {
+            cn := nodes[n.a]
+            if cn.kind == K_CALL { g_nc_fn = append(g_nc_fn, fn)  g_nc_ce = append(g_nc_ce, cn.s) }
+            gd_rd(fn, locals, n.a)
+        } else { if k == K_ASSIGN { gd_rd(fn, locals, n.a)
+        } else { if k == K_IDXASSIGN {
+            root, ok := place_root(n.a)
+            if ok == 1 { if is_gaccess(root, locals) == 1 { gd_merge(0, fn, root, 0, 1) } }
+            gd_rd(fn, locals, nodes[n.a].b)  gd_rd(fn, locals, n.b)
+        } else { if k == K_FLDASSIGN {
+            root, ok := place_root(n.a)
+            if ok == 1 { if is_gaccess(root, locals) == 1 { gd_merge(0, fn, root, 0, 1) } }
+            gd_rd(fn, locals, n.b)
+        } else { if k == K_IF { gd_rd(fn, locals, n.a)  gd_walk_loop(fn, locals, n.kids)  gd_walk_loop(fn, locals, n.kids2)
+        } else { if k == K_WHILE || k == K_RANGE || k == K_ARENA { gd_walk_loop(fn, locals, n.kids)
+        } else { if k == K_SEND { gd_rd(fn, locals, n.a)  gd_rd(fn, locals, n.b)
+        }}}}}}}}
+    }
+}
+
+func collect_locals(kids, into) (out) {
+    out = into
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_ASSIGN { if n.s2 == ":=" { out = append(out, n.s) }
+        } else { if k == K_MULTI { if n.s2 == ":=" { for _, nm := range n.names { out = append(out, nm) } }
+        } else { if k == K_RANGE {
+            if n.s != "" { out = append(out, n.s) }
+            if n.s2 != "" { out = append(out, n.s2) }
+            out = collect_locals(n.kids, out)
+        } else { if k == K_IF { out = collect_locals(n.kids, out)  out = collect_locals(n.kids2, out)
+        } else { if k == K_WHILE || k == K_ARENA { out = collect_locals(n.kids, out)
+        }}}}}
+    }
+}
+
+func mc_merge(g, r, w) {
+    i := 0
+    for i < len(g_mc_g) { if g_mc_g[i] == g { if r == 1 { g_mc_r[i] = 1 }  if w == 1 { g_mc_w[i] = 1 }  return }  i = i + 1 }
+    g_mc_g = append(g_mc_g, g)  g_mc_r = append(g_mc_r, r)  g_mc_w = append(g_mc_w, w)
+}
+
+func global_races() {
+    if len(g_global_names) == 0 { return }
+    g_gd_fn = []string{}  g_gd_g = []string{}  g_gd_r = []int{}  g_gd_w = []int{}
+    g_gall_fn = []string{}  g_gall_g = []string{}  g_gall_r = []int{}  g_gall_w = []int{}
+    g_nc_fn = []string{}  g_nc_ce = []string{}
+    g_go_ce = []string{}  g_go_loop = []int{}
+    g_mc_g = []string{}  g_mc_r = []int{}  g_mc_w = []int{}
+
+    // direct global accesses per source function (+ normal-callee / go edges)
+    fi := 0
+    for fi < len(g_func_names) {
+        fr := g_func_roots[fi]
+        locals := []string{}
+        for _, p := range nodes[fr].names { locals = append(locals, p) }
+        locals = collect_locals(nodes[fr].kids, locals)
+        gd_walk(g_func_names[fi], locals, nodes[fr].kids)
+        fi = fi + 1
+    }
+    // seed gall = gdirect
+    gi := 0
+    for gi < len(g_gd_fn) { gd_merge(1, g_gd_fn[gi], g_gd_g[gi], g_gd_r[gi], g_gd_w[gi])  gi = gi + 1 }
+    // transitive over NORMAL calls
+    run := 1
+    for run == 1 {
+        run = 0
+        ei := 0
+        for ei < len(g_nc_fn) {
+            fn := g_nc_fn[ei]
+            ce := g_nc_ce[ei]
+            ai := 0
+            for ai < len(g_gall_fn) {
+                if g_gall_fn[ai] == ce { if gd_merge(1, fn, g_gall_g[ai], g_gall_r[ai], g_gall_w[ai]) == 1 { run = 1 } }
+                ai = ai + 1
+            }
+            ei = ei + 1
+        }
+    }
+    // main-thread concurrent globals: direct post-spawn + normal-callee transitive
+    mr := func_root("main")
+    if mr >= 0 {
+        mlocals := []string{}
+        for _, p := range nodes[mr].names { mlocals = append(mlocals, p) }
+        mlocals = collect_locals(nodes[mr].kids, mlocals)
+        main_post_globals(mlocals, nodes[mr].kids)
+        // normal callees of main -> their gall
+        ei := 0
+        for ei < len(g_nc_fn) {
+            if g_nc_fn[ei] == "main" {
+                ai := 0
+                for ai < len(g_gall_fn) {
+                    if g_gall_fn[ai] == g_nc_ce[ei] { mc_merge(g_gall_g[ai], g_gall_r[ai], g_gall_w[ai]) }
+                    ai = ai + 1
+                }
+            }
+            ei = ei + 1
+        }
+    }
+
+    // per global G: gather concurrent threads
+    ni := 0
+    for ni < len(g_global_names) {
+        g := g_global_names[ni]
+        total := 0
+        writes := 0
+        gothreads := 0
+        descs := []string{}
+        // goroutine threads (any `go` site whose callee's gall footprint touches G)
+        si := 0
+        for si < len(g_go_ce) {
+            ce := g_go_ce[si]
+            ai := 0
+            for ai < len(g_gall_fn) {
+                if g_gall_fn[ai] == ce && g_gall_g[ai] == g {
+                    mult := 1
+                    label := "goroutine"
+                    if g_go_loop[si] == 1 { mult = 2  label = "loop-spawned goroutine" }
+                    verb := "reads"
+                    isw := 0
+                    if g_gall_w[ai] == 1 { verb = "writes"  isw = 1 }
+                    total = total + mult
+                    if isw == 1 { writes = writes + mult }
+                    gothreads = gothreads + 1
+                    descs = append(descs, label + " `go " + ce + "(...)` " + verb + " global `" + g + "`")
+                }
+                ai = ai + 1
+            }
+            si = si + 1
+        }
+        // main thread
+        mi := 0
+        for mi < len(g_mc_g) {
+            if g_mc_g[mi] == g {
+                verb := "reads"
+                isw := 0
+                if g_mc_w[mi] == 1 { verb = "writes"  isw = 1 }
+                total = total + 1
+                if isw == 1 { writes = writes + 1 }
+                descs = append(descs, "main thread " + verb + " global `" + g + "`")
+            }
+            mi = mi + 1
+        }
+        if gothreads >= 1 && total >= 2 && writes >= 1 {
+            kind := "read/write"
+            if writes >= 2 { kind = "write/write" }
+            descs = sort_strings(descs)
+            g_rf_decl = append(g_rf_decl, "")
+            g_rf_kind = append(g_rf_kind, kind)
+            g_rf_root = append(g_rf_root, g)
+            g_rf_writers = append(g_rf_writers, join(descs, "\x01"))
+        }
+        ni = ni + 1
+    }
+}
+
+// main_post_globals: main's DIRECT global accesses AFTER the first `go` spawn (a write
+// before the spawn is ordered-before it), collected into g_mc_*.
+var g_mpg_spawned = 0
+func main_post_globals(locals, kids) {
+    g_mpg_spawned = 0
+    mpg_walk(locals, kids)
+}
+func mpg_walk(locals, kids) {
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_GO { g_mpg_spawned = 1
+        } else {
+            if g_mpg_spawned == 1 {
+                mpg_stmt(locals, s)
+            } else {
+                b, ok := mpg_block(s)
+                if ok == 1 { mpg_walk(locals, b) }
+            }
+        }
+    }
+}
+func mpg_block(s) (b, ok) {
+    n := nodes[s]
+    k := n.kind
+    ok = 0
+    b = []int{}
+    if k == K_IF { b = n.kids  ok = 1  bi := 0  for bi < len(n.kids2) { b = append(b, n.kids2[bi])  bi = bi + 1 }  return b, ok }
+    if k == K_WHILE || k == K_RANGE || k == K_ARENA { b = n.kids  ok = 1 }
+}
+// mpg_stmt: record a single post-spawn statement's direct globals into g_mc_*.
+func mpg_stmt(locals, s) {
+    // reuse gd_walk into a temp fn name, then fold new g_gd_* rows for that fn into g_mc_*
+    before := len(g_gd_fn)
+    one := []int{}
+    one = append(one, s)
+    gd_walk("\x02mpg", locals, one)
+    i := before
+    for i < len(g_gd_fn) {
+        if g_gd_fn[i] == "\x02mpg" { mc_merge(g_gd_g[i], g_gd_r[i], g_gd_w[i]) }
+        i = i + 1
+    }
+}
+
+// ── move-on-send: `ch <- v` transfers ownership; touching v afterward = use-after-move ──
+var g_moved = []string{}
+var g_uam_done = []string{}   // dedup keyed by src\x00name (across instances of a src)
+var g_uam_iid = 0
+
+func moved_has(name) (b) {
+    b = 0
+    i := 0
+    for i < len(g_moved) { if g_moved[i] == name { b = 1  return b }  i = i + 1 }
+}
+func moved_add(name) { if moved_has(name) == 0 { g_moved = append(g_moved, name) } }
+func moved_del(name) {
+    nm := []string{}
+    i := 0
+    for i < len(g_moved) { if g_moved[i] != name { nm = append(nm, g_moved[i]) }  i = i + 1 }
+    g_moved = nm
+}
+func uam_flag(name) {
+    if moved_has(name) == 0 { return }
+    key := g_insts[g_uam_iid].src + "\x00" + name
+    if name_in(key, g_uam_done) == 1 { return }
+    g_uam_done = append(g_uam_done, key)
+    g_rf_decl = append(g_rf_decl, g_insts[g_uam_iid].src)
+    g_rf_kind = append(g_rf_kind, "use-after-move")
+    g_rf_root = append(g_rf_root, name)
+    g_rf_writers = append(g_rf_writers, "`" + name + "` is used after it was sent on a channel (ownership moved to the receiver)")
+}
+func uam_uses(idx) {
+    n := nodes[idx]
+    k := n.kind
+    if k == K_ID { uam_flag(n.s)  return }
+    if k == K_INDEX { root, ok := place_root(idx)  if ok == 1 { uam_flag(root) }  uam_uses(n.a)  uam_uses(n.b)  return }
+    if k == K_FIELD { root, ok := place_root(idx)  if ok == 1 { uam_flag(root) }  uam_uses(n.a)  return }
+    if k == K_CALL { for _, a := range n.kids { uam_uses(a) }  return }
+    if k == K_BIN { uam_uses(n.a)  uam_uses(n.b)  return }
+    if k == K_UNARY { uam_uses(n.a)  return }
+    if k == K_SLICE || k == K_STRUCT { for _, e := range n.kids { uam_uses(e) }  return }
+}
+func uam_shared(iid, name) (b) {
+    b = 0
+    slot := inst_var_slot(iid, name)
+    if slot < 0 { return b }
+    if chan_needs_json(slot_type_name(slot)) == 1 { b = 1 }
+}
+func uam_scan(iid, kids) {
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_SEND {
+            uam_uses(n.a)
+            vn := nodes[n.b]
+            if vn.kind == K_ID {
+                if moved_has(vn.s) == 1 { uam_flag(vn.s) } else { if uam_shared(iid, vn.s) == 1 { moved_add(vn.s) } }
+            } else { uam_uses(n.b) }
+        } else { if k == K_ASSIGN {
+            uam_uses(n.a)  moved_del(n.s)
+        } else { if k == K_MULTI {
+            for _, e := range n.kids { uam_uses(e) }
+            for _, nm := range n.names { moved_del(nm) }
+        } else { if k == K_IDXASSIGN {
+            root, ok := place_root(n.a)
+            if ok == 1 { uam_flag(root) }
+            uam_uses(nodes[n.a].b)  uam_uses(n.b)
+        } else { if k == K_FLDASSIGN {
+            root, ok := place_root(n.a)
+            if ok == 1 { uam_flag(root) }
+            uam_uses(n.b)
+        } else { if k == K_EXPRSTMT { uam_uses(n.a)
+        } else { if k == K_RETURN { for _, e := range n.kids { uam_uses(e) }
+        } else { if k == K_GO { gc := nodes[n.a]  for _, a := range gc.kids { uam_uses(a) }
+        } else { if k == K_IF { uam_uses(n.a)  uam_scan(iid, n.kids)  uam_scan(iid, n.kids2)
+        } else { if k == K_WHILE { uam_uses(n.a)  uam_scan(iid, n.kids)
+        } else { if k == K_RANGE { uam_uses(n.a)  moved_del(n.s)  moved_del(n.s2)  uam_scan(iid, n.kids)
+        } else { if k == K_ARENA { uam_scan(iid, n.kids)
+        }}}}}}}}}}}}
+    }
+}
+func use_after_send() {
+    g_uam_done = []string{}
+    ri := 0
+    for ri < len(g_insts) {
+        ins := g_insts[ri]
+        fr := func_root(ins.src)
+        if fr < 0 { ri = ri + 1  continue }
+        g_moved = []string{}
+        g_uam_iid = ri
+        uam_scan(ri, nodes[fr].kids)
+        ri = ri + 1
+    }
+}

--- a/selfhost/racecheck.src
+++ b/selfhost/racecheck.src
@@ -229,32 +229,133 @@ func inst_var_slot(iid, name) (slot) {
 var g_x_root = []string{}
 var g_x_write = []int{}
 var g_x_go = []int{}
+var g_x_mult = []int{}
 var g_x_desc = []string{}
 
-func rc_note(iid, root, path, write, byGo, desc) {
+// ── happens-before state (Slice: order sensitivity + channel-join barriers) ──
+// live[root] = spawned-but-not-yet-joined goroutines touching root; a THIS-THREAD
+// access is concurrent only while live>0. Goroutine accessors are always recorded.
+var g_live_root = []string{}
+var g_live_n = []int{}
+// join bookkeeping (top-level linear path only): a `go f(...,done)` whose callee's
+// LAST statement is `done <- ...` provably completes before a receiver reads `done`.
+var g_spawn_ch = []string{}
+var g_spawn_n = []int{}
+var g_recv_ch = []string{}
+var g_recv_n = []int{}
+var g_pend_ch = []string{}
+var g_pend_root = []string{}
+var g_pend_n = []int{}
+
+func live_get(root) (v) {
+    v = 0
+    i := 0
+    for i < len(g_live_root) { if g_live_root[i] == root { v = g_live_n[i]  return v }  i = i + 1 }
+}
+func live_add(root, d) {
+    i := 0
+    for i < len(g_live_root) {
+        if g_live_root[i] == root { nv := g_live_n[i] + d  if nv < 0 { nv = 0 }  g_live_n[i] = nv  return }
+        i = i + 1
+    }
+    nv := d
+    if nv < 0 { nv = 0 }
+    g_live_root = append(g_live_root, root)
+    g_live_n = append(g_live_n, nv)
+}
+
+func ctr_get(chs, cns, ch) (v) {
+    v = 0
+    i := 0
+    for i < len(chs) { if chs[i] == ch { v = cns[i]  return v }  i = i + 1 }
+}
+
+func spawn_inc(ch) {
+    i := 0
+    for i < len(g_spawn_ch) { if g_spawn_ch[i] == ch { g_spawn_n[i] = g_spawn_n[i] + 1  return }  i = i + 1 }
+    g_spawn_ch = append(g_spawn_ch, ch)
+    g_spawn_n = append(g_spawn_n, 1)
+}
+func spawn_set0(ch) {
+    i := 0
+    for i < len(g_spawn_ch) { if g_spawn_ch[i] == ch { g_spawn_n[i] = 0  return }  i = i + 1 }
+}
+func recv_inc(ch) (v) {
+    i := 0
+    for i < len(g_recv_ch) { if g_recv_ch[i] == ch { g_recv_n[i] = g_recv_n[i] + 1  v = g_recv_n[i]  return v }  i = i + 1 }
+    g_recv_ch = append(g_recv_ch, ch)
+    g_recv_n = append(g_recv_n, 1)
+    v = 1
+}
+func recv_set0(ch) {
+    i := 0
+    for i < len(g_recv_ch) { if g_recv_ch[i] == ch { g_recv_n[i] = 0  return }  i = i + 1 }
+}
+func pend_add(ch, root) {
+    i := 0
+    for i < len(g_pend_ch) {
+        if g_pend_ch[i] == ch && g_pend_root[i] == root { g_pend_n[i] = g_pend_n[i] + 1  return }
+        i = i + 1
+    }
+    g_pend_ch = append(g_pend_ch, ch)
+    g_pend_root = append(g_pend_root, root)
+    g_pend_n = append(g_pend_n, 1)
+}
+
+// param_signals_complete: is callee's param #j the channel it signals completion on
+// (its LAST statement is `param_j <- ...`)? The sound basis for a channel-join barrier.
+func param_signals_complete(callee, j) (b) {
+    b = 0
+    fr := func_root(callee)
+    if fr < 0 { return b }
+    ps := nodes[fr].names
+    if j >= len(ps) { return b }
+    pname := ps[j]
+    kids := nodes[fr].kids
+    if len(kids) == 0 { return b }
+    last := nodes[kids[len(kids) - 1]]
+    if last.kind == K_SEND {
+        chn := nodes[last.a]
+        if chn.kind == K_ID { if chn.s == pname { b = 1 } }
+    }
+}
+
+func rc_note_go(iid, root, path, write, mult, desc) {
     slot := inst_var_slot(iid, root)
     if slot < 0 { return }
     if path_shared(slot_type_name(slot), path) == 0 { return }
     g_x_root = append(g_x_root, root)
     g_x_write = append(g_x_write, write)
-    g_x_go = append(g_x_go, byGo)
+    g_x_go = append(g_x_go, 1)
+    g_x_mult = append(g_x_mult, mult)
+    g_x_desc = append(g_x_desc, desc)
+}
+func rc_note_this(iid, root, path, write, desc) {
+    if live_get(root) <= 0 { return }
+    slot := inst_var_slot(iid, root)
+    if slot < 0 { return }
+    if path_shared(slot_type_name(slot), path) == 0 { return }
+    g_x_root = append(g_x_root, root)
+    g_x_write = append(g_x_write, write)
+    g_x_go = append(g_x_go, 0)
+    g_x_mult = append(g_x_mult, 1)
     g_x_desc = append(g_x_desc, desc)
 }
 
-// rc_reads: this-thread element/field reads in an expression.
+// rc_reads: this-thread element/field reads in an expression (live-gated).
 func rc_reads(iid, fnroot, idx) {
     n := nodes[idx]
     k := n.kind
     if k == K_INDEX {
         root, ok := place_root(idx)
-        if ok == 1 { rc_note(iid, root, place_path(idx), 0, 0, "this thread reads `" + root + "`") }
+        if ok == 1 { rc_note_this(iid, root, place_path(idx), 0, "this thread reads `" + root + "`") }
         rc_reads(iid, fnroot, n.a)
         rc_reads(iid, fnroot, n.b)
         return
     }
     if k == K_FIELD {
         root, ok := place_root(idx)
-        if ok == 1 { rc_note(iid, root, place_path(idx), 0, 0, "this thread reads `" + root + "`") }
+        if ok == 1 { rc_note_this(iid, root, place_path(idx), 0, "this thread reads `" + root + "`") }
         rc_reads(iid, fnroot, n.a)
         return
     }
@@ -264,8 +365,51 @@ func rc_reads(iid, fnroot, idx) {
     if k == K_SLICE || k == K_STRUCT { for _, e := range n.kids { rc_reads(iid, fnroot, e) }  return }
 }
 
-// rc_walk: collect this-thread + goroutine accessors over a body.
-func rc_walk(iid, fnroot, kids) {
+func live_set(root, v) {
+    i := 0
+    for i < len(g_live_root) { if g_live_root[i] == root { g_live_n[i] = v  return }  i = i + 1 }
+    g_live_root = append(g_live_root, root)
+    g_live_n = append(g_live_n, v)
+}
+func pend_clear(ch) {
+    nc := []string{}
+    nr := []string{}
+    nn := []int{}
+    i := 0
+    for i < len(g_pend_ch) {
+        if g_pend_ch[i] != ch { nc = append(nc, g_pend_ch[i])  nr = append(nr, g_pend_root[i])  nn = append(nn, g_pend_n[i]) }
+        i = i + 1
+    }
+    g_pend_ch = nc
+    g_pend_root = nr
+    g_pend_n = nn
+}
+
+// join_recv: a top-level `<-ch`. Once received >= times spawned on a signalling
+// channel, the joined goroutines have finished — drain their roots from live.
+func join_recv(valexpr) {
+    vn := nodes[valexpr]
+    if vn.kind != K_RECV { return }
+    chn := nodes[vn.a]
+    if chn.kind != K_ID { return }
+    ch := chn.s
+    rc := recv_inc(ch)
+    sc := ctr_get(g_spawn_ch, g_spawn_n, ch)
+    if sc >= 1 && rc >= sc {
+        i := 0
+        for i < len(g_pend_ch) {
+            if g_pend_ch[i] == ch { live_add(g_pend_root[i], 0 - g_pend_n[i]) }
+            i = i + 1
+        }
+        pend_clear(ch)
+        spawn_set0(ch)
+        recv_set0(ch)
+    }
+}
+
+// mark_loop_spawns: pre-mark roots touched by goroutines inside a loop body as live,
+// so every this-thread access in the loop is treated as concurrent.
+func mark_loop_spawns(kids) {
     for _, s := range kids {
         n := nodes[s]
         k := n.kind
@@ -276,38 +420,105 @@ func rc_walk(iid, fnroot, kids) {
             for j < len(gc.kids) {
                 root, ok := place_root(gc.kids[j])
                 if ok == 1 {
+                    i := 0
+                    for i < len(g_ac_fn) { if g_ac_fn[i] == g && g_ac_pi[i] == j { live_add(root, 1) }  i = i + 1 }
+                }
+                j = j + 1
+            }
+        } else { if k == K_IF { mark_loop_spawns(n.kids)  mark_loop_spawns(n.kids2)
+        } else { if k == K_WHILE || k == K_RANGE || k == K_ARENA { mark_loop_spawns(n.kids)
+        }}}
+    }
+}
+
+// rc_visit: order-sensitive collection. `inLoop` gives loop-spawn multiplicity;
+// `top` (function's linear statement list) enables join bookkeeping. This-thread
+// accesses are recorded only while live>0; goroutine accessors always.
+func rc_visit(iid, fnroot, kids, inLoop, top) {
+    for _, s := range kids {
+        n := nodes[s]
+        k := n.kind
+        if k == K_GO {
+            gc := nodes[n.a]
+            g := gc.s
+            mult := 1
+            label := "goroutine"
+            if inLoop == 1 { mult = 2  label = "loop-spawned goroutine" }
+            touched := []string{}
+            j := 0
+            for j < len(gc.kids) {
+                root, ok := place_root(gc.kids[j])
+                if ok == 1 {
                     pfx := place_path(gc.kids[j])
                     i := 0
                     for i < len(g_ac_fn) {
                         if g_ac_fn[i] == g && g_ac_pi[i] == j {
                             verb := "reads"
                             if g_ac_w[i] == 1 { verb = "writes" }
-                            rc_note(iid, root, pfx + g_ac_path[i], g_ac_w[i], 1, "goroutine `go " + g + "(...)` " + verb + " `" + root + "`")
+                            rc_note_go(iid, root, pfx + g_ac_path[i], g_ac_w[i], mult, label + " `go " + g + "(...)` " + verb + " `" + root + "`")
+                            seen := 0
+                            ti := 0
+                            for ti < len(touched) { if touched[ti] == root { seen = 1  ti = len(touched) } else { ti = ti + 1 } }
+                            if seen == 0 { touched = append(touched, root) }
                         }
                         i = i + 1
                     }
                 }
                 j = j + 1
             }
+            ti := 0
+            for ti < len(touched) { live_add(touched[ti], 1)  ti = ti + 1 }
+            if top == 1 && inLoop == 0 {
+                j = 0
+                for j < len(gc.kids) {
+                    an := nodes[gc.kids[j]]
+                    if an.kind == K_ID {
+                        if param_signals_complete(g, j) == 1 {
+                            spawn_inc(an.s)
+                            ti = 0
+                            for ti < len(touched) { pend_add(an.s, touched[ti])  ti = ti + 1 }
+                        }
+                    }
+                    j = j + 1
+                }
+            }
         } else { if k == K_IDXASSIGN || k == K_FLDASSIGN {
             root, ok := place_root(n.a)
-            if ok == 1 { rc_note(iid, root, place_path(n.a), 1, 0, "this thread writes `" + root + "`") }
-        } else { if k == K_EXPRSTMT { rc_reads(iid, fnroot, n.a)
-        } else { if k == K_ASSIGN { rc_reads(iid, fnroot, n.a)
-        } else { if k == K_RETURN || k == K_MULTI { for _, e := range n.kids { rc_reads(iid, fnroot, e) }
+            if ok == 1 { rc_note_this(iid, root, place_path(n.a), 1, "this thread writes `" + root + "`") }
+        } else { if k == K_EXPRSTMT {
+            if top == 1 && inLoop == 0 { join_recv(n.a) }
+            rc_reads(iid, fnroot, n.a)
+        } else { if k == K_ASSIGN {
+            if top == 1 && inLoop == 0 { join_recv(n.a) }
+            rc_reads(iid, fnroot, n.a)
+        } else { if k == K_MULTI {
+            for _, e := range n.kids { if top == 1 && inLoop == 0 { join_recv(e) }  rc_reads(iid, fnroot, e) }
+        } else { if k == K_RETURN { for _, e := range n.kids { rc_reads(iid, fnroot, e) }
         } else { if k == K_IF {
             rc_reads(iid, fnroot, n.a)
-            rc_walk(iid, fnroot, n.kids)
-            rc_walk(iid, fnroot, n.kids2)
+            sr := []string{}
+            sn := []int{}
+            ci := 0
+            for ci < len(g_live_root) { sr = append(sr, g_live_root[ci])  sn = append(sn, g_live_n[ci])  ci = ci + 1 }
+            rc_visit(iid, fnroot, n.kids, inLoop, 0)
+            tr := g_live_root
+            tn := g_live_n
+            g_live_root = sr
+            g_live_n = sn
+            rc_visit(iid, fnroot, n.kids2, inLoop, 0)
+            mi := 0
+            for mi < len(tr) { if tn[mi] > live_get(tr[mi]) { live_set(tr[mi], tn[mi]) }  mi = mi + 1 }
         } else { if k == K_WHILE {
             rc_reads(iid, fnroot, n.a)
-            rc_walk(iid, fnroot, n.kids)
+            mark_loop_spawns(n.kids)
+            rc_visit(iid, fnroot, n.kids, 1, 0)
         } else { if k == K_RANGE {
             rc_reads(iid, fnroot, n.a)
-            rc_walk(iid, fnroot, n.kids)
+            mark_loop_spawns(n.kids)
+            rc_visit(iid, fnroot, n.kids, 1, 0)
         } else { if k == K_ARENA {
-            rc_walk(iid, fnroot, n.kids)
-        }}}}}}}}}
+            rc_visit(iid, fnroot, n.kids, inLoop, top)
+        }}}}}}}}}}
     }
 }
 
@@ -359,8 +570,18 @@ func detect_races() {
         g_x_root = []string{}
         g_x_write = []int{}
         g_x_go = []int{}
+        g_x_mult = []int{}
         g_x_desc = []string{}
-        rc_walk(iid, fnroot, nodes[fnroot].kids)
+        g_live_root = []string{}
+        g_live_n = []int{}
+        g_spawn_ch = []string{}
+        g_spawn_n = []int{}
+        g_recv_ch = []string{}
+        g_recv_n = []int{}
+        g_pend_ch = []string{}
+        g_pend_root = []string{}
+        g_pend_n = []int{}
+        rc_visit(iid, fnroot, nodes[fnroot].kids, 0, 1)
         // group accessors by distinct root; a root with >=2 accessors, >=1 write and
         // >=1 goroutine is a race.
         seen := []string{}
@@ -379,8 +600,8 @@ func detect_races() {
                 bi := 0
                 for bi < len(g_x_root) {
                     if g_x_root[bi] == root {
-                        total = total + 1
-                        if g_x_write[bi] == 1 { writes = writes + 1 }
+                        total = total + g_x_mult[bi]
+                        if g_x_write[bi] == 1 { writes = writes + g_x_mult[bi] }
                         if g_x_go[bi] == 1 { gos = gos + 1 }
                         descs = append(descs, g_x_desc[bi])
                     }

--- a/selfhost/racemain.src
+++ b/selfhost/racemain.src
@@ -1,0 +1,98 @@
+// selfhost/racemain.src — `machin racetest --program <file.mfl>` for the self-hosted
+// data-race pass. Runs the same parse -> check pipeline as checkmain, then the race
+// analysis, dumping findings in the canonical hex form the Go-reference oracle emits.
+
+func main() {
+    a := args()
+    if len(a) < 3 { write(2, "usage: racetest --program <file.mfl>\n")  exit(2) }
+    if a[1] != "--program" { write(2, "only --program is supported\n")  exit(2) }
+    data := read_file(a[2])
+    lines := split(data, "\n")
+
+    // pass 1: seed struct names so T{...} parses
+    for _, ln := range lines {
+        reset(ln)
+        i := 0
+        while i + 1 < len(T) {
+            if T[i].val == "type" || T[i].val == "cstruct" {
+                if T[i + 1].kind == 1 { g_structs = append(g_structs, T[i + 1].val) }
+            }
+            i = i + 1
+        }
+    }
+    // pass 1b: register struct field names/types + extern cstructs/fns
+    for _, ln := range lines {
+        if has_prefix(ln, "type ") {
+            reset(ln)
+            tidx := parse_type_decl()
+            if g_err == 0 { register_struct(nodes[tidx].s, nodes[tidx].names, nodes[tidx].names2) }
+        }
+        if has_prefix(ln, "extern ") {
+            reset(ln)
+            eidx := parse_extern_decl()
+            if g_err == 0 {
+                for _, ci := range nodes[eidx].kids {
+                    cn := nodes[ci]
+                    register_struct(cn.s, cn.names, cn.names2)
+                }
+                for _, fi := range nodes[eidx].kids2 {
+                    fnn := nodes[fi]
+                    register_extfn(fnn.s, fnn.names, fnn.s2)
+                }
+            }
+        }
+    }
+
+    // pass 2: parse every function + global into the shared nodes array
+    nodes = []Node{}
+    global_names := []string{}
+    global_inits := []int{}
+    for _, ln := range lines {
+        if has_prefix(ln, "func ") || has_prefix(ln, "export func ") {
+            lex_only(ln)
+            r := parse_func_decl()
+            if g_err == 1 || pk().kind != 0 { write(1, "(parse-error)\n")  return }
+            g_func_names = append(g_func_names, nodes[r].s)
+            g_func_roots = append(g_func_roots, r)
+        }
+        if has_prefix(ln, "var ") {
+            lex_only(ln)
+            r := parse_global()
+            if g_err == 0 && pk().kind == 0 {
+                global_names = append(global_names, nodes[r].s)
+                global_inits = append(global_inits, nodes[r].a)
+            }
+        }
+    }
+
+    has_main := 0
+    if func_root("main") >= 0 { has_main = 1 }
+    exported := []string{}
+    i := 0
+    for i < len(g_func_names) {
+        if nodes[g_func_roots[i]].ival == 1 { exported = append(exported, g_func_names[i]) }
+        i = i + 1
+    }
+    if has_main == 0 && len(exported) == 0 { write(1, "(check-error)\n")  return }
+
+    init_consts()
+    gi := 0
+    for gi < len(global_names) {
+        vs := gen_expr(global_inits[gi])
+        gslot := new_slot(0)
+        add_pair(gslot, vs)
+        register_global(global_names[gi], gslot)
+        gi = gi + 1
+    }
+    if has_main == 1 { instantiate("main") }
+    for _, en := range exported { instantiate(en) }
+    if g_unsupported == 1 { write(1, "(unsupported)\n")  return }
+    solve()
+    resolve_deferred()
+    finalize()
+    if g_terr == 1 || g_check_err == 1 { write(1, "(check-error)\n")  return }
+
+    // the race pass
+    detect_races()
+    write(1, dump_races())
+}

--- a/selfhost/racemain.src
+++ b/selfhost/racemain.src
@@ -94,5 +94,7 @@ func main() {
 
     // the race pass
     detect_races()
+    global_races()
+    use_after_send()
     write(1, dump_races())
 }

--- a/selfhost/verify-cgen.sh
+++ b/selfhost/verify-cgen.sh
@@ -188,6 +188,35 @@ func main() {
 EOF
 run "$T/h8.src"
 
+# h9 — select: recv/send/default/comma-ok cases (Slice 4 of #280).
+cat > "$T/h9.src" <<'EOF'
+func feed(ch) { ch <- 9  close(ch) }
+func drain(ch) { x := <-ch  print(x) }
+func main() {
+    a := make(chan int)
+    b := make(chan int)
+    go feed(a)
+    go drain(b)
+    select {
+    case x, ok := <-a:
+        if ok { print(x) }
+    case b <- 5:
+        print(1)
+    default:
+        print(0)
+    }
+    c := make(chan int)
+    go feed(c)
+    select {
+    case v := <-c:
+        print(v)
+    case <-a:
+        print(7)
+    }
+}
+EOF
+run "$T/h9.src"
+
 # SELF-APPLICATION: the MFL codegen emits byte-identical C for the compiler's OWN
 # source (checker + full codegen) — the fixpoint-adjacent milestone.
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \

--- a/selfhost/verify-cgen.sh
+++ b/selfhost/verify-cgen.sh
@@ -166,6 +166,28 @@ func main() {
 EOF
 run "$T/h7.src"
 
+# h8 — string channels + range over a channel (Slice 2 of #280).
+cat > "$T/h8.src" <<'EOF'
+func gen(ch) { ch <- "a"  ch <- "b"  close(ch) }
+func nums(ch) { ch <- 5  ch <- 7  close(ch) }
+func main() {
+    sc := make(chan string)
+    go gen(sc)
+    for s := range sc { print(s) }
+    nc := make(chan int)
+    go nums(nc)
+    total := 0
+    for v := range nc { total = total + v }
+    print(total)
+    dc := make(chan int)
+    go nums(dc)
+    cnt := 0
+    for _ := range dc { cnt = cnt + 1 }
+    print(cnt)
+}
+EOF
+run "$T/h8.src"
+
 # SELF-APPLICATION: the MFL codegen emits byte-identical C for the compiler's OWN
 # source (checker + full codegen) — the fixpoint-adjacent milestone.
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \

--- a/selfhost/verify-cgen.sh
+++ b/selfhost/verify-cgen.sh
@@ -147,6 +147,25 @@ func main() {
 EOF
 run "$T/h6.src"
 
+# h7 — concurrency: go + scalar channels (trampoline + make/send/recv). Slice 1 of #280.
+cat > "$T/h7.src" <<'EOF'
+func worker(ch, n) { ch <- n * 2 }
+func producer(ch) { ch <- true }
+func main() {
+    ch := make(chan int)
+    go worker(ch, 21)
+    go worker(ch, 10)
+    a := <-ch
+    b := <-ch
+    bc := make(chan bool)
+    go producer(bc)
+    v, ok := <-bc
+    if ok { print(a + b) }
+    print(v)
+}
+EOF
+run "$T/h7.src"
+
 # SELF-APPLICATION: the MFL codegen emits byte-identical C for the compiler's OWN
 # source (checker + full codegen) — the fixpoint-adjacent milestone.
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \

--- a/selfhost/verify-cgen.sh
+++ b/selfhost/verify-cgen.sh
@@ -217,6 +217,21 @@ func main() {
 EOF
 run "$T/h9.src"
 
+# h10 — struct channels via the string-offset copy path (Slice 3 of #280).
+cat > "$T/h10.src" <<'EOF'
+type Result struct { url string  status int  label string  ok bool }
+func work(ch, u) { r := Result{u, 200, "ok", true}  ch <- r }
+func main() {
+    ch := make(chan Result)
+    go work(ch, "a")
+    go work(ch, "bb")
+    r1 := <-ch
+    r2 := <-ch
+    print(r1.status + r2.status)
+}
+EOF
+run "$T/h10.src"
+
 # SELF-APPLICATION: the MFL codegen emits byte-identical C for the compiler's OWN
 # source (checker + full codegen) — the fixpoint-adjacent milestone.
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \

--- a/selfhost/verify-race.sh
+++ b/selfhost/verify-race.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Verifier for the self-hosted data-race pass (racecheck.src): its findings must be
+# byte-identical to the Go reference `machin racetest --program`. Slice A covers local
+# parameter races (write/write + read/write), type-aware; the race-free concurrency
+# corpus must stay clean.
+set -u
+N="nice -n 15"
+MACHIN=./bin/machin
+T=$(mktemp -d)
+pass=0; fail=0
+
+echo "building Go machin (oracle) + MFL race pass…"
+$N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
+$N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+    selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src \
+    selfhost/racecheck.src selfhost/racemain.src > "$T/sh-race.mfl" || { echo "encode failed"; exit 1; }
+$N "$MACHIN" build "$T/sh-race.mfl" -o selfhost/mfl-race || { echo "build failed"; exit 1; }
+echo "built selfhost/mfl-race"
+
+run() {
+  $N "$MACHIN" encode "$1" > "$T/x.mfl" 2>/dev/null || { echo "ENCODE-FAIL: $1"; fail=$((fail+1)); return; }
+  [ -s "$T/x.mfl" ] || { echo "ENCODE-EMPTY: $1"; fail=$((fail+1)); return; }
+  $N "$MACHIN" racetest --program "$T/x.mfl" > "$T/o.txt" 2>/dev/null
+  $N ./selfhost/mfl-race --program "$T/x.mfl" > "$T/m.txt" 2>/dev/null
+  if diff -q "$T/o.txt" "$T/m.txt" >/dev/null; then pass=$((pass+1)); else
+    fail=$((fail+1)); echo "MISMATCH: $1"; diff "$T/o.txt" "$T/m.txt" | head -8
+  fi
+}
+
+# r1 write/write, r2 read/write, r3 transitive, r4 distinct(clean), r5 scalar-field(clean),
+# r6 slice-field(race)
+cat > "$T/r1.src" <<'EOF'
+func w(xs, i) { xs[i] = i }
+func main() { d := []int{0, 0} go w(d, 0) go w(d, 1) }
+EOF
+run "$T/r1.src"
+cat > "$T/r2.src" <<'EOF'
+func w(xs) { xs[0] = 9 }
+func main() { d := []int{0, 0} go w(d) v := d[1] print(v) }
+EOF
+run "$T/r2.src"
+cat > "$T/r3.src" <<'EOF'
+func poke(ys, k) { ys[k] = 1 }
+func w(xs, i) { poke(xs, i) }
+func main() { d := []int{0, 0} go w(d, 0) go w(d, 1) }
+EOF
+run "$T/r3.src"
+cat > "$T/r4.src" <<'EOF'
+func w(xs, i) { xs[i] = i }
+func main() { a := []int{0, 0} b := []int{0, 0} go w(a, 0) go w(b, 1) }
+EOF
+run "$T/r4.src"
+cat > "$T/r5.src" <<'EOF'
+type Box struct { n int }
+func w(b) { b.n = 9 }
+func main() { x := Box{0} go w(x) go w(x) }
+EOF
+run "$T/r5.src"
+cat > "$T/r6.src" <<'EOF'
+type Bag struct { items []int }
+func w(b, i) { b.items[i] = i }
+func main() { g := Bag{[]int{0, 0}} go w(g, 0) go w(g, 1) }
+EOF
+run "$T/r6.src"
+
+# the race-free concurrency corpus must stay clean (empty) on both sides
+for app in machin-healthcheck machin-linkcheck machin-pipe machin-pool machin-wscat; do
+  s=$(ls ../$app/*.src 2>/dev/null | head -1)
+  [ -n "$s" ] && run "$s"
+done
+
+echo "----"
+echo "PASS $pass  FAIL $fail"
+rm -rf "$T"
+[ "$fail" -eq 0 ]

--- a/selfhost/verify-race.sh
+++ b/selfhost/verify-race.sh
@@ -92,6 +92,45 @@ func main() { d := []int{0, 0} go w(d) d[1] = 7 }
 EOF
 run "$T/h5.src"
 
+# globals: g1 shared counter (write/write), g2 go-write+main-read (read/write),
+# g3 init-then-spawn (clean, pre-spawn ordered), g4 read-only (clean)
+cat > "$T/g1.src" <<'EOF'
+var counter = 0
+func incr() { counter = counter + 1 }
+func main() { go incr() go incr() print(counter) }
+EOF
+run "$T/g1.src"
+cat > "$T/g2.src" <<'EOF'
+var total = 0
+func add(n) { total = total + n }
+func main() { go add(5) x := total print(x) }
+EOF
+run "$T/g2.src"
+cat > "$T/g3.src" <<'EOF'
+var config = 0
+func reader(id) { x := config print(x + id) }
+func main() { config = 42 go reader(0) go reader(1) }
+EOF
+run "$T/g3.src"
+cat > "$T/g4.src" <<'EOF'
+var base = 100
+func reader(id, ch) { ch <- base + id }
+func main() { ch := make(chan int) go reader(0, ch) go reader(1, ch) a := <-ch b := <-ch print(a + b) }
+EOF
+run "$T/g4.src"
+
+# move-on-send: m1 use-after-send (RACE004), m2 send-then-drop (clean)
+cat > "$T/m1.src" <<'EOF'
+func producer(ch) { out := []int{1, 2, 3} ch <- out out[0] = 99 }
+func main() { ch := make(chan []int) go producer(ch) got := <-ch print(got[0]) }
+EOF
+run "$T/m1.src"
+cat > "$T/m2.src" <<'EOF'
+func producer(ch) { out := []int{1, 2, 3} ch <- out }
+func main() { ch := make(chan []int) go producer(ch) got := <-ch print(got[0]) }
+EOF
+run "$T/m2.src"
+
 # the race-free concurrency corpus must stay clean (empty) on both sides
 for app in machin-healthcheck machin-linkcheck machin-pipe machin-pool machin-wscat; do
   s=$(ls ../$app/*.src 2>/dev/null | head -1)

--- a/selfhost/verify-race.sh
+++ b/selfhost/verify-race.sh
@@ -64,6 +64,34 @@ func main() { g := Bag{[]int{0, 0}} go w(g, 0) go w(g, 1) }
 EOF
 run "$T/r6.src"
 
+# happens-before: h1 pre-spawn setup (clean), h2 join barrier (clean), h3 signal-before-
+# write (race), h4 loop-spawn writer (race, multiplicity), h5 post-spawn write (race)
+cat > "$T/h1.src" <<'EOF'
+func w(xs) { xs[0] = 9 }
+func main() { d := []int{0, 0} d[0] = 5 go w(d) }
+EOF
+run "$T/h1.src"
+cat > "$T/h2.src" <<'EOF'
+func w(xs, done) { xs[0] = 9  done <- 1 }
+func main() { d := []int{0, 0} done := make(chan int) go w(d, done) x := <-done print(d[0] + x) }
+EOF
+run "$T/h2.src"
+cat > "$T/h3.src" <<'EOF'
+func w(xs, done) { done <- 1  xs[0] = 9 }
+func main() { d := []int{0, 0} done := make(chan int) go w(d, done) x := <-done print(d[0] + x) }
+EOF
+run "$T/h3.src"
+cat > "$T/h4.src" <<'EOF'
+func w(xs, i) { xs[i] = i }
+func main() { d := []int{0, 0} i := 0 while i < 2 { go w(d, i) i = i + 1 } }
+EOF
+run "$T/h4.src"
+cat > "$T/h5.src" <<'EOF'
+func w(xs) { xs[0] = 9 }
+func main() { d := []int{0, 0} go w(d) d[1] = 7 }
+EOF
+run "$T/h5.src"
+
 # the race-free concurrency corpus must stay clean (empty) on both sides
 for app in machin-healthcheck machin-linkcheck machin-pipe machin-pool machin-wscat; do
   s=$(ls ../$app/*.src 2>/dev/null | head -1)


### PR DESCRIPTION
Brings the **self-hosted** MFL compiler to concurrency parity (#280) and ports the **data-race analysis** into it — so machin-in-machin both *compiles* concurrent programs and *proves* them race-free.

## Concurrency codegen (#280)
The reference already supported `go`/channels/`select`; this teaches the self-hosted compiler (`selfhost/*.src`) to emit byte-identical C for it:
- **go + scalar channels** — `make(chan T)`, `ch <- v`, `<-ch`, and the `go f(args)` trampoline (arg-struct + trampoline fn spliced before bodies via a body-buffer swap) + detached `pthread_create`.
- **string channels + `range` over a channel** (`mfl_chan_recv2` loop).
- **`select`** — checker `K_SELECT` constraints + the poll-loop codegen.
- **struct channels** — the `offsetof` string-copy path (`chan_needs_json`/`chan_str_offsets`).

**Result: all 5 concurrency corpus apps (healthcheck/linkcheck/pipe/pool/wscat) now self-host byte-identically.** `verify-cgen.sh` 411 PASS / 0 FAIL (incl. fuzz + self-application).

## The data-race pass, in MFL
Ported `racecheck.go` (the "better than Rust" inferred race checker) into `selfhost/racecheck.src`, verified against a new `machin racetest --program` oracle. Flat-rewritten (MFL has no closures): local param races (type-aware reachability), happens-before (live-counting + channel-join barriers + loop multiplicity), package globals (unconditional sharing), and move-on-send (use-after-move). `verify-race.sh` 22 PASS / 0 FAIL — byte-identical to the reference, and the race-free corpus stays clean.

Only slice/map (JSON) channels remain of #280 codegen — no corpus program uses them.

`go test .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `racetest` command for generating canonical race-analysis output from a program file.
  * Expanded self-hosted support for channels, `select`, `go` routines, and channel ranges.

* **Bug Fixes**
  * Improved race detection coverage, including shared-state races and use-after-send/move cases.
  * Added clearer parse/check error reporting for race test runs.

* **Tests**
  * Added broader verification coverage for concurrency, channels, and race-analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->