### PR TITLE
fix: parse() silently mangled \uXXXX JSON escapes instead of decoding them (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Fixed a high-severity data-corruption bug: `parse()` silently mangled
+  `\uXXXX` JSON escapes instead of decoding them.** `{"s":"em—dash"}`
+  parsed to the literal text `emu2014dash` instead of `em—dash` — the
+  backslash was dropped and the four hex digits leaked through as ordinary
+  characters. Common in practice: many JSON producers (including LLM APIs)
+  escape non-ASCII characters this way. Now correctly UTF-8 encodes the code
+  point, including surrogate-pair decoding for astral characters (emoji,
+  etc); a malformed `\u` escape degrades safely to literal text rather than
+  crashing. See issue #311.
+- Documented that MFL string literals have no `\uXXXX` escape form (SPEC.md)
+  — embed non-ASCII as raw UTF-8 in source files instead.
+
 ## v0.105.0
 
 - **Self-hosted compiler: ported the #310 `go`-argument use-after-free fix to

--- a/SPEC.md
+++ b/SPEC.md
@@ -78,7 +78,10 @@ The decoded text of a declaration is tokenized as follows.
 - **Integer literals.** decimal (`42`), hex (`0xff`), binary (`0b1010`), or octal
   (`0o17`); underscores allowed as separators (`0xff_00`).
 - **Float literals.** digits with a `.`, e.g. `3.14`, `0.5`.
-- **String literals.** `"..."` with escapes `\n \t \r \" \\`.
+- **String literals.** `"..."` with escapes `\n \t \r \" \\`. No `\uXXXX`
+  escape form — embed non-ASCII as raw UTF-8 bytes in the source file instead
+  (a tool generating `.src`/`.mfl` text should emit real UTF-8, not escape it —
+  e.g. Python's `json.dumps(..., ensure_ascii=False)`).
 - **Keywords.** `func return if else while for range true false nil var go type
   struct chan make map arena extern export break continue select`.
 - **Operators and punctuation.** `+ - * / % & | ^ << >> == != < <= > >= && || ! = := <- .

--- a/codegen.go
+++ b/codegen.go
@@ -723,6 +723,28 @@ static void mfl_js_ws(const char** p) { while (**p==' '||**p=='\t'||**p=='\n'||*
 static int64_t mfl_js_int(const char** p) { mfl_js_ws(p); char* e; long long v = strtoll(*p, &e, 10); *p = e; return v; }
 static double mfl_js_float(const char** p) { mfl_js_ws(p); char* e; double v = strtod(*p, &e); *p = e; return v; }
 static int mfl_js_bool(const char** p) { mfl_js_ws(p); if (**p=='t') { *p += 4; return 1; } if (**p=='f') { *p += 5; return 0; } return 0; }
+/* mfl_hex4: the 4 hex digits at p as an int, or -1 if any of them aren't hex
+   (a malformed \u escape -- the caller falls back to treating it literally). */
+static int mfl_hex4(const char* p) {
+    int v = 0;
+    for (int i = 0; i < 4; i++) {
+        char c = p[i]; int d;
+        if (c >= '0' && c <= '9') d = c - '0';
+        else if (c >= 'a' && c <= 'f') d = c - 'a' + 10;
+        else if (c >= 'A' && c <= 'F') d = c - 'A' + 10;
+        else return -1;
+        v = v * 16 + d;
+    }
+    return v;
+}
+/* mfl_utf8_encode: UTF-8 encode one Unicode code point into out, returning the
+   byte count written (1-4). */
+static size_t mfl_utf8_encode(char* out, int cp) {
+    if (cp < 0x80) { out[0] = (char)cp; return 1; }
+    if (cp < 0x800) { out[0] = (char)(0xC0 | (cp >> 6)); out[1] = (char)(0x80 | (cp & 0x3F)); return 2; }
+    if (cp < 0x10000) { out[0] = (char)(0xE0 | (cp >> 12)); out[1] = (char)(0x80 | ((cp >> 6) & 0x3F)); out[2] = (char)(0x80 | (cp & 0x3F)); return 3; }
+    out[0] = (char)(0xF0 | (cp >> 18)); out[1] = (char)(0x80 | ((cp >> 12) & 0x3F)); out[2] = (char)(0x80 | ((cp >> 6) & 0x3F)); out[3] = (char)(0x80 | (cp & 0x3F)); return 4;
+}
 static char* mfl_js_str(const char** p) {
     mfl_js_ws(p);
     if (**p != '"') return mfl_dup("");
@@ -732,10 +754,26 @@ static char* mfl_js_str(const char** p) {
         char c = **p;
         if (c == '\\') {
             (*p)++; char e = **p;
-            if (e=='n') out[j++]='\n'; else if (e=='t') out[j++]='\t'; else if (e=='r') out[j++]='\r';
-            else out[j++] = e;
-        } else out[j++] = c;
-        (*p)++;
+            if (e == 'u') {
+                int cp = mfl_hex4(*p + 1);
+                if (cp < 0) { out[j++] = 'u'; (*p)++; }
+                else {
+                    *p += 5; /* past "u" + 4 hex digits */
+                    if (cp >= 0xD800 && cp <= 0xDBFF && (*p)[0] == '\\' && (*p)[1] == 'u') {
+                        int lo = mfl_hex4(*p + 2);
+                        if (lo >= 0xDC00 && lo <= 0xDFFF) {
+                            cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                            *p += 6;
+                        }
+                    }
+                    j += mfl_utf8_encode(out + j, cp);
+                }
+            }
+            else if (e=='n') { out[j++]='\n'; (*p)++; }
+            else if (e=='t') { out[j++]='\t'; (*p)++; }
+            else if (e=='r') { out[j++]='\r'; (*p)++; }
+            else { out[j++] = e; (*p)++; }
+        } else { out[j++] = c; (*p)++; }
     }
     if (**p == '"') (*p)++;
     out[j] = 0; return out;

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -222,6 +222,45 @@ func TestJSONParseSliceAndMap(t *testing.T) {
 	}
 }
 
+// parse() must decode \uXXXX JSON escapes (UTF-8 encoding the code point) --
+// #311: the old parser dropped the backslash and leaked the literal "uXXXX"
+// text through, silently corrupting any JSON with an escaped non-ASCII char
+// (common: LLM API responses escaping an em-dash, curly quote, etc).
+func TestJSONParseUnicodeEscape(t *testing.T) {
+	got := runProg(t,
+		`type T struct { s string }`,
+		`func main() { t := parse("{\"s\":\"a\\u000bb\\u2014d\"}", T{}) println(t.s) }`)
+	want := "ab—d\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// A surrogate pair (😀, an astral character outside the BMP) must
+// combine into a single code point, not two separate replacement-ish values.
+func TestJSONParseSurrogatePair(t *testing.T) {
+	got := runProg(t,
+		`type T struct { s string }`,
+		`func main() { t := parse("{\"s\":\"emoji=\\uD83D\\uDE00 end\"}", T{}) println(t.s) }`)
+	want := "emoji=\U0001F600 end\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// A malformed \u escape (non-hex digits, or truncated at end of string) must
+// degrade safely -- the literal "u" plus whatever follows, not a crash or an
+// out-of-bounds read.
+func TestJSONParseMalformedUnicodeEscape(t *testing.T) {
+	got := runProg(t,
+		`type T struct { s string  t string }`,
+		`func main() { v := parse("{\"s\":\"bad=\\uZZZZend\",\"t\":\"short=\\u12\"}", T{}) println(v.s) println(v.t) }`)
+	want := "bad=uZZZZend\nshort=u12\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestHTTPBody(t *testing.T) {
 	got := runProg(t,
 		`func main() { println(http_body("POST / HTTP/1.1\r\nHost: x\r\n\r\nthe-body")) }`)


### PR DESCRIPTION
## Summary

- Fixes a high-severity data-corruption bug (#311): `parse()`'s JSON string decoder (`mfl_js_str`) had no `\uXXXX` handling — it emitted a literal `u` and let the four hex digits leak through as ordinary text. `{"s":"em—dash"}` parsed to `"emu2014dash"` instead of `"em—dash"`. Common in practice: many JSON producers (including LLM APIs) escape non-ASCII this way.
- Adds `mfl_hex4` (parse 4 hex digits, `-1` on any non-hex byte) and `mfl_utf8_encode` (UTF-8 encode one code point, 1-4 bytes), and teaches `mfl_js_str` to decode `\uXXXX`, including surrogate-pair combination for astral characters (emoji, etc). A malformed `\u` escape falls back to the pre-existing literal-`u` behavior rather than crashing — `mfl_hex4` stops at the first invalid byte (including a bare NUL), so it can never read past the string's allocation even on truncated input.
- Documents (SPEC.md) that MFL string *literals* still have no `\uXXXX` form — a separate, smaller, pre-existing limitation the issue flagged as worth a doc line.

## Verification

- Built the fix and manually confirmed the exact em-dash repro round-trips correctly — checked the raw UTF-8 bytes (`e2 80 94`), not just the printed glyph.
- Confirmed a surrogate-pair emoji (`😀`) decodes to the correct 4-byte UTF-8 sequence (`f0 9f 98 80`).
- Confirmed malformed `\u` (non-hex digits, or truncated near end-of-string) degrades safely to literal text, no crash.
- Three new regression tests: 2 of 3 confirmed to fail on the pre-fix code and pass on the fix; the third (malformed input) correctly passes on both, since that fallback behavior is intentionally unchanged.
- Full `go test ./...` green.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 .` (full suite)
- [x] Manual byte-level verification (em-dash, surrogate pair, malformed input)
- [x] New regression tests confirmed to fail on old code, pass on fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON parsing now correctly decodes `\uXXXX` escapes into proper UTF-8, including surrogate pairs and malformed escape handling.
  * Prevents escaped Unicode text from appearing as raw hex in output.

* **Documentation**
  * Clarified that string literals do not support `\uXXXX` escapes.
  * Updated guidance to use raw UTF-8 characters directly in source text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->