### PR TITLE
docs(#86): add CONTRIBUTING.md authoring guide, link from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to machin
+
+The one thing that trips up new contributors: `.mfl` files aren't meant to be
+typed by hand. Here's the actual workflow for reading and editing one.
+
+## The `.mfl` format
+
+A `.mfl` file is the canonical MFL source: **plain text**, one normalized
+function (or type) per line, a blank line between declarations. It's already
+human-readable — open it in an editor like any other source file; that
+tightened one-liner *is* the source of truth. (`machin pack` can additionally
+emit a dense base64 "packed" form for distribution/wire transfer, and `machin
+run` accepts either form, but the form committed to this repo is always plain
+text.)
+
+Because each line is whitespace-tightened by the compiler, don't hand-edit a
+`.mfl` line directly — use the authoring loop below so the result stays
+canonical and typechecked.
+
+## Authoring loop
+
+1. Write your function(s) as loose, human-formatted Go-like text in a `.src`
+   file — whitespace, comments, multiple lines, whatever's comfortable.
+2. Run it through `encode`, which normalizes each function to one canonical
+   line and **typechecks the result before printing anything**:
+
+   ```bash
+   go run . encode app.src > app.mfl
+   ```
+
+   If `encode` fails, fix `app.src` — nothing is emitted on error, so a
+   `.mfl` file that exists in this repo is always known-good.
+3. Multiple `.src` files concatenate in order, so a framework module can be
+   composed ahead of an app:
+
+   ```bash
+   go run . encode framework/machweb.src app.src > app.mfl
+   ```
+4. Run or build the result:
+
+   ```bash
+   go run . run app.mfl
+   go run . build app.mfl -o app
+   ```
+
+## Adding a new example
+
+- Basic language features go in `examples/basic/`; larger/composite programs
+  go in `examples/complex/`.
+- Author it as a `.src` file, `encode` it into the matching `.mfl`, and commit
+  the `.mfl` (the `.src` is scratch and doesn't need to be committed).
+- `examples/run.sh` (and `make examples`) picks up every `*.mfl` under
+  `examples/` automatically — no registration step needed.
+- Name long-running programs so they match `*server*` or `*_api*` (e.g.
+  `http_server.mfl`, `json_api.mfl`) — `examples/run.sh` skips those instead
+  of hanging on a process that never exits.
+- If the example demonstrates a real language feature, add a row to
+  `examples/README.md` and a note in `docs/LANGUAGE.md`/`SPEC.md`.
+
+## Build and test
+
+```bash
+make build   # go build -o bin/machin .
+make test    # go test ./...
+```
+
+Tests must pass before a PR. `make examples` (or `./examples/run.sh`) is a
+good sanity check that nothing regressed at runtime.
+
+See [AGENTS.md](AGENTS.md) for the fuller dev workflow and standing
+constraints (in particular: the `.mfl` source of truth is canonical plain
+text, not base64).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A language **shaped for AI agents to write and edit cheaply**: zero type annotations, one canonical declaration per line, every design choice measured for token cost. Compiles through C to a single native binary — C/Rust-class speed, unboxed values, no runtime.
 
-[Spec](SPEC.md) · [Language tour](docs/LANGUAGE.md) · [Agent guide](AGENTS.md) · [Ecosystem → **awesome-machin**](https://github.com/javimosch/awesome-machin) · [Landing](https://javimosch.github.io/machin/) · [Releases](https://github.com/javimosch/machin/releases)
+[Spec](SPEC.md) · [Language tour](docs/LANGUAGE.md) · [Agent guide](AGENTS.md) · [Contributing](CONTRIBUTING.md) · [Ecosystem → **awesome-machin**](https://github.com/javimosch/awesome-machin) · [Landing](https://javimosch.github.io/machin/) · [Releases](https://github.com/javimosch/machin/releases)
 
 > ### ▶ [Try machin in your browser → **play.intrane.fr**](https://play.intrane.fr)
 > Write MFL, hit Run — it compiles to WebAssembly and runs client-side. No install.


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #86: "docs: no CONTRIBUTING / authoring guide — contributors have no documented path to write or edit a base64 .mfl file")

ISSUE DESCRIPTION:
## Problem

MFL's defining premise is that a program **IS** base64 — one function per line, no human-readable source, and (per `main.go`) "no decode." A would-be contributor who clones the repo therefore has no obvious way to add an example or fix a program: opening any `.mfl` (e.g. `examples/complex/primes.mfl`) shows only base64 lines, and there is no `CONTRIBUTING.md`, issue template, or authoring guide explaining the workflow.

The mechanism actually exists in the toolchain but is scattered and under-documented:
- `machin encode <src>` lifts loose Go-like text into canonical base64 `.mfl` (`cmdEncode` in `main.go`; `splitFunctions`/`normalize`/`stripLineComment`).
- `framework/README.md` and `examples/README.md` mention `encode` in passing, but nothing ties it together as "this is how you author/modify a program in this repo."

## Where

- Repo root: no `CONTRIBUTING.md`.
- `.github/`: contains only `workflows/release.yml` — no issue/PR templates, no contributor docs.

## Why it matters

The whole point of the project is unusual enough that the normal "just edit the file" intuition fails. Without a documented round-trip (author Go-like `.src` → `machin encode` → base64 `.mfl`, and how to inspect an existing program), external contributions and even routine maintenance of the examples are needlessly hard. This is the kind of gap most likely to turn away contributors.

## Suggested fix

Add a `CONTRIBUTING.md` (linked from `README.md`) that documents:
- How to read/verify an existing `.mfl` (decode a line) and the "the `.mfl` is the source of truth" rule.
- The authoring loop: write Go-like text, run `machin encode app.src > app.mfl`, and that `encode` typechecks before emitting.
- How to add a new example (where it goes, that `examples/run.sh` will pick it up, and the `*server*`/`*_api*` skip convention).
- `make build` / `make test` and the expectation that tests pass before a PR.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#86): <brief description>
5. The PR body MUST include 'Fixes #86' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thndvg`

## Summary

Adds CONTRIBUTING.md documenting the actual authoring workflow for MFL programs: .mfl is canonical plain text (not base64 — that changed in an earlier release), the .src -> `machin encode` -> .mfl loop (encode typechecks before emitting), how to add a new example (examples/run.sh auto-discovery and the *server*/*_api* skip convention), and the make build/test expectations. Linked from README.md's top link bar. Fixes #86.

**Diff:**
```
CONTRIBUTING.md | 72 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 README.md       |  2 +-
 2 files changed, 73 insertions(+), 1 deletion(-)
```
