### PR TITLE
fix: reject duplicate function definitions (last-wins was silent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Fixed: duplicate function definitions were silently accepted (last wins).** Two
+  functions with the same name compiled with no error — the checker's registration
+  loop just overwrote the earlier entry in its lookup map. A real footgun for the
+  framework composition model (`machin encode framework/machweb.src app.src`), which
+  puts the framework and the app in one shared global namespace: an app name
+  colliding with a framework name (`route`, `param`, `serve`, …) silently won or lost
+  depending on declaration order, with zero diagnostic. `Check` already rejected
+  duplicate *types* this way; functions had no equivalent guard. Now a clear
+  `duplicate function "name"` error (`machin check --json` code `duplicate-function`).
+  Fixing this surfaced a real latent collision already shipping in the repo:
+  `framework/example.src`'s `route(req)` collided with `machweb.src`'s
+  `route(router, method, path, handler)` — renamed to `handle_request`, and
+  `framework/README.md` now documents the shared-namespace rule explicitly. See
+  issue #88.
+
 - **Added: `machin test [--json] <src...>` — a native MFL test runner (#236 Stage A).**
   `framework/test.src` provides `assert(cond, msg)`, `assert_eq_int(got, want, name)`,
   `assert_eq_str(got, want, name)`, and `test_summary()` (call last in `main()` — prints the

--- a/check.go
+++ b/check.go
@@ -349,6 +349,8 @@ func classifyCheck(msg string) string {
 		return "no-main"
 	case strings.Contains(msg, "duplicate type"):
 		return "duplicate-type"
+	case strings.Contains(msg, "duplicate function"):
+		return "duplicate-function"
 	case strings.Contains(msg, "field"):
 		return "undefined-field"
 	case strings.Contains(msg, "undefined") || strings.Contains(msg, "unknown") || strings.Contains(msg, "not defined"):

--- a/check_test.go
+++ b/check_test.go
@@ -59,3 +59,23 @@ func TestCheckNoMain(t *testing.T) {
 		t.Fatalf("expected no-main, got %+v", r)
 	}
 }
+
+// #88: two functions with the same name used to be silently accepted (the
+// second definition overwrote the first in the checker's lookup map, no
+// diagnostic) — a real footgun for framework composition, where an app
+// function name colliding with a framework one silently wins or loses
+// depending on declaration order. Must now be a typecheck error.
+func TestCheckDuplicateFunction(t *testing.T) {
+	src := `func greet(){return "FIRST"}
+func greet(){return "SECOND"}
+func main(){println(greet())}
+`
+	r := analyzeSource(src, []string{"<t>"})
+	if r.OK || r.ErrorCount != 1 {
+		t.Fatalf("expected one error, got %+v", r)
+	}
+	d := r.Diagnostics[0]
+	if d.Phase != "typecheck" || d.Code != "duplicate-function" {
+		t.Fatalf("expected typecheck/duplicate-function, got phase=%q code=%q", d.Phase, d.Code)
+	}
+}

--- a/framework/README.md
+++ b/framework/README.md
@@ -28,7 +28,12 @@ machin run app.mfl
 ```
 
 `machin encode` accepts multiple source files and concatenates them, so the
-framework's functions and yours end up in one program.
+framework's functions and yours end up in **one shared global namespace** — not
+two separate modules. If your app defines a function or type with the same name
+as one machweb already defines (`route`, `param`, `serve`, `dispatch`,
+`Request`, `Response`, …), that's a name collision, not a shadow: `machin
+check`/`build`/`run` reject it with a `duplicate function`/`duplicate type`
+error (#88). Pick a different name for your app-level declaration.
 
 ## API
 

--- a/framework/example.src
+++ b/framework/example.src
@@ -20,7 +20,7 @@ func todos() (list) {
     list = append(list, Todo{id: 2, title: "build a backend on machweb", done: false})
 }
 
-func route(req) (res) {
+func handle_request(req) (res) {
     if req.path == "/" {
         res = ok_html("<h1>machweb</h1><p>Endpoints: <code>/api/todos</code>, <code>/hello/&lt;name&gt;</code>, POST <code>/api/echo</code></p>")
     } else if req.path == "/api/todos" {
@@ -36,5 +36,5 @@ func route(req) (res) {
 }
 
 func main() {
-    serve(48080, func(req) { return route(req) })
+    serve(48080, func(req) { return handle_request(req) })
 }

--- a/types.go
+++ b/types.go
@@ -660,6 +660,9 @@ func Check(p *Program) (*Checker, error) {
 		if isBuiltinName(fn.Name) {
 			return nil, fmt.Errorf("function %q shadows the builtin %q — it would be silently ignored at call sites; rename it", fn.Name, fn.Name)
 		}
+		if _, dup := c.funcs[fn.Name]; dup {
+			return nil, fmt.Errorf("duplicate function %q", fn.Name)
+		}
 		c.funcs[fn.Name] = fn
 		if fn.Exported {
 			exported = append(exported, fn.Name)


### PR DESCRIPTION
## Summary
- Two functions with the same name compiled with no error — `Check`'s registration loop just overwrote the earlier entry in its lookup map. Types already had this guard (`duplicate type %q`); functions had none.
- A real footgun for the framework composition model, which puts the framework and the app in one shared global namespace: an app function name colliding with a framework one silently won or lost depending on declaration order.
- Added the matching guard, classified as `duplicate-function` in `machin check --json`'s stable code list.
- Fixing this surfaced a real latent collision already shipping in the repo: `framework/example.src`'s `route(req)` collided with `machweb.src`'s `route(router, method, path, handler)` — `framework/run.sh` composes both by default. Renamed to `handle_request`; verified the example still serves correctly end-to-end. `framework/README.md` now documents the shared-namespace rule explicitly.

Fixes #88.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 .` full suite passes
- [x] New `TestCheckDuplicateFunction`
- [x] Reproduced the original bug (`greet()` defined twice → `SECOND` silently wins), confirmed it now errors with `duplicate function "greet"` / `machin check --json` code `duplicate-function`
- [x] `framework/run.sh` (composes `machweb.src` + `example.src`) verified working end-to-end after the rename — curl against `/`, `/api/todos`, `/hello/machine` all correct
- [x] Checked all other `machin encode` compose call sites in the repo (`bench/*`) for the same collision class — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate function names are now rejected with a clear diagnostic instead of being accepted silently.
  * Analysis now reports a dedicated error code for this case, improving JSON output and tooling feedback.

* **Documentation**
  * Updated docs to explain that app and framework code share one namespace, and that name collisions are not allowed.

* **Tests**
  * Added coverage for duplicate function detection to verify the new error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->