### PR TITLE
fix(#71): document scoped arenas and --safe in LANGUAGE.md

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -548,6 +548,58 @@ See `examples/complex/http_client_api.mfl` for the full runnable example.
 
 ---
 
+## Memory / arenas
+
+Each goroutine allocates from its own per-goroutine arena, which is garbage
+collected automatically — there is no manual `free`. Within a goroutine, a
+scoped `arena { }` block bump-allocates everything created inside it and
+reclaims that memory as soon as the block exits, which avoids GC pressure in
+hot loops:
+
+```go
+func render(i) {
+    row := "row-" + str(i)
+    return len(row)
+}
+
+func main() {
+    checksum := 0
+    n := 0
+    while n < 100000 {
+        arena {
+            checksum = checksum + render(n)
+        }
+        n = n + 1
+    }
+    println("checksum:", checksum)
+}
+```
+
+Values that need to outlive the block (like `checksum` above) must be
+assigned to a variable declared outside it. See
+`examples/complex/arena.mfl` for the full runnable example.
+
+---
+
+## Safety checks (`--safe`)
+
+Passing `--safe` to `machin build` or `machin run` inserts runtime checks for:
+
+- **bounds** — slice/array/string indexing out of range
+- **div-zero** — integer division or modulo by zero
+- **overflow** — integer arithmetic overflow
+
+```
+machin build app.mfl --safe
+machin run   app.mfl --safe
+```
+
+These checks add overhead, so they are opt-in rather than always on; a
+separate `--race-safe` flag (not related to `--safe`) refuses to build if a
+data race is inferred in `go`/channel usage.
+
+---
+
 ## C FFI (extern)
 
 MFL can call C functions directly. An `extern` block declares the library, its


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #71: "docs: LANGUAGE.md (the \"full reference\") omits scoped arenas and --safe")

ISSUE DESCRIPTION:
## Problem
`docs/LANGUAGE.md` is presented as the full language reference (README:123: "See `docs/LANGUAGE.md` for the full reference"), but it does not document two shipped features:

1. **Scoped arenas** — `arena { }` blocks. Shipped in v0.4.0 (#68), listed in the README feature/status tables, with example `examples/complex/arena.mfl`. Not mentioned anywhere in `docs/LANGUAGE.md` (no `arena` occurrence in the file).
2. **`--safe` mode** — bounds / div-zero / overflow checks. Shipped in v0.4.0, documented in `README.md:114` and `main.go` usage. Not mentioned in `docs/LANGUAGE.md`.

## Why it matters
A reader pointed to LANGUAGE.md as the authoritative reference will not find two of the language's memory/safety features. The reference and the README have drifted.

## Suggested fix
Add sections to `docs/LANGUAGE.md`:
- A **Memory / arenas** section describing the per-goroutine arena and scoped `arena { }` blocks (cross-link `examples/complex/arena.mfl`).
- A short **Safety checks (`--safe`)** note covering bounds / div-zero / overflow checks, consistent with `README.md:114` and the `main.go` usage text.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#71): <brief description>
5. The PR body MUST include 'Fixes #71' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnii4`

## Summary

Added two missing sections to docs/LANGUAGE.md: "Memory / arenas" (documents the per-goroutine arena and scoped `arena { }` blocks, with a runnable example cross-linking `examples/complex/arena.mfl`) and "Safety checks (--safe)" (documents bounds/div-zero/overflow checks enabled via `--safe`, consistent with README.md and main.go usage text). This closes the drift between LANGUAGE.md (billed as the full reference) and the README/CLI, which had documented these v0.4.0 features everywhere except the language reference.

Fixes #71

**Diff:**
```
docs/LANGUAGE.md | 52 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 52 insertions(+)
```
