### PR TITLE
fix(#156): document json_get in LANGUAGE.md and add a runnable example

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -325,6 +325,7 @@ first := users[0]                                // value copy
 | `keys(m)`                   | a slice of map `m`'s keys                    |
 | `json(x)`                   | serialize any value to a JSON string         |
 | `parse(s, T{})`             | parse a JSON string into a value of `T`'s type |
+| `json_get(json, path)`      | value at a jq-style path → `(value, err)`; `err` is `""`/`"notfound"`/`"path"`/`"parse"` — **multi-assign only** |
 | `http_body(req)`            | the body of an HTTP message (after the blank line) |
 | `substr(s, i, j)`           | the substring `s[i:j]` (bounds-clamped)      |
 | `index(s, sub)`             | first index of `sub` in `s`, or `-1`         |
@@ -476,6 +477,24 @@ zero-fills missing ones. `http_body(req)` returns the body of an HTTP message
 (the bytes after the blank line) — so a server can `parse(http_body(req), T{})`.
 See `examples/complex/json_parse.mfl` and the echo server
 `examples/complex/json_echo_api.mfl`.
+
+`json_get(json, path)` digs a single value out of a JSON string by a
+jq-style path (`.field`, `[index]`, chained) without parsing the whole
+document into a struct — handy when you only need one field, or the shape
+isn't known ahead of time. It's **multi-assign only**, returning
+`(value, err)`: `value` is the raw JSON text at that path, and `err` is
+`""` on success, `"notfound"` if the path doesn't resolve, `"path"` if the
+path string itself is malformed, or `"parse"` if the JSON at that location
+can't be read:
+
+```go
+s := json(Todo{id: 1, title: "ship it", done: false})
+title, err := json_get(s, ".title")   // title == `"ship it"`, err == ""
+_, err = json_get(s, ".nope")         // err == "notfound"
+```
+
+See `examples/complex/json_get.mfl`, and `sqlite_query`'s use of it for
+single-field access on query rows.
 
 ### Channels
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,7 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `json`            | `json()` serialization of scalars, slices, structs, maps |
 | `json_api`        | JSON-over-HTTP API — each request returns JSON-serialized structs |
 | `json_parse`      | `parse(s, T{})` — JSON into struct/slice/map/scalar, with round-trips |
+| `json_get`        | `json_get(json, path)` — jq-style path lookup, `(value, err)` multi-assign, all `err` cases |
 | `json_echo_api`   | POST JSON → parse into a struct → echo it back as JSON |
 | `strings`         | string ops (`split`/`join`/`substr`/`index`/`replace`/…) + request-line parsing |
 | `bytes`           | `bytes` type: construct, `to_hex`/`from_hex`, `byte_at`, `bytes_sub`, `bytes_concat`, `bytes_str`; NUL-safe vs string |

--- a/examples/complex/json_get.mfl
+++ b/examples/complex/json_get.mfl
@@ -1,0 +1,18 @@
+type Todo struct{id int title string done bool}
+
+func main(){
+    s := json(Todo{id:1,title:"ship it",done:false})
+    println("source:", s)
+
+    title, err := json_get(s, ".title")
+    println("title:", title, "err:", err)
+
+    missing, err2 := json_get(s, ".nope")
+    println("missing:", missing, "err:", err2)
+
+    bad, err3 := json_get(s, "not a path")
+    println("bad path:", bad, "err:", err3)
+
+    broken, err4 := json_get("{\"a\":}", ".a")
+    println("broken value:", broken, "err:", err4)
+}

--- a/examples/complex/json_get.mfl
+++ b/examples/complex/json_get.mfl
@@ -1,18 +1,18 @@
 type Todo struct{id int title string done bool}
 
 func main(){
-    s := json(Todo{id:1,title:"ship it",done:false})
-    println("source:", s)
+    s:=json(Todo{id:1,title:"ship it",done:false})
+    println("source:",s)
 
-    title, err := json_get(s, ".title")
-    println("title:", title, "err:", err)
+    title,err:=json_get(s,".title")
+    println("title:",title,"err:",err)
 
-    missing, err2 := json_get(s, ".nope")
-    println("missing:", missing, "err:", err2)
+    missing,err2:=json_get(s,".nope")
+    println("missing:",missing,"err:",err2)
 
-    bad, err3 := json_get(s, "not a path")
-    println("bad path:", bad, "err:", err3)
+    bad,err3:=json_get(s,"not a path")
+    println("bad path:",bad,"err:",err3)
 
-    broken, err4 := json_get("{\"a\":}", ".a")
-    println("broken value:", broken, "err:", err4)
+    broken,err4:=json_get("{\"a\":}",".a")
+    println("broken value:",broken,"err:",err4)
 }


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #156: "docs: json_get builtin (jq-style JSON path) is undocumented in docs/LANGUAGE.md and has no runnable example")

ISSUE DESCRIPTION:
## Problem

`json_get(json, path)` is a real, shipped builtin (added in the v0.13.0 era per `CHANGELOG.md`). It is documented in:

- `README.md` line 48 — listed under **Capabilities → I/O & data**: `json`/`parse`/`json_get` (jq-style path)
- `SPEC.md` line 248 — builtins table: `json_get | (string, string) -> (string, string) | value at a jq-style path → (value, err)…`
- the `machin guide` catalog (`guide.go`)

But it is **missing from `docs/LANGUAGE.md`** entirely:

- The **Builtins** table (LANGUAGE.md lines ~311–339) lists `json(x)` and `parse(s, T{})` but not `json_get`.
- The **JSON** subsection (lines ~353–387) walks through `json()` and `parse()` in detail but never mentions `json_get`.

There is also **no runnable example** demonstrating it. `json()` and `parse()` each have dedicated examples (`examples/complex/json.mfl`, `examples/complex/json_parse.mfl`), but a grep of `examples/` shows no `.mfl`/`.src` file uses `json_get` — so an agent reading LANGUAGE.md/examples has no way to learn it exists, despite the README promoting it.

> Note: this is **not** covered by #148 (which is about omitted builtin *categories*: file I/O, HTTP/TLS, time, process, WebSocket) — `json_get` is a JSON builtin sitting next to the `json`/`parse` that *are* documented.

## Why it matters

`json_get` is the idiomatic way to dig into JSON without fragile substring search (the CHANGELOG says "every machin tool used to dig into JSON with fragile substring search" before it). Leaving the canonical reference (and every example) silent on it pushes agents back to the brittle pattern it was added to replace.

## Where

- `docs/LANGUAGE.md` — Builtins table (~line 311) and the JSON subsection (~line 353).
- `examples/complex/` — no example exercises `json_get`.

## Suggested fix

1. Add `json_get` to the LANGUAGE.md Builtins table and document it in the JSON subsection, including the multi-assign `(value, err)` contract and the `err` values (`""`/`"notfound"`/`"path"`/`"parse"`) already specified in SPEC.md line 248.
2. Add a small runnable example (e.g. `examples/complex/json_get.mfl`) and list it in `examples/README.md`, mirroring how `json`/`parse` are demonstrated.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#156): <brief description>
5. The PR body MUST include 'Fixes #156' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thn9w4`

## Summary

Documented the json_get builtin in docs/LANGUAGE.md (Builtins table + new JSON subsection paragraph covering the (value, err) multi-assign contract and all four err values), and added a runnable example examples/complex/json_get.mfl exercising success, notfound, path, and parse error cases, listed in examples/README.md. Fixes #156.

**Diff:**
```
docs/LANGUAGE.md              | 19 +++++++++++++++++++
 examples/README.md            |  1 +
 examples/complex/json_get.mfl | 18 ++++++++++++++++++
 3 files changed, 38 insertions(+)
```
