### PR TITLE
fix(#90): clarify break/return is the only way out of an infinite for loop

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -218,7 +218,8 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 - `if cond { ... } else if cond { ... } else { ... }` — conditions are `bool`.
 - Loops:
   - `while cond { ... }`
-  - `for cond { ... }` and `for { ... }` (infinite)
+  - `for cond { ... }` and `for { ... }` (infinite) — exit an infinite loop
+    with `break` or `return`; there is no other way out
   - `for k, v := range x { ... }` over a slice (index, element), map (key,
     value), or string (index, 1-char). Either variable may be `_`.
   - `for v := range ch { ... }` over a channel: receives each value until the


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #90: "docs: language reference never documents that `break`/`continue` don't exist (no early loop exit)")

ISSUE DESCRIPTION:
## Problem

MFL is presented as "Go-flavored," and both the spec and the tour document the infinite loop form `for { ... }`:

- `SPEC.md` §7 Statements (lines ~183-186) lists `for cond { ... }` and `for { ... }` (infinite) as supported loops.
- `docs/LANGUAGE.md` §Control flow (lines ~172-194) documents `while`, `for cond`, and `for k, v := range`.

But the language has **no `break` and no `continue`** — they are not keywords (`lexer.go:27-32` keyword set: `func return if else while for true false nil var go type struct chan make map range arena`), and the parser has no handling for them. Typing `break` or `continue` is parsed as a bare identifier and fails later as an undefined reference. A reader is given an infinite `for { }` loop (used in the showcased servers, e.g. `framework/machweb.src:72-79` `serve`) with **no documented way to exit it except `return`**.

Neither `docs/LANGUAGE.md`, `SPEC.md`, nor `README.md` mentions this anywhere (grep for `break`/`continue` in those files returns nothing).

## Why it matters

The control-flow docs read as a complete enumeration of looping. A Go programmer will reflexively reach for `break`/`continue` and get a confusing "undefined" error with no hint that the feature simply doesn't exist. Anyone writing an accept/event loop needs to know the only exit is `return` (or never returning).

## Suggested fix

In `docs/LANGUAGE.md` §Control flow and `SPEC.md` §7, add an explicit note that `break` and `continue` are not supported, and that an infinite `for { ... }` is exited with `return` (or by structuring the loop condition). Alternatively, treat this as the tracking issue for *implementing* `break`/`continue` if that is preferred over documenting the limitation.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#90): <brief description>
5. The PR body MUST include 'Fixes #90' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnec4`

## Summary

Issue #90 claimed break/continue don't exist in MFL, but the compiler already implements them (lexer.go keyword set, parser.go handling) and SPEC.md §7 already documented them. The one real residual gap — that break is the way to exit an infinite `for { ... }` loop — wasn't explicit, so I added a short clarifying clause to that bullet in SPEC.md. docs/LANGUAGE.md, the other file the issue named, is currently claimed by an in-flight PR (#321) so it was left untouched to avoid a conflict.

**Diff:**
```
SPEC.md | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```
