### PR TITLE
fix(#157): document the CC env var that overrides the C compiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ Notes:
 - machin is **pure Go** (no cgo), so binaries are static (~2 MB) and
   cross-compile cleanly. The shipped binary is a **compiler frontend** — it
   emits C and invokes `cc`/`gcc`/`clang` at build time, so end users still need
-  a C compiler on PATH. Say so in release notes.
+  a C compiler on PATH. The compiler frontend defaults to `cc`; set `CC` to
+  override it, e.g. `CC=clang machin build app.mfl -o app`. Say so in release notes.
 - Versioning: minor bump (`v0.X.0`) for new language/library features, patch
   (`v0.X.Y`) for fixes and tooling/CI.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ machin guide                             # learn the language (version-exact cat
 ```
 
 Installs the latest release binary to `~/.local/bin` (override with `MACHIN_INSTALL`).
-machin compiles MFL through C, so building programs needs a **C compiler** (`cc`); the
+machin compiles MFL through C, so building programs needs a **C compiler** (`cc`
+by default — set `CC` to override it, e.g. `CC=clang machin build app.mfl -o app`); the
 `--target wasm` web target additionally needs [`zig`](https://ziglang.org). Building
 web apps? See the [`machin-web` skill](skills/machin-web/SKILL.md).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -484,7 +484,9 @@ id(42); id("hi"); id(3.14)   // → three native functions
   additionally emit a TLS runtime (HTTPS and/or RFC 6455 WebSocket framing over a
   shared TLS core) and link OpenSSL (`-lssl -lcrypto`) — but only when used, so
   programs that touch neither stay libc-only.
-- **Targets.** The default target is a native binary via `cc -O2`. `machin build
+- **Targets.** The default target is a native binary via `cc -O2` (the C compiler
+  defaults to `cc`; set `CC` to override it, e.g. `CC=clang machin build app.mfl
+  -o app`). `machin build
   --target wasm` instead emits a WebAssembly module (`wasm32-wasi`, reactor model)
   via `zig cc` — zig bundles clang + a wasi-libc, so it is a single-binary C→wasm
   toolchain (override with `ZIG=`). For the wasm target: each `export func`


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #157: "docs: the `CC` env var (override the C compiler) is undocumented")

ISSUE DESCRIPTION:
## Problem

machin's build step shells out to a C compiler, and the binary it uses is overridable via the **`CC` environment variable** — but this is documented nowhere.

\`\`\`go
// build.go:11-16
func ccPath() string {
	if cc := os.Getenv("CC"); cc != "" {
		return cc
	}
	return "cc"
}
\`\`\`

So `CC=clang machin build app.mfl -o app` (or `CC=gcc-13 …`) works, yet a user reading the docs has no way to know it. The docs only ever say "needs a C compiler on PATH" and hard-reference `cc`:

- `README.md:33` — "`make build  # → bin/machin (needs Go 1.22 + a C compiler)`"
- `AGENTS.md:137-138` — "emits C and invokes `cc`/`gcc`/`clang` at build time, so end users still need a C compiler on PATH"
- `SPEC.md:29`, `docs/LANGUAGE.md:6` — "`cc -O2`"
- `Makefile:31` — "requires a C compiler on PATH at runtime"

None mention that `cc` is just the default and that `CC` overrides it.

## Why it matters

- The compiler frontend defaults to `cc`. On systems where `cc` is absent or points at an unwanted toolchain (only `clang`/`gcc-N` installed, cross-compile setups, CI images), the only fix is the `CC` override — and a user can't discover it without reading `build.go`.
- This is exactly the "undocumented env var" gap docs should close. `CC` is also the conventional knob the release notes already nod to ("end users still need a C compiler on PATH") without telling people how to point at a specific one.

## Suggested fix

Document `CC` where build/install is described — e.g. a line in `README.md`'s `## Use` block and in `AGENTS.md` near the C-compiler note (and/or `SPEC.md` §13 Compilation model):

> The C compiler defaults to `cc`; set `CC` to override it, e.g. `CC=clang machin build app.mfl -o app`.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#157): <brief description>
5. The PR body MUST include 'Fixes #157' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thna64`

## Summary

Documents the `CC` environment variable, which overrides machin's default C compiler (`cc`) at build time. Previously this override existed only in `build.go` code with no mention in user-facing docs. Added a one-line note (with a `CC=clang machin build app.mfl -o app` example) to README.md's Install section, AGENTS.md's release-notes guidance, and SPEC.md's Compilation model/Targets section.

**Diff:**
```
AGENTS.md | 3 ++-
 README.md | 3 ++-
 SPEC.md   | 4 +++-
 3 files changed, 7 insertions(+), 3 deletions(-)
```
