### PR TITLE
fix(#104): clarify README's canonical-form snippet isn't a demo.mfl transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Every mainstream language was designed for **human** ergonomics — readable syn
 
 ## The form
 
-`.mfl` is plain canonical text: one normalized declaration per line, whitespace tightened. Greppable, diffable, no type annotations.
+`.mfl` is plain canonical text: one normalized declaration per line, whitespace tightened. Greppable, diffable, no type annotations. A minimal illustration (not a transcript of any specific file — see [`examples/demo.mfl`](examples/demo.mfl) for a fuller runnable program):
 
 ```
 func fib(n){if n<2{return n}return fib(n-1)+fib(n-2)}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #104: "docs: README's `cat examples/demo.mfl` snippet doesn't match the actual file (shows 2 funcs, file has 4)")

ISSUE DESCRIPTION:
## Problem

The README's first code block (the TL;DR / Quick-Start, `README.md:23-42`) tells the reader to `cat examples/demo.mfl` and shows the output as a two-function program:

```
# cat examples/demo.mfl
#   func fib(n){if n<2{return n}return fib(n-1)+fib(n-2)}
#
#   func main(){println(fib(10))}
```

But the actual file (`examples/demo.mfl`) contains **four** functions, and `main` is different:

```
func fib(n){if n<2{return n}return fib(n-1)+fib(n-2)}

func fact(n){acc:=1 i:=2 while i<=n{acc=acc*i i=i+1}return acc}

func fizzbuzz(n){i:=1 while i<=n{if i%15==0{println("FizzBuzz")}else if i%3==0{println("Fizz")}else if i%5==0{println("Buzz")}else{println(i)}i=i+1}}

func main(){println("fib(10) =",fib(10))println("fact(6) =",fact(6))println("greeting: "+"hello, machine")println("--- fizzbuzz 1..15 ---")fizzbuzz(15)}
```

So the very first thing a reader is told to run produces output that doesn't match what the README claims. The `main` shown (`println(fib(10))`) isn't even in the file.

## Where
- `README.md:23-42` (the inline `cat examples/demo.mfl` comment in the TL;DR code block)
- vs. `examples/demo.mfl`

## Why it matters
This is the first concrete example in the README — the canonical "here's what MFL looks like" snippet. An inaccurate `cat` output undermines the "plain text, greppable, just read it" pitch the same block is making.

## Suggested fix
Either (a) update the README comment to reflect the real `demo.mfl` contents (at least the real `fib` + the real `main`), or (b) point the snippet at a genuinely two-function file (or trim `demo.mfl`). Option (a) keeps the demo rich; just make the shown `cat` output match the file.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#104): <brief description>
5. The PR body MUST include 'Fixes #104' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thncy3`

## Summary

Issue #104's literal bug (a "cat examples/demo.mfl" comment showing fake 2-func output) was already removed by an earlier README restructuring (PR #114) that landed hours after the issue was filed. The only remaining lookalike is the README's "## The form" illustrative fib/main snippet, which doesn't claim file provenance but could still confuse a reader. Added a one-line clarification that it's a minimal illustration, not demo.mfl's actual content, with a link to the real file.

**Diff:**
```
README.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
