### PR TITLE
fix(#99): drop stale "decoded form" wording from SPEC.md §14 title

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -501,7 +501,7 @@ id(42); id("hi"); id(3.14)   // → three native functions
 
 ---
 
-## 14. Grammar (decoded form, informal)
+## 14. Grammar (informal)
 
 ```
 Program     = { Decl } .


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #99: "docs: SPEC.md §14 titled \"Grammar (decoded form)\" is stale base64-era wording, and §2's \"(§14)\" pack cross-reference points to the wrong section")

ISSUE DESCRIPTION:
## Problem

Two leftover base64-era artifacts in `SPEC.md` after the #97 plain-text pivot:

1. **§14 title** (line 350) reads `## 14. Grammar (decoded form, informal)`. The "decoded form" parenthetical dates from when the source was base64 and you *decoded* it to recover this grammar. Post-pivot the canonical `.mfl` **is** this plain text — it is not the "decoded form" of anything — so the qualifier is now misleading.

2. **§2 cross-reference** (lines 47–48):
   > A line that contains no whitespace is treated as a base64-**packed** declaration and decoded first, so `machin pack` output (§14) also loads.

   The `(§14)` points readers to the grammar section for the packed-form spec, but §14 is the grammar of the plain-text form and says nothing about base64 / packing. The packed form is described in §2 itself and mentioned in §1; there is no dedicated section, so the `(§14)` reference is dangling/misleading.

## Where

- `SPEC.md` line 350 (§14 heading)
- `SPEC.md` lines 47–48 (the `(§14)` cross-reference in §2)

## Why it matters

SPEC.md is billed as the full reference (linked from README). Stale "decoded form" terminology and a cross-reference to a section that doesn't cover what it claims confuse readers about whether the text or the base64 form is canonical — the exact point the #97 pivot set out to make unambiguous.

## Suggested fix

- Retitle §14 to `## 14. Grammar (informal)` (drop "decoded form"), or "Grammar of the canonical text form".
- Fix or drop the `(§14)` reference in §2 — either remove it (the rule is self-contained) or point to §1/the `machin pack` description, not the grammar.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#99): <brief description>
5. The PR body MUST include 'Fixes #99' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thncrg`

## Summary

Fixed stale base64-era wording in SPEC.md: retitled §14 from "Grammar (decoded form, informal)" to "Grammar (informal)" since the canonical .mfl source is now plain text, not something decoded from base64. The §2 "(§14)" cross-reference mentioned in the issue was already absent from the current SPEC.md text (likely cleaned up in a prior pass), so no change was needed there.

**Diff:**
```
SPEC.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
