### PR TITLE
STARTTLS support in framework/smtp.src (closes #260's SMTP half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **`framework/smtp.src` gained STARTTLS support, closing issue #260's SMTP half.**
+  `smtp_send` takes a new `use_tls` argument: after `EHLO`, it sends `STARTTLS`, upgrades
+  the connection in place via `tls_client_fd` (shipped v0.92.0), and re-issues `EHLO` over
+  the now-encrypted channel per RFC 3207 (capabilities can change post-upgrade, and
+  skipping this would let a MITM strip the plaintext EHLO unnoticed) — the rest of the
+  session (AUTH/MAIL/RCPT/DATA/QUIT) then runs over the TLS handle. New `smtp_write`/
+  `smtp_close` helpers dispatch to the TLS handle or the plain fd depending on whether the
+  session was upgraded. A real submission relay that *requires* TLS (Gmail/SendGrid/SES on
+  `:587`) is now reachable; a local catcher or a relay that accepts plaintext submission
+  still works with `use_tls=0`. Verified two ways: `machin-mail`'s new `--starttls 1` flag
+  against a genuinely live `smtp.gmail.com:587` — the full plaintext dance, the upgrade, and
+  the post-upgrade `EHLO` all succeed, failing only at the expected, auth-gated `MAIL FROM`
+  step (no real credentials supplied) — and a new `TestSMTPSendStartTLS` against a local Go
+  SMTP-shaped server, confirming an untrusted/self-signed cert is correctly **rejected**
+  (verification is active, not disabled). Hit MFL's flat-function-scope gotcha along the
+  way: `smtp_close`'s two branches return different types (`tls_close`'s `int` vs `close`'s
+  void), so neither result is captured into a shared variable.
+
 ## v0.96.0
 
 - **Self-hosted concurrency: the MFL-in-MFL compiler now compiles `go`/channels/

--- a/framework/smtp.src
+++ b/framework/smtp.src
@@ -1,25 +1,30 @@
 // smtp.src — a pure-MFL SMTP toolkit: a client that SENDS mail and the server side that
 // RECEIVES it, both over dial()/listen() + read/write. No external library, no cgo.
 //
-//   smtp_send(host, port, from, to, subject, body, user, pass) -> (ok, errmsg)   // a sender
-//   smtp_recv(conn) -> (Mail, ok)                                                 // one server session
+//   smtp_send(host, port, from, to, subject, body, user, pass, use_tls) -> (ok, errmsg)  // a sender
+//   smtp_recv(conn) -> (Mail, ok)                                                         // one server session
 //
 // The protocol is line-oriented (CRLF), so reads go through a small buffered line reader
-// (the slice-box trick, so a line split across packets reassembles). This is plaintext
-// SMTP + AUTH LOGIN/PLAIN — enough to talk to a submission relay that doesn't force TLS,
-// and to a local catcher. (STARTTLS/implicit TLS would need a TLS-wrap-an-fd primitive.)
+// (the slice-box trick, so a line split across packets reassembles). Plaintext SMTP +
+// AUTH LOGIN/PLAIN, with optional STARTTLS (use_tls=1): dial plaintext, EHLO, STARTTLS,
+// tls_client_fd to upgrade in place, re-EHLO (RFC 3207 — capabilities can change post-
+// upgrade, and re-issuing it prevents a plaintext command-injection downgrade), then the
+// rest of the session over the tls handle. Enough to talk to a submission relay that
+// requires TLS (Gmail/SendGrid/SES on :587) as well as one that doesn't, and to a local
+// catcher (which stays plaintext-only — it's a dev sink, not a public relay).
 
-// ---- a buffered line reader over a socket fd ----
+// ---- a buffered line reader over a socket fd (or, after STARTTLS, a tls handle) ----
 
 type LineReader struct {
     fd  int
+    tls int      // 0 = read from fd; else a tls_client_fd handle — read from that instead
     buf []bytes
 }
 
 func line_reader(fd) (r) {
     bx := []bytes{}
     bx = append(bx, bytes(""))
-    r = LineReader{fd: fd, buf: bx}
+    r = LineReader{fd: fd, tls: 0, buf: bx}
 }
 
 // read_line returns the next CRLF/LF-delimited line (without the terminator), ok=0 on EOF.
@@ -36,7 +41,8 @@ func read_line(r) (line, ok) {
             ok = 1
             return
         }
-        chunk := read_bytes(r.fd)
+        chunk := bytes("")
+        if r.tls != 0 { chunk = tls_read_bytes(r.tls) } else { chunk = read_bytes(r.fd) }
         if len(chunk) == 0 {
             if len(r.buf[0]) > 0 { line = bytes_str(r.buf[0])  r.buf[0] = bytes("")  ok = 1 }
             return
@@ -82,14 +88,33 @@ func smtp_build(from, to, subject, body) (m) {
     }
 }
 
-// smtp_send sends one message. user=="" skips AUTH. Returns (1,"") on success, else
-// (0, reason). Expects the standard 220/250/334/235/354/250 reply codes.
-func smtp_send(host, port, from, to, subject, body, user, pass) (ok, errmsg) {
+// smtp_write sends s over the tls handle if the session was upgraded via
+// STARTTLS (tls != 0), else over the plain fd.
+func smtp_write(fd, tls, s) (n) {
+    n = 0
+    if tls != 0 { n = tls_write(tls, s) } else { n = write(fd, s) }
+}
+
+// smtp_close tears down a session: tls_close (which also closes the
+// underlying fd) if upgraded, else a plain close. Its two branches return
+// different types (int vs void), so neither result is captured — MFL's flat
+// function scope would otherwise unify them into a single conflicting `c`.
+func smtp_close(fd, tls) {
+    if tls != 0 { tls_close(tls) } else { close(fd) }
+}
+
+// smtp_send sends one message. user=="" skips AUTH; use_tls==1 upgrades to
+// TLS via STARTTLS right after EHLO (required by Gmail/SendGrid/SES on :587;
+// a local catcher or a relay that accepts plaintext submission wants 0).
+// Returns (1,"") on success, else (0, reason). Expects the standard
+// 220/250/334/235/354/250 reply codes.
+func smtp_send(host, port, from, to, subject, body, user, pass, use_tls) (ok, errmsg) {
     ok = 0
     errmsg = ""
     conn := dial(host, port)
     if conn < 0 { errmsg = "dial failed"  return }
     r := line_reader(conn)
+    tls := 0
 
     code, good := read_reply(r)
     if good == 0 || code != 220 { errmsg = "no 220 greeting"  close(conn)  return }
@@ -98,43 +123,58 @@ func smtp_send(host, port, from, to, subject, body, user, pass) (ok, errmsg) {
     code, good = read_reply(r)
     if code != 250 { errmsg = "EHLO rejected"  close(conn)  return }
 
-    if user != "" {
-        w = write(conn, "AUTH LOGIN\r\n")
+    if use_tls == 1 {
+        w = write(conn, "STARTTLS\r\n")
         code, good = read_reply(r)
-        if code != 334 { errmsg = "AUTH LOGIN unsupported"  close(conn)  return }
-        w = write(conn, base64_encode(user) + "\r\n")
+        if code != 220 { errmsg = "STARTTLS rejected"  close(conn)  return }
+        tls = tls_client_fd(conn, host)
+        if tls == 0 { errmsg = "TLS handshake failed"  close(conn)  return }
+        r.tls = tls
+        // re-EHLO over the encrypted channel (RFC 3207): capabilities can
+        // differ post-upgrade, and skipping this would let a MITM strip the
+        // plaintext EHLO's capabilities without the client noticing.
+        w = smtp_write(conn, tls, "EHLO machin-mail\r\n")
         code, good = read_reply(r)
-        if code != 334 { errmsg = "AUTH username rejected"  close(conn)  return }
-        w = write(conn, base64_encode(pass) + "\r\n")
-        code, good = read_reply(r)
-        if code != 235 { errmsg = "authentication failed"  close(conn)  return }
+        if code != 250 { errmsg = "post-STARTTLS EHLO rejected"  smtp_close(conn, tls)  return }
     }
 
-    w = write(conn, "MAIL FROM:<" + from + ">\r\n")
+    if user != "" {
+        w = smtp_write(conn, tls, "AUTH LOGIN\r\n")
+        code, good = read_reply(r)
+        if code != 334 { errmsg = "AUTH LOGIN unsupported"  smtp_close(conn, tls)  return }
+        w = smtp_write(conn, tls, base64_encode(user) + "\r\n")
+        code, good = read_reply(r)
+        if code != 334 { errmsg = "AUTH username rejected"  smtp_close(conn, tls)  return }
+        w = smtp_write(conn, tls, base64_encode(pass) + "\r\n")
+        code, good = read_reply(r)
+        if code != 235 { errmsg = "authentication failed"  smtp_close(conn, tls)  return }
+    }
+
+    w = smtp_write(conn, tls, "MAIL FROM:<" + from + ">\r\n")
     code, good = read_reply(r)
-    if code != 250 { errmsg = "MAIL FROM rejected"  close(conn)  return }
+    if code != 250 { errmsg = "MAIL FROM rejected"  smtp_close(conn, tls)  return }
 
     for _, rcpt := range split(to, ",") {
         addr := trim(rcpt)
         if addr != "" {
-            w = write(conn, "RCPT TO:<" + addr + ">\r\n")
+            w = smtp_write(conn, tls, "RCPT TO:<" + addr + ">\r\n")
             code, good = read_reply(r)
-            if code != 250 { errmsg = "RCPT rejected: " + addr  close(conn)  return }
+            if code != 250 { errmsg = "RCPT rejected: " + addr  smtp_close(conn, tls)  return }
         }
     }
 
-    w = write(conn, "DATA\r\n")
+    w = smtp_write(conn, tls, "DATA\r\n")
     code, good = read_reply(r)
-    if code != 354 { errmsg = "DATA rejected"  close(conn)  return }
+    if code != 354 { errmsg = "DATA rejected"  smtp_close(conn, tls)  return }
 
-    w = write(conn, smtp_build(from, to, subject, body))
-    w = write(conn, "\r\n.\r\n")
+    w = smtp_write(conn, tls, smtp_build(from, to, subject, body))
+    w = smtp_write(conn, tls, "\r\n.\r\n")
     code, good = read_reply(r)
-    if code != 250 { errmsg = "message rejected"  close(conn)  return }
+    if code != 250 { errmsg = "message rejected"  smtp_close(conn, tls)  return }
 
-    w = write(conn, "QUIT\r\n")
+    w = smtp_write(conn, tls, "QUIT\r\n")
     cq, gq := read_reply(r)
-    close(conn)
+    smtp_close(conn, tls)
     ok = 1
 }
 

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -42,7 +44,7 @@ func main() {
     if srv < 0 { println("listen-failed")  return }
     go catch(srv)
     sleep(50)
-    ok, errmsg := smtp_send("127.0.0.1", port, "alice@x", "b@y, c@z", "Hello", "line one\n.dotline\nline three", "user", "pass")
+    ok, errmsg := smtp_send("127.0.0.1", port, "alice@x", "b@y, c@z", "Hello", "line one\n.dotline\nline three", "user", "pass", 0)
     println("SENT ok=" + str(ok) + " err=[" + errmsg + "]")
     sleep(60)
 }`
@@ -63,5 +65,58 @@ func main() {
 	// dot-stuffing round-tripped: the body line ".dotline" survives intact (not "" / "dotline")
 	if !strings.Contains(out, ".dotline") {
 		t.Fatalf("a dot-prefixed body line should survive dot-stuffing; got:\n%s", out)
+	}
+}
+
+// smtp_send's STARTTLS path (use_tls=1): dial plaintext, EHLO, STARTTLS,
+// tls_client_fd to upgrade, re-EHLO — driven against a real Go SMTP-shaped
+// server that speaks the plaintext dance then upgrades with tls.Server,
+// exactly like a real relay (Gmail/SendGrid/SES on :587). Its cert is
+// self-signed and untrusted, so tls_client_fd — which verifies, same as
+// https_get — must REJECT it: proves the upgrade path's verification is
+// genuinely active, the same discipline as TestSTARTTLS in
+// tls_server_test.go. The positive case (a real successful STARTTLS
+// negotiation all the way to the auth-gated MAIL FROM step) was verified
+// manually against smtp.gmail.com:587 with machin-mail — see issue #260.
+func TestSMTPSendStartTLS(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const port = 48262
+	ln, err := net.Listen("tcp", "127.0.0.1:"+itoa(port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 4096)
+		conn.Write([]byte("220 test.local ESMTP\r\n"))
+		conn.Read(buf) // EHLO
+		conn.Write([]byte("250-test.local\r\n250 STARTTLS\r\n"))
+		conn.Read(buf) // STARTTLS
+		conn.Write([]byte("220 2.0.0 Ready to start TLS\r\n"))
+		tconn := tls.Server(conn, &tls.Config{Certificates: []tls.Certificate{cert}})
+		tconn.Handshake() // expected to fail: the MFL client won't trust this cert
+	}()
+
+	app := `func main() {
+	ok, errmsg := smtp_send("127.0.0.1", ` + itoa(port) + `, "a@x", "b@y", "Hi", "body", "", "", 1)
+	println("SENT ok=" + str(ok) + " err=[" + errmsg + "]")
+}`
+	out, err := RunCaptured(smtpProg(t, app))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out, "SENT ok=0 err=[TLS handshake failed]") {
+		t.Fatalf("expected the untrusted STARTTLS cert to be rejected, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- `smtp_send` takes a new `use_tls` argument: after `EHLO`, sends `STARTTLS`, upgrades in place via `tls_client_fd` (shipped v0.92.0), and re-issues `EHLO` over the now-encrypted channel per RFC 3207 (capabilities can change post-upgrade, and skipping the re-EHLO would let a MITM strip the plaintext EHLO unnoticed). The rest of the session (AUTH/MAIL/RCPT/DATA/QUIT) then runs over the TLS handle via new `smtp_write`/`smtp_close` helpers.
- A real submission relay that *requires* TLS (Gmail/SendGrid/SES on `:587`) is now reachable; a local catcher or a relay that accepts plaintext submission still works with `use_tls=0`.
- Companion PR in `machin-mail` (separate repo) wires this into its `send` command via a new `--starttls` flag.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 .` full suite passes
- [x] `TestSMTPRoundTrip` updated for the new signature, still passes (plaintext, non-regression)
- [x] New `TestSMTPSendStartTLS`: an untrusted/self-signed cert from a local Go SMTP-shaped server is correctly **rejected** — proves verification is active, not disabled
- [x] Manually verified against a genuinely live `smtp.gmail.com:587` via `machin-mail --starttls 1`: the full plaintext dance, the TLS upgrade, and the post-upgrade `EHLO` all succeed, failing only at the expected, auth-gated `MAIL FROM` step (no real credentials supplied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)