### PR TITLE
fix(#155): add docs/LANGUAGE.md and machin guide catalog to feature checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,8 @@ When adding a language feature, thread it through **every** pass that switches o
 node type: `transform.go` (lifter, `collectDeclared`, `freeIdents`), `types.go`
 (`genStmt`, and arity/return walkers), and `codegen.go`. Add a test in
 `*_test.go` and, when it is user-facing, an example under `examples/complex/`
-and a note in `SPEC.md` + `README.md`.
+and a note in `SPEC.md`, `README.md`, and `docs/LANGUAGE.md`, plus the relevant
+idiom/gotcha in the `machin guide` catalog (`guide.go`).
 
 ### Branch → PR → merge
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #155: "docs: AGENTS.md feature-addition checklist omits docs/LANGUAGE.md (and the machin guide catalog) — the root cause of the LANGUAGE.md drift")

ISSUE DESCRIPTION:
## Problem

`AGENTS.md` is the contributor process doc. Its **"Dev workflow → When adding a language feature"** paragraph tells contributors which artifacts to update:

> When adding a language feature, thread it through **every** pass that switches on node type: `transform.go` …, `types.go` …, and `codegen.go`. Add a test in `*_test.go` and, when it is user-facing, an example under `examples/complex/` and a note in **`SPEC.md` + `README.md`**.

(`AGENTS.md` lines ~82–86.)

The checklist lists `SPEC.md` and `README.md` — but **never mentions `docs/LANGUAGE.md`** (linked from the README as the *"Language tour"* / "full reference") nor the **`machin guide` catalog** in `guide.go` (whose idioms/gotchas are hand-maintained).

## Why it matters

This omission is the institutional root cause of `docs/LANGUAGE.md` perpetually lagging the implementation. There are currently **~12 open issues** tracking individual LANGUAGE.md staleness symptoms (#70, #71, #76, #78, #79, #89, #95, #147, #148, #149, #150, #152). Each time a feature lands, the documented process directs the author to SPEC.md + README.md and silently skips LANGUAGE.md — so it falls further behind with every release. Fixing the symptoms one-by-one without fixing the process guarantees the drift recurs.

## Where

- `AGENTS.md`, the "When adding a language feature" paragraph in the **Dev workflow** section (lines ~82–86).

## Suggested fix

Add `docs/LANGUAGE.md` (and the manually-maintained portions of the `guide.go` catalog — idioms/gotchas, which are not test-guarded the way the builtin list is) to the "a note in SPEC.md + README.md" step, e.g.:

> … and a note in `SPEC.md`, `README.md`, and `docs/LANGUAGE.md`, plus the relevant idiom/gotcha in the `machin guide` catalog (`guide.go`).

Optionally, note that the long-term fix is to stop hand-maintaining LANGUAGE.md and generate it (or its surface tables) from the same catalog `machin guide` emits, so it can't drift — see #152.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#155): <brief description>
5. The PR body MUST include 'Fixes #155' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thn9pg`

## Summary

Fixed the "when adding a language feature" checklist in AGENTS.md, which told contributors to update only SPEC.md + README.md when landing a user-facing language feature — silently omitting docs/LANGUAGE.md and the machin guide catalog (guide.go). This was the institutional root cause of docs/LANGUAGE.md perpetually lagging the implementation (~12 open staleness issues tracked). The checklist now explicitly names docs/LANGUAGE.md and the relevant idiom/gotcha entry in the machin guide catalog.

**Diff:**
```
AGENTS.md | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```
