### PR TITLE
fix(#89): document logical operators (&&, ||, !) in LANGUAGE.md

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -213,9 +213,11 @@ for i, c := range s  { ... }                     // string index + character
 |-------------|------------------------------------|
 | Arithmetic  | `+`  `-`  `*`  `/`  `%`             |
 | Comparison  | `==`  `!=`  `<`  `<=`  `>`  `>=`    |
+| Logical     | `&&`  `\|\|`  `!` (short-circuit; `!` is unary) |
 | String      | `+` (concatenation)                |
 
-`%` is integer-only. `/` on `int` is integer division.
+`%` is integer-only. `/` on `int` is integer division. Comparisons and logical
+operators yield `bool`.
 
 ---
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #89: "docs: LANGUAGE.md Operators table omits the logical operators && || !")

ISSUE DESCRIPTION:
## Problem

The Operators section of `docs/LANGUAGE.md` lists only Arithmetic, Comparison, and String operators. It omits the **logical operators** `&&`, `||`, and `!` entirely:

```
## Operators

| Category    | Operators                          |
|-------------|------------------------------------|
| Arithmetic  | `+`  `-`  `*`  `/`  `%`             |
| Comparison  | `==`  `!=`  `<`  `<=`  `>`  `>=`    |
| String      | `+` (concatenation)                |
```

A grep of `docs/LANGUAGE.md` for `&&` / `||` finds no mention anywhere in the doc.

## Why it matters

`docs/LANGUAGE.md` is presented as the language tour / reference (linked from `README.md` and `SPEC.md`). The logical operators are core language features:

- `README.md` lists them under Operators: `&& || !`
- `SPEC.md` §6 documents them ("Comparisons yield `bool`; `&&`/`||` short-circuit") and unary `!`
- They are used in the shipped examples, e.g. `framework/example.src`: `req.method == "POST" && req.path == "/api/echo"`

A reader relying on LANGUAGE.md alone would conclude the language has no boolean AND/OR/NOT.

## Suggested fix

Add a Logical row to the Operators table and a note on short-circuit / unary `!`, e.g.:

```
| Logical     | `&&`  `||`  `!` (short-circuit; `!` is unary) |
```

and mention that comparisons/logical ops yield `bool`, matching SPEC §6.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#89): <brief description>
5. The PR body MUST include 'Fixes #89' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thne5g`

## Summary

Fixes #89: docs/LANGUAGE.md's Operators table omitted the logical operators (&&, ||, !) entirely, despite them being core language features documented in README.md and SPEC.md §6. Added a Logical row to the table and a short note that comparisons/logical ops yield bool. Minimal, additive-only 2-line diff scoped to just the Operators section, avoiding overlap with other in-flight PRs (#321, #328) that touch different sections of the same file.

**Diff:**
```
docs/LANGUAGE.md | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```
