### PR TITLE
fix(#162): add landing page, changelog, and selfhost version to release checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,12 @@ GitHub release. **To cut a release:**
 1. Update the version: bump the badge in `README.md`, the `Version` line in
    `SPEC.md`, **`machinVersion` in `guide.go`** (a test enforces it matches the
    README badge), and add a section to the top of `CHANGELOG.md` (newest first).
-   Commit to `main`.
+   Also bump the other version-stamped, user-facing surfaces, which have **no
+   automated guard** (the `guide.go` test only checks the README↔guide pair) and
+   must be updated by hand: the landing-page badge in `docs/index.html`, the
+   `version:` field in `selfhost/server.mfl`, and the monthly changelog pages
+   (`docs/changelog-YYYY-MM.html` / `docs/changelog-YYYY-MM-product.md` — add
+   the new release to the latest month's page). Commit to `main`.
    ```
    release: vX.Y.Z (one-line summary)
    ```


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #162: "docs: AGENTS.md \"Releasing\" checklist omits the landing page, monthly changelog, and selfhost server version — the root cause of their version drift")

ISSUE DESCRIPTION:
## Problem

The release checklist in `AGENTS.md` (`AGENTS.md:107`, "## Releasing", step 1) enumerates exactly which files to bump on a release:

> "Update the version: bump the badge in `README.md`, the `Version` line in `SPEC.md`, **`machinVersion` in `guide.go`** … and add a section to the top of `CHANGELOG.md`."

It lists **only** those four. It does **not** mention the other version-stamped, user-facing files in the repo:

- `docs/index.html:55` — landing-page badge, still `v0.7.0`
- `docs/changelog-2026-06.html` / `docs/changelog-2026-06-product.md` — the public "June 2026" changelog, still stops at `v0.3.0`
- `selfhost/server.mfl:5` — the dogfood info server reports `version:"0.2.1"`

Current toolchain version is **0.21.0**. Because these files aren't on the checklist, they get skipped on every release and have drifted 14–18 minor versions behind.

## Why it matters

This checklist gap is the **root cause** of the recurring per-file staleness already filed as separate symptoms:

- #80 — landing page stale
- #83 — monthly changelog pages stop at v0.3.0
- #75 — selfhost server reports stale version 0.2.1

Fixing those files individually won't stop them re-drifting on the next release; the process doc has to name them. This is the release-drift analogue of #155 (which addresses the *feature-addition* checklist omitting `docs/LANGUAGE.md`).

## Suggested fix

Extend `AGENTS.md` "## Releasing" step 1 to list every version-stamped surface so a release updates them together: add `docs/index.html` (badge), the `docs/changelog-2026-06*.{html,md}` monthly pages (add the new release section), and `selfhost/server.mfl` (the `version:` field). Consider noting that `guide.go`'s version test only guards the README↔guide pair, so these other files have no automated guard and must be bumped by hand.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#162): <brief description>
5. The PR body MUST include 'Fixes #162' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnb04`

## Summary

Extended AGENTS.md's "## Releasing" checklist (step 1) to name docs/index.html (landing badge), selfhost/server.mfl (version field), and the monthly docs/changelog-YYYY-MM*.{html,md} pages alongside the existing README/SPEC/guide.go/CHANGELOG entries, since these were being skipped on every release and drifted 14-18 minor versions behind (root cause of #80, #83, #75). Also noted that unlike the README<->guide.go pair, these files have no automated version-sync test and must be bumped by hand.

**Diff:**
```
AGENTS.md | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```
