### PR TITLE
fix(#161): describe MFL source as plain canonical text in changelog pages, not base64

### DIFF
--- a/docs/changelog-2026-06-product.md
+++ b/docs/changelog-2026-06-product.md
@@ -6,7 +6,7 @@
             </div>
             <div>
               <h3 class="text-xl font-semibold text-white mb-2">A new machine-first language</h3>
-              <p class="text-slate-400 leading-relaxed">MFL was born: a backend language whose source is base64 — one function per line — designed to be written and read by machines, not humans. The whole toolchain (lexer, parser, type inference, code generator) ships in Go.</p>
+              <p class="text-slate-400 leading-relaxed">MFL was born: a backend language whose source is plain canonical text — one normalized declaration per line — designed to be written and read by machines, not humans. The whole toolchain (lexer, parser, type inference, code generator) ships in Go.</p>
             </div>
           </div>
         </div>

--- a/docs/changelog-2026-06.html
+++ b/docs/changelog-2026-06.html
@@ -46,7 +46,7 @@
             </div>
             <div>
               <h3 class="text-xl font-semibold text-white mb-2">A new machine-first language</h3>
-              <p class="text-slate-400 leading-relaxed">MFL was born: a backend language whose source is base64 — one function per line — designed to be written and read by machines, not humans. The whole toolchain (lexer, parser, type inference, code generator) ships in Go.</p>
+              <p class="text-slate-400 leading-relaxed">MFL was born: a backend language whose source is plain canonical text — one normalized declaration per line — designed to be written and read by machines, not humans. The whole toolchain (lexer, parser, type inference, code generator) ships in Go.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #161: "docs: the public changelog pages still describe MFL's source as base64 (the abandoned design)")

ISSUE DESCRIPTION:
## Problem

Both monthly changelog pages — which are public docs linked from `docs/changelog.html` → `docs/index.html` — still describe MFL's source form as **base64**, the design the project explicitly abandoned for plain canonical text:

- `docs/changelog-2026-06.html:49`
- `docs/changelog-2026-06-product.md:9`

> "MFL was born: a backend language whose **source is base64** — one function per line — designed to be written and read by machines, not humans."

## Why it matters

The plain-text pivot is the project's central, hard-won narrative: the README ("Why not base64 (the old design)?"), `AGENTS.md` ("This replaced a base64-as-source design"), and `SPEC.md` all now describe `.mfl` as plain canonical text, with base64 surviving only as the `machin pack` distribution form. A reader who lands on the changelog from the docs index is told the opposite — that the language's source *is* base64 — directly contradicting the canonical docs. The same misleading "feature card" is duplicated verbatim in both files.

This is distinct from the existing base64-wording issues, which target other files:
- #98 — `examples/README.md` base64 wording
- #99 — `SPEC.md` §14 base64-era grammar wording

…and from #83 (these pages stop at v0.3.0 / omit later releases). Neither covers the base64-as-source claim on the changelog pages.

## Suggested fix

Reword the "A new machine-first language" card in both files so it reflects the plain-text source model (or, if the card is meant as historical narrative of v0.1.0, add a follow-up card noting the later pivot to plain canonical text so the page doesn't leave base64 as the reader's final impression). Keep both files in sync since the card is duplicated.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#161): <brief description>
5. The PR body MUST include 'Fixes #161' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnatg`

## Summary

Fixed #161: both monthly changelog pages (docs/changelog-2026-06.html and docs/changelog-2026-06-product.md) claimed MFL's source form is base64, contradicting the plain-text pivot documented in README.md/AGENTS.md/SPEC.md. Reworded the duplicated "A new machine-first language" feature card in both files to say the source is plain canonical text (one normalized declaration per line), matching the canonical phrasing used elsewhere; base64 now only survives as the `machin pack` distribution form.

**Diff:**
```
docs/changelog-2026-06-product.md | 2 +-
 docs/changelog-2026-06.html       | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```
