### PR TITLE
fix(#158): add missing gui/ section to examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -84,3 +84,13 @@ curl -i http://localhost:48080/
 | program | shows |
 |---------|-------|
 | `fib`   | `fib(40)` — native MFL runs neck-and-neck with hand-written C |
+
+## gui/
+
+| program | shows |
+|---------|-------|
+| `game_menu` | native raylib desktop GUI (clickable Start/Settings/Exit menu) driven through machin's C FFI |
+
+Unlike the rest of the catalog, this is **not** a no-dependency binary — it links
+raylib + `libGL`/`libX11` and needs a display. See
+[`examples/gui/README.md`](gui/README.md) for build/run instructions.


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #158: "docs: examples/README.md has no `gui/` section — the raylib FFI desktop example is absent from the catalog")

ISSUE DESCRIPTION:
## Problem

`examples/README.md` catalogs the example programs by directory — but it only documents three of the four:

- `## basic/`
- `## complex/`
- `## bench/`

There is **no `## gui/` section**, even though `examples/gui/` exists and contains a fully documented, showcased program:

- `examples/gui/game_menu.mfl` — a native raylib desktop GUI (clickable Start/Settings/Exit menu) driven through machin's C FFI
- `examples/gui/README.md` — build/run instructions, an ASCII mock-up, and an FFI mapping table

The top-level `README.md` Capabilities section even advertises this as a headline feature ("C FFI … drove a real raylib **GUI**"), and `examples/run.sh` special-cases `examples/gui/*` (skips it, pointing at `examples/gui/README.md`). Yet a reader of the examples catalog never learns the directory exists or that `examples/gui/README.md` is where the GUI story lives.

## Why it matters

- The examples README is the catalog/index for `examples/`; silently omitting a whole directory makes the most visually compelling demo (and the only FFI-GUI example) undiscoverable from the catalog.
- The build steps for the GUI example are non-standard (it is **not** a no-dependency binary — needs raylib + a display), so it specifically needs a pointer to `examples/gui/README.md` rather than the generic `machin run …` instructions at the top of the file.

## Note (not a duplicate)

This is distinct from #95, which is about the **console** `input()` menu (`examples/complex/game_menu.mfl`) and `docs/LANGUAGE.md`. This issue is about the separate `examples/gui/game_menu.mfl` (raylib desktop) and the missing `gui/` section in `examples/README.md`. It is also distinct from #154 (the `complex/` table omitting the FFI/arena/counter examples).

## Suggested fix

Add a `## gui/` section to `examples/README.md` listing `game_menu` and linking to `examples/gui/README.md`, with a one-line caveat that it needs raylib + a display (so it isn't a self-contained binary like the other examples).

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#158): <brief description>
5. The PR body MUST include 'Fixes #158' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnacs`

## Summary

Added a `## gui/` section to examples/README.md documenting `game_menu.mfl`, the raylib FFI desktop demo that was previously absent from the catalog. Includes a caveat that it needs raylib + a display and a link to examples/gui/README.md for build/run instructions. Fixes #158.

**Diff:**
```
examples/README.md | 10 ++++++++++
 1 file changed, 10 insertions(+)
```
