### PR TITLE
fix(#147): add C FFI / extern section to docs/LANGUAGE.md

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -519,6 +519,114 @@ See `examples/complex/http_client_api.mfl` for the full runnable example.
 
 ---
 
+## C FFI (extern)
+
+MFL can call C functions directly. An `extern` block declares the library, its
+header, link flags, and the functions (or C structs) to expose:
+
+```go
+extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) float }
+
+func main() {
+    println("sqrt(2) =", sqrt(2.0))
+    println("2^10  =", pow(2.0, 10.0))
+}
+```
+
+- `"m"` — an informational name for the library.
+- `header "h.h"` — emits `#include <h.h>` so the real C prototype is in scope.
+  Omit it and machin synthesizes a prototype from the declared signature.
+- `link "l"` — passes `-l<l>` to the compiler. Repeat for multiple libraries
+  (`link "raylib" link "GL" link "m"`); they are emitted in order.
+- `cflags "..."` — passes extra flags (`-I`/`-L` paths, etc.) to the C compiler.
+- `fn Name(t, …) ret` — a foreign function. A missing return type means `void`.
+
+See `examples/complex/ffi_math.mfl` for the runnable version.
+
+### FFI scalar types
+
+| MFL type | C type        | Notes                                       |
+|----------|---------------|---------------------------------------------|
+| `int`    | `int64_t`     |                                             |
+| `i32`    | `int32_t`     | use for 32-bit C params (e.g. raylib)       |
+| `i16`    | `int16_t`     |                                             |
+| `i8`     | `int8_t`      |                                             |
+| `u64`…`u8` | `uint64_t`…`uint8_t` |                                  |
+| `float` / `f64` | `double` |                                        |
+| `f32`    | `float`       |                                             |
+| `bool`   | `int`         |                                             |
+| `string` | `const char*` |                                             |
+| `ptr`    | `void*`       | opaque handle, held as `int` in MFL (see below) |
+
+### `cstruct` — by-value C structs
+
+`cstruct Name { field ctype … }` declares a C struct. machin synthesizes a
+matching MFL struct and marshals it at the boundary:
+
+```go
+extern "c" {
+    header "stdlib.h"
+    cstruct div_t { quot i32  rem i32 }
+    fn div(i32, i32) div_t
+}
+
+func main() {
+    r := div(17, 5)
+    println("17 / 5 =", r.quot, "remainder", r.rem)
+}
+```
+
+A field may be another `cstruct` (declare the inner one first), enabling nested
+by-value aggregates like raylib's `Camera3D`.
+
+See `examples/complex/ffi_struct.mfl`.
+
+### Opaque handles (`ptr` and opaque `cstruct`)
+
+Use **`ptr`** for a single opaque C pointer (held as an `int`):
+
+```go
+extern "c" {
+    header "stdio.h"
+    fn fopen(string, string) ptr
+    fn fputs(string, ptr) i32
+    fn fclose(ptr) i32
+}
+
+func main() {
+    f := fopen("/tmp/out.txt", "w")
+    if f == 0 { println("error") } else {
+        fputs("hello from MFL\n", f)
+        fclose(f)
+    }
+}
+```
+
+Use **`cstruct Name {}`** (empty body) for a by-value C type whose fields you
+don't need in MFL (e.g. raylib's `Sound`/`Music`/`Font`). machin holds the full
+C struct and passes it back to functions — you can store it in a variable or
+slice, but cannot construct or field-access it.
+
+See `examples/complex/ffi_ptr.mfl`.
+
+### Multi-`link` and `cflags`
+
+```go
+extern "raylib" {
+    cflags "-I/usr/local/include"
+    link "raylib"  link "GL"  link "m"
+    header "raylib.h"
+    fn InitWindow(i32, i32, string)
+    fn WindowShouldClose() bool
+    fn CloseWindow()
+}
+```
+
+Libraries are linked in declaration order; `cflags` entries are passed directly
+to the C compiler. See `examples/gui/` for a working raylib desktop application.
+
+---
+
 ## See also
 
 - [`../README.md`](../README.md) — project overview and the toolchain


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #147: "docs: LANGUAGE.md (the \"full reference\") has no C FFI / extern section at all")

ISSUE DESCRIPTION:
## Problem

`docs/LANGUAGE.md` is linked from the README as the **"Language tour"** / full reference, yet it contains **zero** documentation of the C FFI / `extern` feature. Grepping the file for `extern`, `cstruct`, `link`, `header`, or `foreign` returns nothing — the document jumps straight from `## Concurrency` (line 342) to `## See also` (line 412) with no FFI section.

C FFI is a first-class, prominently-advertised capability everywhere else:

- **README** "Capabilities": *"C FFI: `extern` blocks — scalars, by-value structs (`cstruct`), opaque `ptr` handles, multi-`link` (drove a real raylib GUI)"*
- **SPEC.md** `## 15. Foreign functions (C FFI)` (lines 430-477) documents the full grammar.
- **`machin guide`** ships an `ffi-extern` idiom (`guide.go:165`).
- Runnable examples exist: `examples/complex/ffi_math.mfl`, `ffi_struct.mfl`, `ffi_ptr.mfl`.
- It is covered by tests: `ffi_test.go`.

A reader who learns the language from LANGUAGE.md (as the README directs) has no idea `extern` exists or how to call C.

## Why it matters

The standing docs goal is keeping the reference complete and trustworthy. An entire advertised subsystem missing from the canonical reference is the most severe kind of doc gap — readers can't discover the feature, and the reference silently contradicts the README's capability list.

## Suggested fix

Add a `## C FFI (extern)` section to `docs/LANGUAGE.md` covering the `extern "lib" { header ... link ... fn ... }` form, scalar/`cstruct`/`ptr` argument kinds, and `cflags`/multi-`link`. Mirror SPEC §15 and the `ffi-extern` idiom in `guide.go`, and link the `examples/complex/ffi_*.mfl` programs.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#147): <brief description>
5. The PR body MUST include 'Fixes #147' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thmcbf`

## Summary

Added a `## C FFI (extern)` section to `docs/LANGUAGE.md`, the canonical language reference that was entirely missing FFI documentation. The section covers the `extern "lib" { header ... link ... fn ... }` block form, the full FFI scalar type table, `cstruct` by-value structs (with runnable `div_t` example), opaque `ptr` handles (with `FILE*` example), and multi-`link`/`cflags` usage with a raylib snippet. All three `examples/complex/ffi_*.mfl` programs are linked. Mirrors SPEC §15 and the `ffi-extern` idiom in `guide.go`.

**Diff:**
```
docs/LANGUAGE.md | 108 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 108 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section covering C FFI support, including how to declare and call external C functions.
  * Documented library, header, linker, and compiler flag usage for foreign function integration.
  * Added guidance on type mapping, struct interoperability, opaque pointers, and ordering rules for multiple external linkage entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->