### PR TITLE
fix(#154): add missing FFI/arena/counter/game_menu rows to examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,12 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `http_client_api` | HTTP client: `http_get` multi-assign + error branch, `http_request` with auth/Accept headers (real network calls) |
 | `router_api`      | HTTP router — dispatch by method+path, extract path params |
 | `sqlite_crud`     | SQLite: `sqlite_open`/`sqlite_exec`/`sqlite_query`/`sqlite_close` — in-memory CRUD with parameterized queries, `parse()` row decode, and `json_get` single-field access |
+| `arena`           | scoped `arena{}` allocation |
+| `counter`         | closure/state counter |
+| `ffi_math`        | C FFI — calling external C functions (scalars) |
+| `ffi_ptr`         | C FFI — opaque `ptr` handles |
+| `ffi_struct`      | C FFI — by-value `cstruct` |
+| `game_menu`       | `input()` + interactive menu |
 
 `http_server` loops forever, so it's skipped by `run.sh`. Run it directly:
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #154: "docs: examples/README.md `complex/` catalog omits the FFI examples (ffi_math, ffi_ptr, ffi_struct) and arena/counter")

ISSUE DESCRIPTION:
The `complex/` example catalog in `examples/README.md` (the table starting around line 30) lists 28 programs, but `examples/complex/` actually contains 34 `.mfl` files. Six are missing from the table:

| missing file | demonstrates |
|---|---|
| `ffi_math.mfl` | C FFI — calling external C functions (scalars) |
| `ffi_ptr.mfl` | C FFI — opaque `ptr` handles |
| `ffi_struct.mfl` | C FFI — by-value `cstruct` |
| `arena.mfl` | scoped `arena{}` allocation |
| `counter.mfl` | (closure/state counter) |
| `game_menu.mfl` | `input()` + interactive menu |

The most notable omission is the **entire C FFI example suite** (`ffi_math`, `ffi_ptr`, `ffi_struct`). FFI is a headline capability — `README.md:50` advertises `extern` blocks that "drove a real raylib **GUI**" — yet a reader browsing the example catalog finds no FFI entry at all and would not discover these runnable examples exist.

(`game_menu`'s absence from `examples/README.md` is already tracked in #95, and `counter`/`arena` were noted in #72; the **`ffi_*` omission is untracked** and is the main reason to fix the table.)

**Why it matters:** `examples/README.md` is the discovery surface for runnable programs. An incomplete catalog hides working demonstrations of a flagship feature (FFI) and contributes to the "example catalogs are out of date" pattern.

**Suggested fix:** add table rows for `ffi_math`, `ffi_ptr`, `ffi_struct`, `arena`, and `counter` (and `game_menu` per #95) so the catalog matches the directory. A small guard test that diffs `examples/complex/*.mfl` against the catalog rows would prevent future drift.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#154): <brief description>
5. The PR body MUST include 'Fixes #154' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thn94i`

## Summary

Fixed #154: examples/README.md's complex/ example catalog table was missing 6 of 34 .mfl files, most notably the entire C FFI example suite (ffi_math, ffi_ptr, ffi_struct) which advertises a flagship language feature. Added table rows for ffi_math, ffi_ptr, ffi_struct, arena, counter, and game_menu so the catalog now matches the directory contents exactly.

**Diff:**
```
examples/README.md | 6 ++++++
 1 file changed, 6 insertions(+)
```
