### PR TITLE
fix: read_file/read_file_bytes segfaulted on a directory path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Fixed: `read_file`/`read_file_bytes` segfaulted on a directory path.** `fopen(dir,
+  "rb")` succeeds on Linux (opening a directory read-only is legal at the syscall
+  level), but `ftell()` on the resulting stream returns `LONG_MAX` — not `-1` — so the
+  existing "if (n < 0) n = 0" guard never caught it, and the runtime tried to allocate
+  ~9.2 exabytes for the "file size." A very easy path to hit in practice: `list_dir()`'s
+  entries can themselves be subdirectories, so `read_file_bytes` on any of those crashed
+  — found building a concurrent file-hasher demo (`machin-hasher`) that reliably
+  segfaulted on any target directory containing so much as one subdirectory, even
+  single-threaded (not a race — a plain crash). Fixed with an explicit `stat()`-based
+  directory check before `fopen`; both builtins now return empty (matching their
+  existing "can't open" behavior) instead of crashing. New `TestReadFileOnDirectory`.
+
 ## v0.97.0
 
 - **`framework/smtp.src` gained STARTTLS support, closing issue #260's SMTP half.**

--- a/cli_test.go
+++ b/cli_test.go
@@ -63,6 +63,30 @@ func TestFileIO(t *testing.T) {
 	}
 }
 
+// read_file/read_file_bytes on a directory path used to SEGFAULT: fopen(dir,
+// "rb") succeeds on Linux, but ftell() on it returns LONG_MAX (not -1), so
+// the "if (n < 0) n = 0" guard never caught it and the runtime tried to
+// alloc ~9.2 exabytes. This is an easy real path to hit — list_dir()'s
+// entries can themselves be directories — surfaced building a concurrent
+// file-hasher demo (`machin-hasher`) that crashed on any directory
+// containing so much as one subdirectory. Both must now return empty
+// (matching the existing "can't open" behavior), not crash.
+func TestReadFileOnDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(dir+"/sub", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := `func main(){
+	println("[" + read_file("` + dir + `/sub") + "]")
+	b := read_file_bytes("` + dir + `/sub")
+	println(str(len(b)))
+}`
+	got := runNative(t, src)
+	if want := "[]\n0\n"; got != want {
+		t.Fatalf("read_file(_bytes) on a directory: got %q, want %q (must not crash)", got, want)
+	}
+}
+
 // loadMFL (used by `machin run`/`build` on a .mfl FILE) used to only accept
 // canonical one-declaration-per-line text or the packed base64 form, so a
 // hand-written .mfl with ordinary Go-like multi-line formatting failed with a

--- a/codegen.go
+++ b/codegen.go
@@ -906,7 +906,19 @@ static int64_t mfl_parse_int(const char* s) { return (int64_t)strtoll(s, NULL, 1
 static double mfl_parse_float(const char* s) { return strtod(s, NULL); }
 
 /* file system: read/write whole files, list a directory, make a directory */
+
+/* fopen(dir, "rb") SUCCEEDS on Linux (opening a directory read-only is legal
+   at the syscall level), but ftell() on it returns LONG_MAX (not -1) rather
+   than failing — so the usual "if (n < 0) n = 0" guard never catches it, and
+   the caller ends up trying to alloc ~9.2 exabytes. list_dir()'s entries can
+   be subdirectories, so read_file/read_file_bytes on one of those is a real,
+   easy-to-hit path, not a contrived one — check with stat() first. */
+static int mfl_is_dir(const char* path) {
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
 static char* mfl_read_file(const char* path) {
+    if (mfl_is_dir(path)) return mfl_dup("");
     FILE* f = fopen(path, "rb");
     if (!f) return mfl_dup("");
     fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);
@@ -935,6 +947,7 @@ static int64_t mfl_remove_file(const char* path) { return remove(path) == 0 ? 0 
    Empty bytes if the file can't be opened. */
 static mfl_bytes mfl_read_file_bytes(const char* path) {
     mfl_bytes b; b.len = 0; b.data = (uint8_t*)mfl_alloc(1);
+    if (mfl_is_dir(path)) return b;
     FILE* f = fopen(path, "rb");
     if (!f) return b;
     fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);


### PR DESCRIPTION
## Summary
- `fopen(dir, "rb")` succeeds on Linux (opening a directory read-only is legal at the syscall level), but `ftell()` on the resulting stream returns `LONG_MAX` — not `-1` — so the existing `if (n < 0) n = 0` guard never caught it, and the runtime tried to allocate ~9.2 exabytes for the "file size."
- A very easy path to hit in practice: `list_dir()`'s entries can themselves be subdirectories, so `read_file_bytes` on any of those crashed. Found while building a concurrent file-hasher demo (`machin-hasher`) that reliably segfaulted on any target directory containing so much as one subdirectory — reproduced deterministically even with a single worker, so it was never a race, just a plain crash waiting for the first subdirectory.
- Fixed with an explicit `stat()`-based directory check before `fopen` in both `mfl_read_file` and `mfl_read_file_bytes`; both now return empty (matching their existing "can't open" behavior) instead of crashing.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 .` full suite passes
- [x] New `TestReadFileOnDirectory` — both builtins return empty on a directory path instead of crashing
- [x] Reproduced the original crash manually (a directory with one file + one subdirectory, worker count 1 — deterministic, not a race) and confirmed the fix resolves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)