### PR TITLE
docs(#152): point LANGUAGE.md to the canonical `machin guide` catalog

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -8,6 +8,11 @@ native code through C (`cc -O2`).
 This document describes the surface syntax — which is exactly what a `.mfl` file
 contains, one normalized declaration per line.
 
+> For the complete, version-exact surface (every keyword and builtin with
+> signatures, idioms, gotchas), run `machin guide` (`--text` for prose) — it is
+> generated from the compiler's own catalog and cannot drift. This tour is a
+> readable companion.
+
 ---
 
 ## Source form
@@ -629,6 +634,8 @@ to the C compiler. See `examples/gui/` for a working raylib desktop application.
 
 ## See also
 
+- `machin guide` (`--text` for prose) — the complete, version-exact catalog of
+  every keyword and builtin, generated from the compiler's own source of truth
 - [`../README.md`](../README.md) — project overview and the toolchain
 - [`../examples/`](../examples/) — runnable programs (`machin run <file>.mfl`)
 - `machin build <file>.mfl --emit-c` — inspect the C the compiler emits


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #152: "docs: LANGUAGE.md never points to `machin guide`, the catalog the README/AGENTS call the canonical, drift-proof reference")

ISSUE DESCRIPTION:
## Problem
`README.md` (line 16) and `AGENTS.md` (lines 6–11) both prominently direct readers to **`machin guide`** as the complete, version-exact, source-of-truth feature surface ("It's emitted from the compiler's own catalog, so it can't drift from the implementation"). `SPEC.md` §2 also lists it in the command table.

`docs/LANGUAGE.md` — the human-facing "Language tour" linked from the README — never mentions `machin guide` anywhere (not in the intro, not in the "See also" at the end). 

## Why it matters
LANGUAGE.md is hand-maintained prose and therefore the doc most prone to drift (e.g. it currently omits `break`/`continue` and the `framework/` modules — see related issues). A reader who lands on LANGUAGE.md has no signal that a guaranteed-accurate, machine-generated catalog exists. Pointing to `machin guide` both helps readers get an authoritative list and sets expectations that the prose tour is a gentler companion, not the source of truth.

## Suggested fix
Add a short note near the top of `docs/LANGUAGE.md` (and/or in its "See also" section, line ~412) along the lines of:

> For the complete, version-exact surface (every keyword and builtin with signatures, idioms, gotchas), run `machin guide` (`--text` for prose) — it is generated from the compiler's own catalog and cannot drift. This tour is a readable companion.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#152): <brief description>
5. The PR body MUST include 'Fixes #152' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thn7qk`

## Summary

Added a pointer to `machin guide` in docs/LANGUAGE.md: a short note near the top (right after the intro) and a new bullet in the "See also" section. This closes the gap where README.md/AGENTS.md both tell readers `machin guide` is the canonical, version-exact, drift-proof feature catalog, but LANGUAGE.md — the hand-maintained prose tour most prone to drift — never mentioned it. Fixes #152.

**Diff:**
```
docs/LANGUAGE.md | 7 +++++++
 1 file changed, 7 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the language reference to point to `machin guide` as the source for version-exact syntax details.
  * Added a note explaining that the generated text output stays aligned with the compiler’s own catalog.
  * Included a new “See also” reference for the text-based guide in the main reference list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->