### PR TITLE
fix(#159): add extern/FFI keywords to machin guide catalog

### DIFF
--- a/guide.go
+++ b/guide.go
@@ -136,6 +136,9 @@ func machinGuide() guideCatalog {
 			"func", "return", "if", "else", "while", "for", "range", "break", "continue",
 			"select", "go", "chan", "make", "map", "struct", "type", "var", "arena",
 			"extern", "export", "true", "false", "nil",
+			// extern-block-only: `fn` declares a foreign function (distinct from `func`),
+			// `cstruct` declares a C struct layout, and header/link/cflags are directives.
+			"fn", "cstruct", "header", "link", "cflags",
 		},
 		Commands: []guideCommand{
 			{"run", "machin run <file.mfl> [--safe]", "compile to native and execute in one step"},

--- a/guide_test.go
+++ b/guide_test.go
@@ -121,6 +121,31 @@ func TestGuideIdiomsCompile(t *testing.T) {
 	}
 }
 
+// No phantoms, no silent omissions: every real lexer keyword and every
+// extern-block directive (fn/cstruct/header/link/cflags — see
+// isExternDirective in parser.go) must appear in the catalog's Keywords list,
+// the same way TestGuideBuiltinsRecognized keeps Builtins honest. This is the
+// guard that would have caught `fn`/`cstruct` missing from the FFI surface.
+func TestGuideKeywordsRecognized(t *testing.T) {
+	catalog := map[string]bool{}
+	for _, k := range machinGuide().Keywords {
+		catalog[k] = true
+	}
+	for k := range keywords {
+		if !catalog[k] {
+			t.Errorf("lexer keyword %q missing from guide Keywords catalog", k)
+		}
+	}
+	for _, d := range []string{"header", "link", "cflags", "fn", "cstruct"} {
+		if !isExternDirective(d) {
+			t.Fatalf("test bug: %q is no longer an extern directive", d)
+		}
+		if !catalog[d] {
+			t.Errorf("extern directive %q missing from guide Keywords catalog", d)
+		}
+	}
+}
+
 // argCount derives the arity from a signature like "(string, int) -> int".
 func argCount(sig string) int {
 	open := strings.Index(sig, "(")


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #159: "docs: `machin guide` keyword catalog omits the extern/FFI keywords (`fn`, `cstruct`) required to write an extern block")

ISSUE DESCRIPTION:
## Problem

`machin guide` is positioned as the canonical, version-exact, *can't-drift* reference — `README.md` and `AGENTS.md` both tell agents to run it to "master the language in one call," and it advertises a complete keyword list. But its keyword catalog is **incomplete for the FFI/`extern` surface**.

The `Keywords` array in `guide.go:55-59` is:

```go
Keywords: []string{
    "func", "return", "if", "else", "while", "for", "range", "break", "continue",
    "select", "go", "chan", "make", "map", "struct", "type", "var", "arena",
    "extern", "true", "false", "nil",
},
```

It includes `extern` but omits the keywords you actually need *inside* an extern block:

- **`fn`** — introduces a foreign function declaration (`fn sqrt(float) float`). It is a real parser keyword: see `parser.go:124` (`isExternDirective`) and `parser.go:193` (`case "fn":`). It is distinct from `func` (regular functions use `func`; foreign functions use `fn`).
- **`cstruct`** — declares a C struct layout inside an extern block (`parser.go:124`).
- the extern directives **`header`**, **`link`**, **`cflags`** (also `parser.go:124`).

## Why it matters

An agent that reads `machin guide` to write an `extern` block sees `extern` listed as a keyword but never learns that the block body uses `fn`/`cstruct`/`header`/`link`/`cflags`. The single `ffi-extern` idiom (`guide.go:165`) shows them by example, but the **keyword list presents itself as the complete keyword surface** and silently omits them — exactly the kind of drift the guide is meant to prevent. `fn` vs `func` is a real footgun (writing `func sqrt(...)` inside an extern block is wrong).

## Where

- `guide.go:55-59` — the incomplete `Keywords` array.
- `parser.go:124,193` — proof that `fn`/`cstruct`/`header`/`link`/`cflags` are recognized keywords/directives.

## Suggested fix

1. Add `fn`, `cstruct` (and ideally `header`, `link`, `cflags`) to the `Keywords` catalog in `guide.go` — or split out an `ExternKeywords`/FFI sub-section so the FFI grammar is self-described.
2. Add a **keyword-completeness test** mirroring the existing `TestGuideBuiltinsRecognized` (`guide_test.go:56`): assert every parser keyword/directive is present in the catalog. The builtin list is guarded this way and stays correct; the keyword list has no such guard, which is why `fn`/`cstruct` slipped.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#159): <brief description>
5. The PR body MUST include 'Fixes #159' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnajg`

## Summary

Fixed #159: `machin guide`'s Keywords catalog listed `extern` but silently omitted the keywords actually needed inside an extern block (`fn`, `cstruct`, and directives `header`/`link`/`cflags`), a real footgun since `fn` (foreign function) is distinct from `func`. Added those to guide.go's Keywords array and added TestGuideKeywordsRecognized in guide_test.go, a completeness guard (mirroring TestGuideBuiltinsRecognized) asserting every lexer keyword and extern directive is present in the catalog so this can't silently drift again.

**Diff:**
```
guide.go      |  3 +++
 guide_test.go | 25 +++++++++++++++++++++++++
 2 files changed, 28 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the language guide’s keyword list to include additional foreign interface and directive keywords.
* **Tests**
  * Added validation to ensure the guide stays in sync with recognized keywords and external directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->