### PR TITLE
fix(#70): document closures as capturing by reference, not by value

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -113,7 +113,7 @@ instantiation).
 
 Functions are values. A `func(params) { ... }` literal is an expression you can
 store, pass, return, and call. A literal **captures** variables from the
-enclosing scope (by value, at the moment it is created):
+enclosing scope (by reference — mutable captured state, Go semantics):
 
 ```go
 func adder(n) {
@@ -138,8 +138,10 @@ func main() {
 
 - Function values are compiled by closure conversion (lambda-lifting): each
   literal becomes a top-level function plus a captured environment.
-- Capture is **by value** — a closure snapshots the captured variables when it
-  is created; later changes to them are not seen by the closure.
+- Capture is **by reference** — a closure shares the captured variables with
+  the enclosing scope; later changes to them (by either side) are visible to
+  the closure. See `examples/complex/counter.mfl` for a closure that mutates
+  a captured counter across calls.
 - A function value holds a single return value (or none).
 
 ---


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #70: "docs: LANGUAGE.md says closures capture by value, but capture is by reference")

ISSUE DESCRIPTION:
## Problem
`docs/LANGUAGE.md` documents closure capture as **by value**, which is now incorrect and directly contradicts both the README and the shipped behavior.

In `docs/LANGUAGE.md` ("Functions as values (closures)" section):
- Line ~103: "captures variables from the enclosing scope (**by value**, at the moment it is created)"
- Line ~128–130: "Capture is **by value** — a closure snapshots the captured variables when it is created; later changes to them are not seen by the closure."

## Why it matters
This is the opposite of the actual semantics. `README.md:154` states closures "capture by reference (mutable captured state)", and v0.4.0 shipped by-reference capture (#67). The example `examples/complex/counter.mfl` relies on it:

```go
func counter() { n := 0  return func() { n = n + 1  return n } }
```

Here the inner closure mutates the captured `n` and the change persists across calls — i.e. capture is by reference. The `account` function in the same file mutates a captured `balance` across multiple closures. The LANGUAGE.md text would tell a reader this cannot work.

## Suggested fix
Update the closures section of `docs/LANGUAGE.md` to describe **by-reference** capture (mutable captured state, Go semantics), matching the README and `examples/complex/counter.mfl`. Fix both the `adder` example caption (line ~103) and the bullet at lines ~128–130. Optionally mention `examples/complex/counter.mfl` as the reference example.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#70): <brief description>
5. The PR body MUST include 'Fixes #70' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnibg`

## Summary

Fixed docs/LANGUAGE.md's closures section: it claimed capture is by value, contradicting README.md and the shipped by-reference behavior (v0.4.0, #67). Updated the intro sentence and the bullet list to say capture is by reference, and pointed to examples/complex/counter.mfl as the reference example.

**Diff:**
```
docs/LANGUAGE.md | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified closure behavior in the language docs.
  * Updated the explanation of captured variables to reflect shared mutable state, so later changes are shown as visible inside closures.
  * Replaced the previous wording with a new example reference for closure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->