### PR TITLE
fix: json_echo_api.mfl silently truncated large/split POST bodies (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Fixed: `examples/complex/json_echo_api.mfl` silently truncated large/split POST
+  bodies.** `read(fd)` is one `read(2)` syscall, returning at most 65535 bytes — not a
+  whole HTTP request. `framework/machweb.src`'s own server (`read_request_bytes`) has
+  looped correctly on this for a while; this specific example still used a single
+  `read(conn)` and had no test proving otherwise. Fixed by inlining the same
+  loop-until-`Content-Length` pattern (`read_bytes` + `bytes_index` + a small
+  `content_length` helper), kept self-contained (no framework composition needed).
+  Verified against a real 100 KB body: the old code silently truncated to 65,353
+  bytes; the fix round-trips all 100,000. `docs/LANGUAGE.md` and `SPEC.md` now
+  document the single-read limitation next to `read`/`write`, pointing at the correct
+  pattern. New `TestReadBytesLoopReassemblesLargePayload`. See issue #91.
+
 ## v0.99.0
 
 - **Fixed: duplicate function definitions were silently accepted (last wins).** Two

--- a/SPEC.md
+++ b/SPEC.md
@@ -325,7 +325,7 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 | `sleep` | `(int) -> ` | pause (milliseconds) |
 | `dial` | `(string, int) -> int` | connect to host:port; an fd, or -1 on failure |
 | `listen`, `accept` | `(int) -> int` | open / accept on a TCP socket |
-| `read`, `write` | `(int[, string]) -> string\|int` | socket/fd I/O |
+| `read`, `write` | `(int[, string]) -> string\|int` | socket/fd I/O — `read` is one `read(2)` of up to 65535 bytes, not a whole message; loop `read_bytes` (NUL-safe) to reassemble a complete request (see `framework/machweb.src`'s `read_request_bytes`, and issue #91) |
 | `close` | `(int\|chan) -> ` | close a socket/fd, or a channel (dispatched by argument) |
 | `https_get` | `(string) -> string` | HTTPS GET over TLS; response body ("" on error) |
 | `https_post` | `(string, string) -> string` | HTTPS POST (JSON body) over TLS; response body |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -343,7 +343,7 @@ first := users[0]                                // value copy
 | `sleep(ms)`                 | suspend the current goroutine (milliseconds) |
 | `listen(port)`              | open a TCP listening socket                  |
 | `accept(fd)`                | accept a connection, return its socket fd    |
-| `read(fd)` / `write(fd, s)` | read from / write to a socket                |
+| `read(fd)` / `write(fd, s)` | read from / write to a socket — **one `read(2)` of up to 65535 bytes, not a whole message** (see note below) |
 | `close(fd)`                 | close a socket                               |
 | `https_get(url)`            | GET over TLS (or plain http://) → body string (`""` on error) |
 | `https_post(url, body)`     | POST with string body over TLS (or plain http://) → body string |
@@ -356,6 +356,23 @@ first := users[0]                                // value copy
 | `byte_at(b, i)`             | byte value 0–255 at index `i` (−1 if out of range) |
 | `bytes_sub(b, start, end)`  | sub-range `[start, end)` of a `bytes` value  |
 | `bytes_concat(a, b)`        | concatenate two `bytes` values               |
+
+### Raw sockets (`listen` / `accept` / `read` / `write`)
+
+**`read(fd)` is one `read(2)` syscall, returning whatever is currently in the
+socket's buffer (up to 65535 bytes) — not a whole message.** TCP is a byte
+stream: a request larger than ~64KB, or one whose bytes simply haven't all
+arrived yet (common under load, or for any non-trivial POST body), is
+silently truncated. A single `read(conn)` is only safe when you know the
+peer sends one small, complete message per read (e.g. a line-based
+protocol) — never assume it returns a full HTTP request.
+
+To read a complete HTTP request, loop `read_bytes(fd)` (the NUL-safe,
+`bytes`-returning sibling of `read`) until you've seen the `\r\n\r\n`
+header/body separator, then keep looping until you have `Content-Length`
+bytes of body — this is exactly what `framework/machweb.src`'s
+`read_request_bytes` does; read that function before writing your own raw
+socket server. See also [issue #91](https://github.com/javimosch/machin/issues/91).
 
 ### SQLite
 

--- a/examples/complex/json_echo_api.mfl
+++ b/examples/complex/json_echo_api.mfl
@@ -1,5 +1,49 @@
-type Todo struct{id    int title string done  bool}
+type Todo struct{id int title string done bool}
 
-func handle(conn){req:=read(conn)t:=parse(http_body(req),Todo{})out:=json(t)resp:="HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "+str(len(out))+"\r\nConnection: close\r\n\r\n"+out write(conn,resp)close(conn)}
+//content_length parses the Content-Length header value from a request's headers.
+func content_length(head)(n){
+n=0
+i:=index(to_lower(head),"content-length:")
+if i>=0{
+rest:=substr(head,i+15,len(head))
+nl:=index(rest,"\r\n")
+if nl>=0{rest=substr(rest,0,nl)}
+n=parse_int(trim(rest))
+}
+}
 
-func main(){server:=listen(48080)println("JSON echo API on http://localhost:48080  (POST a Todo)")for{conn:=accept(server)go handle(conn)}}
+//read_request reads a whole request not just the first packet. a single
+//read syscall returns at most 65535 bytes and a POST body often arrives in
+//its own TCP segment so this loops on read_bytes until Content-Length bytes
+//of body are in hand. mirrors framework/machweb.src's read_request_bytes. see issue #91
+func read_request(conn)(raw){
+raw=read_bytes(conn)
+sep:=bytes_index(raw,bytes("\r\n\r\n"),0)
+if sep>=0{
+clen:=content_length(bytes_str(bytes_sub(raw,0,sep)))
+body_start:=sep+4
+for len(raw)-body_start<clen{
+chunk:=read_bytes(conn)
+if len(chunk)==0{break}
+raw=bytes_concat(raw,chunk)
+}
+}
+}
+
+func handle(conn){
+req:=bytes_str(read_request(conn))
+t:=parse(http_body(req),Todo{})
+out:=json(t)
+resp:="HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "+str(len(out))+"\r\nConnection: close\r\n\r\n"+out
+write(conn,resp)
+close(conn)
+}
+
+func main(){
+server:=listen(48080)
+println("JSON echo API on http://localhost:48080  (POST a Todo)")
+for{
+conn:=accept(server)
+go handle(conn)
+}
+}

--- a/wire_test.go
+++ b/wire_test.go
@@ -59,3 +59,55 @@ func main() {
 		t.Fatalf("read_bytes should return all 4 bytes incl. the leading NUL; got:\n%s", out)
 	}
 }
+
+// #91: `read`/`read_bytes` are each one read(2) of at most 65535 bytes, not a
+// whole message — a payload bigger than that (a large HTTP body, or one that
+// simply arrives in more than one TCP segment) needs the CALLER to loop.
+// examples/complex/json_echo_api.mfl's read_request does exactly this (loop
+// read_bytes until Content-Length bytes are in hand, mirroring
+// framework/machweb.src's read_request_bytes) — this test proves the
+// underlying mechanism a single read_bytes call cannot: a server writes a
+// payload well over the 65535-byte single-read cap, and the client must call
+// read_bytes more than once to reassemble it all.
+func TestReadBytesLoopReassemblesLargePayload(t *testing.T) {
+	prog := progFromSrc(t, `
+func serve_big(srv, n) {
+    conn := accept(srv)
+    payload := bytes("")
+    i := 0
+    chunk := from_hex("41")   // one byte, 'A'
+    while i < n {
+        payload = bytes_concat(payload, chunk)
+        i = i + 1
+    }
+    write_bytes(conn, payload)
+    close(conn)
+}
+func main() {
+    n := 100000   // well over the 65535-byte single-read(2) cap
+    srv := listen(48235)
+    go serve_big(srv, n)
+    sleep(100)
+    c := dial("127.0.0.1", 48235)
+    total := bytes("")
+    reads := 0
+    for {
+        chunk := read_bytes(c)
+        if len(chunk) == 0 { break }
+        total = bytes_concat(total, chunk)
+        reads = reads + 1
+    }
+    close(c)
+    println("len=" + str(len(total)) + " reads=" + str(reads))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out, "len=100000") {
+		t.Fatalf("expected the full 100000-byte payload reassembled, got:\n%s", out)
+	}
+	if strings.Contains(out, "reads=1") {
+		t.Fatalf("expected more than one read_bytes call to reassemble 100000 bytes (proves a single read cannot), got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- `read(fd)` is one `read(2)` syscall, returning at most 65535 bytes — not a whole HTTP request. `framework/machweb.src`'s own server (`read_request_bytes`) already loops correctly on this; `examples/complex/json_echo_api.mfl` — one of the two examples #91 named as actually vulnerable (`http_server.mfl` reads but never uses the result, so it's not functionally affected) — still used a single `read(conn)`.
- Fixed by inlining the same loop-until-`Content-Length` pattern (`read_bytes` + `bytes_index` + a small `content_length` helper mirroring `machweb.src`'s), kept self-contained so the example needs no framework composition.
- `docs/LANGUAGE.md` (new "Raw sockets" subsection) and `SPEC.md` now document the single-read limitation next to `read`/`write`, pointing at `read_request_bytes` as the reference pattern — per the issue's own documentation fallback.

Fixes #91.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 .` full suite passes
- [x] New `TestReadBytesLoopReassemblesLargePayload` — proves the underlying mechanism (a single `read_bytes` call cannot return more than its 65536-byte cap) a regression could silently break
- [x] Empirically reproduced the bug against a real 100 KB POST body: old code truncated to 65,353 bytes; fix round-trips all 100,000 — verified with a clean server process each time (not a stale one), confirmed by explicit port checks
- [x] Canonical-form check (the file's own tightening rules) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)