### PR TITLE
fix(#72): add missing grep/time/stdin_upper rows to examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `loops`        | `while`, running sum, countdown |
 | `functions`    | parameters, return values, composition |
 | `temperature`  | float formulas, authored directly as MFL |
+| `stdin_upper`  | `read_stdin()` reads all of stdin verbatim, unlike line-oriented `input()` |
 
 ## complex/
 
@@ -58,6 +59,8 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `json_get`        | `json_get(json, path)` — jq-style path lookup, `(value, err)` multi-assign, all `err` cases |
 | `json_echo_api`   | POST JSON → parse into a struct → echo it back as JSON |
 | `strings`         | string ops (`split`/`join`/`substr`/`index`/`replace`/…) + request-line parsing |
+| `grep`            | `regex_match`/`regex_find`/`regex_groups`/`regex_replace` |
+| `time`            | `time_make`/`time_format`/`time_fields` — build, format, and round-trip a timestamp |
 | `bytes`           | `bytes` type: construct, `to_hex`/`from_hex`, `byte_at`, `bytes_sub`, `bytes_concat`, `bytes_str`; NUL-safe vs string |
 | `sha256`          | `sha256(s)` → lowercase hex; `hmac_sha256(key, msg)` → lowercase hex; webhook signature verification |
 | `crypto`          | OpenSSL crypto suite: SHA-256, HMAC, AES-GCM round-trip (`ct\|\|tag` layout), Ed25519 sign/verify |


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #72: "docs: example catalogs are out of date (wrong count; missing sieve/structs/counter/arena)")

ISSUE DESCRIPTION:
## Problem
The example catalogs in the docs no longer match the files in `examples/`. There are **38** `.mfl` programs under `examples/` (excluding `demo.mfl`), but the docs undercount and omit several.

**`README.md:194`** states: "`examples/` holds **21 programs**". Actual count is 38. The README example table (lines ~197–221) also omits:
- `complex/sieve` (`examples/complex/sieve.mfl`) — Sieve of Eratosthenes
- `complex/structs` (`examples/complex/structs.mfl`) — struct declarations/literals/field access

**`examples/README.md`** `complex/` table omits:
- `counter` (`examples/complex/counter.mfl`) — by-reference capture / mutable closures
- `arena` (`examples/complex/arena.mfl`) — scoped `arena { }`

(Both of these *are* listed in the root README's example table, so the two catalogs are also inconsistent with each other.)

## Why it matters
The example list is a primary discovery surface for the language's features. An undercount plus missing rows means readers miss working demos of structs, the sieve, by-reference closures, and arenas.

## Suggested fix
- Update the `README.md:194` count from "21" to the actual number, and add `sieve` and `structs` rows to the README example table.
- Add `counter` and `arena` rows to the `examples/README.md` `complex/` table.
- Consider a quick consistency pass so both tables list the same set of programs.

(Reproduce the count with: `find examples -name '*.mfl' | wc -l`.)

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#72): <brief description>
5. The PR body MUST include 'Fixes #72' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnios`

## Summary

Fixed issue #72: the example catalogs had already been mostly repaired by earlier commits (sieve, structs, counter, arena were all already listed in both README.md and examples/README.md, and root README.md no longer has a stale program-count line or example table). The remaining actual drift was in examples/README.md's tables: complex/grep, complex/time, and basic/stdin_upper existed as files but had no rows. Added the three missing rows so both the basic/ and complex/ tables now list exactly the .mfl files present in their directories.

**Diff:**
```
examples/README.md | 3 +++
 1 file changed, 3 insertions(+)
```
