### PR TITLE
fix(#169): add sha256/hmac_sha256 to LANGUAGE.md + runnable example

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -338,6 +338,8 @@ first := users[0]                                // value copy
 | `base64_decode(s)`          | base64-decode a string → string; **lenient**: accepts standard *and* URL-safe alphabets, ignores missing padding |
 | `base64_encode_bytes(b)`    | base64-encode raw `bytes` → string (binary-safe; use instead of `base64_encode` for non-text payloads) |
 | `base64_decode_bytes(s)`    | base64-decode → raw `bytes` (lenient; binary-safe; e.g. SCRAM salt or binary token) |
+| `sha256(s)`                 | SHA-256 of string `s` → lowercase hex string (byte-exact against `sha256sum`) |
+| `hmac_sha256(key, msg)`     | HMAC-SHA256(key, msg) → lowercase hex string (RFC 2104; use for webhook signature verification) |
 | `sleep(ms)`                 | suspend the current goroutine (milliseconds) |
 | `listen(port)`              | open a TCP listening socket                  |
 | `accept(fd)`                | accept a connection, return its socket fd    |

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,7 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `json_echo_api`   | POST JSON → parse into a struct → echo it back as JSON |
 | `strings`         | string ops (`split`/`join`/`substr`/`index`/`replace`/…) + request-line parsing |
 | `bytes`           | `bytes` type: construct, `to_hex`/`from_hex`, `byte_at`, `bytes_sub`, `bytes_concat`, `bytes_str`; NUL-safe vs string |
+| `sha256`          | `sha256(s)` → lowercase hex; `hmac_sha256(key, msg)` → lowercase hex; webhook signature verification |
 | `crypto`          | OpenSSL crypto suite: SHA-256, HMAC, AES-GCM round-trip (`ct\|\|tag` layout), Ed25519 sign/verify |
 | `base64`          | `base64_encode`/`base64_decode`: standard padded encode, lenient decode (standard + URL-safe alphabets, ignores padding) |
 | `url_encode`      | `url_encode`/`url_decode`: RFC 3986 percent-encoding round-trip, `+`→space, malformed `%XX` passthrough |

--- a/examples/complex/sha256.mfl
+++ b/examples/complex/sha256.mfl
@@ -1,0 +1,26 @@
+//sha256/hmac_sha256:hash a string and verify a webhook signature.
+//sha256(s)->lowercase hex string;hmac_sha256(key,msg)->lowercase hex string.
+
+func verify_webhook(secret string,payload string,sig string) bool {
+expected:=hmac_sha256(secret,payload)
+return expected==sig
+}
+
+func main(){
+//---sha256: hash a string to lowercase hex---
+msg:="hello, machin"
+digest:=sha256(msg)
+println("sha256: ",digest)
+
+//---hmac_sha256: webhook signature verification---
+secret:="my-webhook-secret"
+payload:="{\"event\":\"push\",\"repo\":\"machin\"}"
+sig:=hmac_sha256(secret,payload)
+println("hmac_sha256: ",sig)
+
+ok:=verify_webhook(secret,payload,sig)
+println("signature valid: ",ok)
+
+bad:=verify_webhook(secret,payload,"deadbeef")
+println("tampered sig valid: ",bad)
+}

--- a/examples/complex/sha256.mfl
+++ b/examples/complex/sha256.mfl
@@ -1,7 +1,7 @@
 //sha256/hmac_sha256:hash a string and verify a webhook signature.
 //sha256(s)->lowercase hex string;hmac_sha256(key,msg)->lowercase hex string.
 
-func verify_webhook(secret string,payload string,sig string)bool{
+func verify_webhook(secret,payload,sig){
 expected:=hmac_sha256(secret,payload)
 return expected==sig
 }

--- a/examples/complex/sha256.mfl
+++ b/examples/complex/sha256.mfl
@@ -1,18 +1,18 @@
 //sha256/hmac_sha256:hash a string and verify a webhook signature.
 //sha256(s)->lowercase hex string;hmac_sha256(key,msg)->lowercase hex string.
 
-func verify_webhook(secret string,payload string,sig string) bool {
+func verify_webhook(secret string,payload string,sig string)bool{
 expected:=hmac_sha256(secret,payload)
 return expected==sig
 }
 
 func main(){
-//---sha256: hash a string to lowercase hex---
+//---sha256:hash a string to lowercase hex---
 msg:="hello, machin"
 digest:=sha256(msg)
 println("sha256: ",digest)
 
-//---hmac_sha256: webhook signature verification---
+//---hmac_sha256:webhook signature verification---
 secret:="my-webhook-secret"
 payload:="{\"event\":\"push\",\"repo\":\"machin\"}"
 sig:=hmac_sha256(secret,payload)


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #169: "docs: hash builtins (sha256/hmac_sha256) are undocumented in docs/LANGUAGE.md and have no runnable example")

ISSUE DESCRIPTION:
## Problem
The hash builtins added in **v0.24.0** (PR #165) — `sha256` and `hmac_sha256` — are absent from the language reference and have no runnable example.

## Where
- `docs/LANGUAGE.md` — the `## Builtins` table (lines 311-338) has **no `sha256` / `hmac_sha256` row**.
- `examples/` — no example program calls either (`grep -rl 'sha256\|hmac' examples` returns nothing).
- They are present in the `machin guide` catalog (`guide.go:115-116`) and `CHANGELOG.md` (v0.24.0), so the reference and catalog disagree (the LANGUAGE.md drift tracked in #155).

## Why it matters
A reader using `docs/LANGUAGE.md` as the canonical reference cannot find these builtins or their contract. Worth documenting precisely: both return a **lowercase hex** digest; `sha256(s)` is byte-exact against `sha256sum`, and `hmac_sha256(key, msg)` against `openssl` (FIPS-180-4 + RFC 2104 vectors). The CHANGELOG notes `hmac_sha256` is the primitive for verifying **webhook signatures** — a concrete, citable use case for the example.

## Suggested fix
- Add `sha256(s) -> string` and `hmac_sha256(key, msg) -> string` rows to the Builtins table in `docs/LANGUAGE.md` (note: lowercase hex output).
- Add a short runnable example (e.g. verifying an HMAC webhook signature) under `examples/` and list it in `examples/README.md`.

Same shape as #156 (json_get) and #163 (regex).

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#169): <brief description>
5. The PR body MUST include 'Fixes #169' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thlcdj`

## Summary

Add sha256/hmac_sha256 rows to docs/LANGUAGE.md Builtins table (noting lowercase hex output and RFC 2104 contract), plus a new examples/complex/sha256.mfl showing both builtins with a webhook signature verification pattern. Also listed in examples/README.md. Fixes #169.

**Diff:**
```
docs/LANGUAGE.md            |  2 ++
 examples/README.md          |  1 +
 examples/complex/sha256.mfl | 26 ++++++++++++++++++++++++++
 3 files changed, 29 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in support for lowercase hex SHA-256 hashing and HMAC-SHA256 generation.
  * Added a new complex example showing message hashing and webhook signature verification.
* **Documentation**
  * Updated the language reference and examples guide to include the new crypto-related functions and their output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->