### PR TITLE
docs(#186): add bytes type and builtins to LANGUAGE.md + runnable example

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -42,6 +42,7 @@ Types are inferred by unification — there are **no type annotations**.
 | `string`  | `"hello"`                      | concatenate with `+`                   |
 | `bool`    | `true`, `false`                | produced by comparisons                |
 | `[]int`   | `[]int{}`, `[]int{1, 2, 3}`    | grow with `append`, index with `xs[i]` |
+| `bytes`   | `bytes("hi")`, `from_hex("ff00")` | NUL-safe binary buffer; `len(b)` counts raw bytes; `println(b)` prints hex; strings truncate at NUL, bytes do not |
 
 Each value's type is determined by how it is used; mixing incompatible types is
 a **compile-time error**, not a runtime surprise.
@@ -336,6 +337,13 @@ first := users[0]                                // value copy
 | `accept(fd)`                | accept a connection, return its socket fd    |
 | `read(fd)` / `write(fd, s)` | read from / write to a socket                |
 | `close(fd)`                 | close a socket                               |
+| `bytes(s)`                  | make a `bytes` value from a string's raw bytes |
+| `bytes_str(b)`              | `bytes` → `string` (NUL-terminated; truncates at embedded `0`) |
+| `to_hex(b)`                 | lowercase hex of a `bytes` value             |
+| `from_hex(s)`               | parse hex string → `bytes` (skips non-hex chars) |
+| `byte_at(b, i)`             | byte value 0–255 at index `i` (−1 if out of range) |
+| `bytes_sub(b, start, end)`  | sub-range `[start, end)` of a `bytes` value  |
+| `bytes_concat(a, b)`        | concatenate two `bytes` values               |
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,6 +56,7 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `json_parse`      | `parse(s, T{})` — JSON into struct/slice/map/scalar, with round-trips |
 | `json_echo_api`   | POST JSON → parse into a struct → echo it back as JSON |
 | `strings`         | string ops (`split`/`join`/`substr`/`index`/`replace`/…) + request-line parsing |
+| `bytes`           | `bytes` type: construct, `to_hex`/`from_hex`, `byte_at`, `bytes_sub`, `bytes_concat`, `bytes_str`; NUL-safe vs string |
 | `router_api`      | HTTP router — dispatch by method+path, extract path params |
 
 `http_server` loops forever, so it's skipped by `run.sh`. Run it directly:

--- a/examples/complex/bytes.mfl
+++ b/examples/complex/bytes.mfl
@@ -16,7 +16,8 @@ b3:=bytes_sub(b2,1,3)//[0xad,0xbe]
 b4:=bytes_concat(b2,b3)
 println("concat len:",len(b4))//6
 
-//bytes_str:truncates at embedded NUL
-nul:=bytes("hi\x00there")
+//bytes_str:truncates at embedded NUL — string literals have no \xNN escape so build it via from_hex("hi"+NUL+"there")
+nul:=from_hex("6869007468657265")
+println("len:",len(nul))//8 not 2 — bytes keeps the NUL
 println("bytes_str:",bytes_str(nul))//hi
 }

--- a/examples/complex/bytes.mfl
+++ b/examples/complex/bytes.mfl
@@ -1,0 +1,22 @@
+// bytes: NUL-safe binary buffer — strings truncate at NUL, bytes do not.
+
+func main() {
+    // construct from a string and inspect
+    b := bytes("hello")
+    println("len:", len(b))           // 5
+    println("hex:", to_hex(b))        // 68656c6c6f
+
+    // round-trip through hex
+    b2 := from_hex("deadbeef")
+    println("from_hex len:", len(b2)) // 4
+    println("byte_at 0:", byte_at(b2, 0)) // 222
+
+    // sub-range and concat
+    b3 := bytes_sub(b2, 1, 3)         // [0xad, 0xbe]
+    b4 := bytes_concat(b2, b3)
+    println("concat len:", len(b4))   // 6
+
+    // bytes_str: truncates at embedded NUL
+    nul := bytes("hi\x00there")
+    println("bytes_str:", bytes_str(nul)) // hi
+}

--- a/examples/complex/bytes.mfl
+++ b/examples/complex/bytes.mfl
@@ -1,22 +1,22 @@
-// bytes: NUL-safe binary buffer — strings truncate at NUL, bytes do not.
+//bytes:NUL-safe binary buffer — strings truncate at NUL,bytes do not.
 
-func main() {
-    // construct from a string and inspect
-    b := bytes("hello")
-    println("len:", len(b))           // 5
-    println("hex:", to_hex(b))        // 68656c6c6f
+func main(){
+//construct from a string and inspect
+b:=bytes("hello")
+println("len:",len(b))//5
+println("hex:",to_hex(b))//68656c6c6f
 
-    // round-trip through hex
-    b2 := from_hex("deadbeef")
-    println("from_hex len:", len(b2)) // 4
-    println("byte_at 0:", byte_at(b2, 0)) // 222
+//round-trip through hex
+b2:=from_hex("deadbeef")
+println("from_hex len:",len(b2))//4
+println("byte_at 0:",byte_at(b2,0))//222
 
-    // sub-range and concat
-    b3 := bytes_sub(b2, 1, 3)         // [0xad, 0xbe]
-    b4 := bytes_concat(b2, b3)
-    println("concat len:", len(b4))   // 6
+//sub-range and concat
+b3:=bytes_sub(b2,1,3)//[0xad,0xbe]
+b4:=bytes_concat(b2,b3)
+println("concat len:",len(b4))//6
 
-    // bytes_str: truncates at embedded NUL
-    nul := bytes("hi\x00there")
-    println("bytes_str:", bytes_str(nul)) // hi
+//bytes_str:truncates at embedded NUL
+nul:=bytes("hi\x00there")
+println("bytes_str:",bytes_str(nul))//hi
 }


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #186: "docs: the `bytes` type and its builtins are absent from docs/LANGUAGE.md (Types + Builtins tables) and have no runnable example")

ISSUE DESCRIPTION:
## Problem
The `bytes` type — a NUL-safe binary buffer added in commit 3cc2b7f (#183) — is fully cataloged in `machin guide` (guide.go:65, 125–131) and described in CHANGELOG.md, but it is **completely absent from docs/LANGUAGE.md**, which the README/AGENTS call the "full reference." This continues the LANGUAGE.md drift pattern (see #78, #148, #155).

## Where
- **docs/LANGUAGE.md ## Types** (lines 34–48): the type table lists `int`, `float`, `string`, `bool`, `[]int` — but **not `bytes`**. (Compare guide.go:65, which documents it: "NUL-safe binary buffer (ptr+len)".)
- **docs/LANGUAGE.md ## Builtins** (lines 309–340): the builtins table omits the entire `bytes` family: `bytes(str)`, `bytes_str(b)`, `to_hex(b)`, `from_hex(s)`, `byte_at(b, i)`, `bytes_sub(b, start, end)`, `bytes_concat(a, b)`. (All documented in guide.go:125–131.)
- **examples/**: no example file uses any `bytes` builtin (`grep -rl 'bytes_\|from_hex\|to_hex' examples` returns nothing), so there is no runnable demonstration. examples/README.md likewise has no entry for it.

## Why it matters
`bytes` is the foundation for binary protocols and the crypto suite (#184). A reader of the canonical "full reference" cannot discover that the type exists, how `len(b)`/`println(b)` behave on it, or that strings truncate at NUL while `bytes` does not — the exact footgun the type was added to solve.

## Suggested fix
1. Add a `bytes` row to the LANGUAGE.md Types table (construction via `bytes()`/`from_hex()`; note `len(b)` works and `println(b)` prints hex).
2. Add the seven `bytes` builtins to the Builtins table.
3. Add a small runnable example under examples/complex/ (e.g. `bytes.mfl`) and list it in examples/README.md — the guide already has a one-liner at guide.go:182 to adapt.

APPROACH: Refactored fix — implement the change described in the issue, but also lightly clean up the immediate surrounding code (rename for clarity, extract a small helper if it simplifies things). Keep scope tight.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#186): <brief description>
5. The PR body MUST include 'Fixes #186' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thko53`

## Summary

Add `bytes` type and its seven builtins (bytes/bytes_str/to_hex/from_hex/byte_at/bytes_sub/bytes_concat) to docs/LANGUAGE.md — both the Types table and Builtins table — and add a runnable example at examples/complex/bytes.mfl demonstrating the NUL-safe binary buffer API. These were completely absent from the full reference doc despite being the foundation for the crypto suite. Fixes #186.

**Diff:**
```
docs/LANGUAGE.md           |  8 ++++++++
 examples/README.md         |  1 +
 examples/complex/bytes.mfl | 22 ++++++++++++++++++++++
 3 files changed, 31 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `bytes` type in the language documentation, including creation, conversion, indexing, slicing, concatenation, and hex handling.
  * Added a new example program demonstrating `bytes` usage, including length, hex round-tripping, byte access, subranges, and NUL-safe string behavior.

* **Documentation**
  * Updated the examples overview to include the new `bytes` example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->