### PR TITLE
fix(#95): document input() builtin in LANGUAGE.md Builtins table

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -318,6 +318,7 @@ first := users[0]                                // value copy
 |-----------------------------|----------------------------------------------|
 | `print(...)`                | print arguments without a trailing newline   |
 | `println(...)`              | print arguments followed by a newline        |
+| `input()`                   | read one line from stdin; newline stripped, `""` at EOF |
 | `len(x)`                    | length of a slice or string                  |
 | `append(xs, v)`             | return `xs` with `v` appended                |
 | `has(m, k)`                 | whether map `m` contains key `k`             |


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #95: "docs: input() builtin and game_menu example (added in #93) are missing from docs/LANGUAGE.md and examples/README.md")

ISSUE DESCRIPTION:
## Problem

The `input()` builtin and its showcase example `examples/complex/game_menu.mfl` were added in #93 (commit 4dcacc0, current `main` HEAD), but the change was only threaded into **SPEC.md** and the top-level **README.md**. Two other reference docs were left stale:

### 1. `docs/LANGUAGE.md` — Builtins table omits `input`

`docs/LANGUAGE.md` is titled "MFL Language Reference" and is linked from README as the language reference. Its Builtins table (starting at `docs/LANGUAGE.md:302`) lists `print`, `println`, `len`, `append`, … `read`/`write`/`close`, but **not `input`**. So the language reference does not document a builtin that:
- is implemented (`codegen.go:1474`, `mfl_input` at `codegen.go:375`; type rule at `types.go:1530`),
- is tested (`operators_net_test.go:121`, `TestInputBuiltin`),
- and is already in `SPEC.md:200` and the README feature table.

### 2. `examples/README.md` — catalog omits `game_menu`

`examples/complex/game_menu.mfl` exists and is listed in the README.md examples table ("native desktop CLI: a Start/Settings/Exit loop reading `input()`"), but the `complex/` table in `examples/README.md` does not list it. (README.md's table conversely omits `sieve`/`structs`, which #72 already tracks — this issue is specifically about `game_menu`/`input`, which #72 predates and does not mention.)

## Why it matters

`input()` is the newest user-facing builtin and the only way to read stdin (interactive CLI / desktop programs). A reader consulting the "language reference" or the examples catalog can't discover it. AGENTS.md's own feature checklist requires a doc note when a feature is user-facing; LANGUAGE.md and examples/README.md were missed.

## Suggested fix

- Add a row to the Builtins table in `docs/LANGUAGE.md`, e.g.:
  `| `input()` | read one line from stdin; newline stripped, `""` at EOF |`
- Add a `game_menu` row to the `complex/` table in `examples/README.md`, e.g.:
  `| `game_menu` | interactive CLI loop (`input()`): Start / Settings / Exit, EOF-aware |`

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#95): <brief description>
5. The PR body MUST include 'Fixes #95' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thncas`

## Summary

Adds the missing `input()` row to docs/LANGUAGE.md's Builtins table, matching the wording already used in SPEC.md. The `examples/README.md` half of the issue (the `game_menu` row in the complex/ table) was already present from an earlier fix, so this single-line doc addition closes out issue #95 (input() builtin added in #93 was undocumented in the language reference). Fixes #95.

**Diff:**
```
docs/LANGUAGE.md | 1 +
 1 file changed, 1 insertion(+)
```
