### PR TITLE
fix(#98): describe .mfl as canonical plain text in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,11 @@
 # MFL examples
 
-Every program here is a **`.mfl`** file: the actual MFL language — **base64, one
-function per line, blank line between functions**. There is no human-readable
-source file; the `.mfl` *is* the source. That's the machine-first point: the
-human states intent, the machine reads and writes the code. Each program is
-compiled to native code (through C) and executed.
+Every program here is a **`.mfl`** file — canonical plain text, one normalized
+function per line. The `.mfl` *is* the source: greppable, diffable,
+machine-authored. That's the machine-first point: the human states intent, the
+machine reads and writes the code. A dense base64 form is available for
+distribution via `machin pack`. Each program is compiled to native code
+(through C) and executed.
 
 ```sh
 machin run examples/complex/primes.mfl          # compile to native + run


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #98: "docs: examples/README.md still calls .mfl \"base64 ... no human-readable source\" — contradicts the #97 plain-text pivot")

ISSUE DESCRIPTION:
## Problem

The opening of `examples/README.md` (lines 3–6) still describes the language as base64-encoded with no readable source:

> Every program here is a **`.mfl`** file: the actual MFL language — **base64, one function per line, blank line between functions**. There is no human-readable source file; the `.mfl` *is* the source.

This is now factually wrong. PR #97 (`pivot: plain canonical text is the source of truth`) made the `.mfl` form **canonical plain text** — one normalized function per line — precisely so it is greppable, diffable, and editable in place. base64 is now only the optional distribution form produced on demand by `machin pack`.

The pivot updated README.md, SPEC.md, AGENTS.md, docs/LANGUAGE.md, docs/index.html, every committed `.mfl`, and even `examples/run.sh` (whose header now reads "The .mfl files are the source of truth — canonical plain text"). But `examples/README.md` was not touched and now directly contradicts all of them — and undercuts the project's headline message.

## Where

- `examples/README.md` lines 3–6 (the intro paragraph).

## Why it matters

This is the first file a newcomer opens to understand the examples. Telling them the source is base64 with "no human-readable source file" is the opposite of the current reality and the opposite of the project's stated machine-first-by-shape (not by encoding) position.

## Suggested fix

Rewrite the intro to match the post-pivot framing used elsewhere, e.g.: "Every program here is a `.mfl` file — canonical plain text, one normalized function per line. The `.mfl` *is* the source: greppable, diffable, machine-authored. A dense base64 form is available for distribution via `machin pack`." Mirror the wording already in `examples/run.sh`, README.md, and docs/LANGUAGE.md.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#98): <brief description>
5. The PR body MUST include 'Fixes #98' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thncks`

## Summary

Fixed the stale base64 description in examples/README.md's intro paragraph, which contradicted the #97 plain-text pivot completed across the rest of the docs. The intro now describes .mfl as canonical plain text (greppable, diffable, machine-authored) with base64 noted only as an optional distribution form via 'machin pack', matching the wording already used in README.md, SPEC.md, AGENTS.md, docs/LANGUAGE.md, and examples/run.sh.

**Diff:**
```
examples/README.md | 11 ++++++-----
 1 file changed, 6 insertions(+), 5 deletions(-)
```
