### PR TITLE
fix(#105): link tokmin.py and reliability harness from README/AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,10 @@ The full language reference is [`SPEC.md`](SPEC.md).
 - **Machine-first / minimalism.** Prefer the smallest change that holds the
   surface minimal. The north star is *low agent write/edit cost* (output tokens)
   — measure form/syntax changes with `tools/tokcost.py` and `tools/tokmin.py`,
-  don't guess. (Lesson already paid for: tokens are saved by removing what the
+  don't guess. Before claiming a syntax change is reliability-neutral, run it
+  through `tools/reliability/` too — tokens saved mean nothing if the change
+  makes a model write the code wrong more often; real cost is tokens × tries.
+  (Lesson already paid for: tokens are saved by removing what the
   tokenizer *charges* for — whitespace, ~13% — not by shortening keywords it
   already packs into one token; `func`→`fn` saves 0, `println`→`pln` is worse.)
   The canonical `.mfl` form is whitespace-tightened; keep emitted/committed code

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ millisecond on ~0.1 MB of RAM.
 
 Every mainstream language was designed for **human** ergonomics — readable syntax, explicit types, multi-line formatting. For an AI agent, every output token costs, and that human-friendly ceremony taxes the writer without adding meaning. machin measured this: [`tools/tokcost.py`](tools/tokcost.py) showed base64 source costs ~2.5× the tokens to output; whitespace alone costs ~13%. The canonical one-line-per-declaration form, with every type inferred, is the end of that measurement — the smallest token surface that still produces C/Rust-class native code with zero runtime overhead.
 
+### Measurement
+
+The form should be *measured, not asserted*. [`tools/README.md`](tools/README.md) is the entry point to the instruments behind that: [`tools/tokcost.py`](tools/tokcost.py) (write/edit token cost of a source form), [`tools/tokmin.py`](tools/tokmin.py) (where MFL spends tokens and what a minimization would save), and [`tools/reliability/`](tools/reliability) — the other half of the metric, since real cost is *tokens × tries*: it measures whether a syntax change makes a model write the code wrong more often, not just whether it's shorter.
+
 > **Agents: run `machin guide`** for the complete, version-exact feature surface — every keyword, every builtin with its signature, the core idioms, and the gotchas, as JSON (`--text` for prose). Emitted from the compiler's own catalog; can't drift from the implementation. Depth lives in [`SPEC.md`](SPEC.md) and [`AGENTS.md`](AGENTS.md).
 
 ## The form


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #105: "docs: the tooling behind the \"measured, not asserted\" thesis (tokmin.py, tools/reliability/) is undiscoverable from any top-level doc")

ISSUE DESCRIPTION:
## Problem

machin's central, repeated claim is that it optimizes agent write/edit cost and **measures** it rather than asserting it (`README.md:55`: "The form should be measured, not asserted"; AGENTS.md's standing constraints lean on the same idea). The repo now has three instruments for this:

- `tools/tokcost.py` — write/edit token cost of a source form
- `tools/tokmin.py` — where MFL spends tokens + what minimizations save (added in #100)
- `tools/reliability/` — the **tokens × tries** half of the metric: a task bank + `score.py` that measures whether a syntax change makes a model write the code *wrong* more often (added in #101/#102, incl. the drop-`func` experiment)

But discoverability is broken:

- **`README.md`** references only `tokcost.py` (lines 55 and 61). It never mentions `tokmin.py` or the reliability harness, and links nothing to `tools/` / `tools/README.md`.
- **`AGENTS.md`** mentions `tokcost.py` and `tokmin.py` (lines 34, 39) but not `tools/reliability/`.
- **`SPEC.md`** and `docs/` reference none of them.

(Verified: `grep -rn "tools/reliability\|tools/README\|reliability harness\|tokmin" README.md SPEC.md docs/` returns nothing.)

So the work that actually backs the project's headline differentiator — especially the reliability harness, which validates that token savings don't cost correctness — is invisible to anyone reading the README, the spec, or the docs site. The harness even encodes a real finding (drop-`func` is de-risked: 0.0pt correctness delta) that no top-level doc surfaces.

## Why it matters
"We measure, not assert" is the project's whole pitch. A reader can't find the measurements. The newest tool (`tokmin.py`) and the entire `tools/reliability/` harness have no entry point from the main docs.

## Suggested fix
- In `README.md`, expand the "measured, not asserted" bullet (or add a short **Measurement** subsection) to link `tools/README.md`, `tools/tokcost.py`, `tools/tokmin.py`, and `tools/reliability/` — and mention the tokens × tries framing the reliability harness adds.
- In `AGENTS.md`, add a pointer to `tools/reliability/` alongside the existing `tokcost.py`/`tokmin.py` references (it's the instrument an agent should use before claiming a syntax change is reliability-neutral).

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#105): <brief description>
5. The PR body MUST include 'Fixes #105' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnd84`

## Summary

Fixes #105: the reliability harness and tokmin.py were invisible from README.md and AGENTS.md, even though they're the tooling behind machin's "measured, not asserted" claim. Added a Measurement subsection in README.md linking tools/README.md, tokcost.py, tokmin.py, and tools/reliability/ (with the tokens x tries framing), and added a pointer in AGENTS.md's standing constraints telling agents to run tools/reliability/ before claiming a syntax change is reliability-neutral.

**Diff:**
```
AGENTS.md | 5 ++++-
 README.md | 4 ++++
 2 files changed, 8 insertions(+), 1 deletion(-)
```
