### PR TITLE
fix(#170): add sqlite_open/exec/query/close to LANGUAGE.md + list example

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -357,6 +357,22 @@ first := users[0]                                // value copy
 | `bytes_sub(b, start, end)`  | sub-range `[start, end)` of a `bytes` value  |
 | `bytes_concat(a, b)`        | concatenate two `bytes` values               |
 
+### SQLite
+
+These builtins require `libsqlite3`; the linker flag (`-lsqlite3`) is added
+automatically when any `sqlite_*` builtin is used (the library must be installed
+on the build/runtime host, e.g. `apt install libsqlite3-dev` on Debian/Ubuntu).
+
+| Builtin                          | Purpose                                                                 |
+|----------------------------------|-------------------------------------------------------------------------|
+| `sqlite_open(path) -> int`       | open or create a SQLite database file → handle (`0` on failure); `":memory:"` opens a transient in-memory db |
+| `sqlite_exec(h, sql[, []string]) -> int` | run result-less SQL (CREATE/INSERT/UPDATE/DELETE); optional `[]string` binds `?` params (injection-safe); returns `0` on success |
+| `sqlite_query(h, sql[, []string]) -> string` | run a SELECT → **JSON array-of-row-objects** string; optional `[]string` binds `?` params; decode with `parse(rows, []T{})` for a typed slice, or `json_get` for a single field |
+| `sqlite_close(h) -> int`         | close the database handle                                               |
+
+See `examples/complex/sqlite_crud.mfl` for a working CRUD example using an
+in-memory database.
+
 ### Crypto (over `bytes`)
 
 These builtins require OpenSSL libcrypto; the linker flag is added automatically

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,6 +63,7 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `url_encode`      | `url_encode`/`url_decode`: RFC 3986 percent-encoding round-trip, `+`→space, malformed `%XX` passthrough |
 | `http_client_api` | HTTP client: `http_get` multi-assign + error branch, `http_request` with auth/Accept headers (real network calls) |
 | `router_api`      | HTTP router — dispatch by method+path, extract path params |
+| `sqlite_crud`     | SQLite: `sqlite_open`/`sqlite_exec`/`sqlite_query`/`sqlite_close` — in-memory CRUD with parameterized queries, `parse()` row decode, and `json_get` single-field access |
 
 `http_server` loops forever, so it's skipped by `run.sh`. Run it directly:
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #170: "docs: SQLite builtins (sqlite_open/exec/query/close) are undocumented in docs/LANGUAGE.md and have no runnable example")

ISSUE DESCRIPTION:
## Problem
The SQLite builtins added in **v0.26.0** (PR #167) — `sqlite_open`, `sqlite_exec`, `sqlite_query`, `sqlite_close` — are absent from the language reference and have no runnable example, despite introducing real persistent database storage.

## Where
- `docs/LANGUAGE.md` — the `## Builtins` table (lines 311-338) has **no `sqlite_*` rows**.
- `examples/` — no example program uses them (`grep -rl sqlite_ examples` returns nothing), even though `CHANGELOG.md` says they were 'surfaced building a persistent key-value store.'
- They are documented in the `machin guide` catalog (`guide.go:118-121`) and `CHANGELOG.md` (v0.26.0), so the reference and catalog disagree (LANGUAGE.md drift tracked in #155).

## Why it matters
This is the language's first real database feature and has behavior-defining semantics a reader must know:
- `sqlite_open(path) -> int` returns a handle (`0` on failure); `":memory:"` opens an in-memory db.
- `sqlite_exec(handle, sql) -> int` runs result-less SQL (CREATE/INSERT/...); `0` = ok.
- `sqlite_query(handle, sql) -> string` runs a SELECT and returns a **JSON array of row objects** — composes with `json_get` (#156).
- `sqlite_close(handle) -> int`.
- It links `-lsqlite3` only when a program calls `sqlite_*` — a build/runtime dependency (libsqlite3) worth documenting.

## Suggested fix
- Add the four `sqlite_*` builtins to the Builtins table in `docs/LANGUAGE.md`, including the JSON-array-of-rows return shape, the `:memory:` handle, error/return conventions, and the `-lsqlite3` dependency note.
- Add a runnable example (e.g. the persistent key-value store from the CHANGELOG) under `examples/` and list it in `examples/README.md`.

Same shape as #156 (json_get) and #163 (regex).

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#170): <brief description>
5. The PR body MUST include 'Fixes #170' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thljnx`

## Summary

Add SQLite builtins (sqlite_open/exec/query/close) to docs/LANGUAGE.md as a dedicated ### SQLite section with signatures, :memory: note, JSON-array-of-rows semantics, parameterized query info, and -lsqlite3 dependency. Also add the existing sqlite_crud.mfl example to examples/README.md so it's discoverable. Fixes #170.

**Diff:**
```
docs/LANGUAGE.md   | 16 ++++++++++++++++
 examples/README.md |  1 +
 2 files changed, 17 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new SQLite section to the builtins reference, including required library/linker setup.
  * Documented available SQLite builtins and how query results are returned.
  * Added a reference to an example CRUD workflow using an in-memory database.
* **Examples**
  * Added a new example entry highlighting SQLite CRUD usage with parameterized queries and row handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->