### PR TITLE
ci: add a workflow that actually runs the test suite (#85)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: ci
+
+# Runs on every push to main and every PR: build, the full Go test suite
+# (compiles + executes real MFL programs natively — needs a C compiler and
+# CGO enabled, unlike release.yml's cross-compiled CGO_ENABLED=0 binaries),
+# and every non-server/non-GUI example as an integration smoke test.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install system deps (crypto + sqlite builtins link against these)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libsqlite3-dev
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Run every example (integration smoke test)
+        run: ./examples/run.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install system deps (crypto + sqlite builtins link against these)
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libsqlite3-dev
+
+      - name: Test
+        run: go test ./...
+
       - name: Build binaries
         env:
           CGO_ENABLED: "0" # pure Go: static binaries that cross-compile cleanly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **CI: added a workflow that actually runs the test suite.** `release.yml` (build +
+  cross-compile + publish) never ran `go test` — a broken compiler could ship to
+  users. Added `ci.yml` (push to `main` + every PR): build, `go test ./...`, and
+  `./examples/run.sh` as an integration smoke test. `release.yml` now runs `go test
+  ./...` before cross-compiling, so a tag with failing tests does not publish a
+  release. See issue #85.
+
 ## v0.101.0
 
 - **Test: covered the `machin encode` command path.** `splitFunctions`, `stripLineComment`,


### PR DESCRIPTION
## Summary
- `release.yml` (build + cross-compile + publish) never ran `go test` — a broken compiler could ship to users, and the ~90 Go tests exercising the full language surface never ran in CI at all.
- Added `ci.yml`: push to `main` + every PR runs `go build`, `go test ./...`, and `./examples/run.sh` (an integration smoke test — builds `machin` and runs every non-server/non-GUI example).
- `release.yml` now runs `go test ./...` before cross-compiling, so a tag with failing tests does not publish a release.
- Both workflows install `libssl-dev`/`libsqlite3-dev` first — the crypto and sqlite builtins' tests link against these, and `release.yml`'s existing cross-compile step (`CGO_ENABLED=0`, pure Go) never needed them before.

Fixes #85.

## Test plan
- [x] `go build ./...` and `go test ./...` pass locally
- [x] Opening this PR triggers `ci.yml` for real — watching the actual GitHub Actions run to confirm the runner environment (system deps, `examples/run.sh`) behaves as expected, not just assuming it will

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated CI checks for pushes and pull requests, including build, test, and a smoke test run.
  * Updated the release workflow to install required system libraries and run tests before publishing binaries.

* **Documentation**
  * Updated the changelog to reflect the new CI and release validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->