### PR TITLE
fix(#74): add arena production to SPEC.md grammar

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -511,7 +511,7 @@ FuncDecl    = "func" ident "(" [ identList [ "..." ] ] ")" [ "(" identList ")" ]
 TypeName    = "int" | "float" | "bool" | "string" | ident
             | "[]" TypeName | "map" "[" TypeName "]" TypeName | "chan" TypeName .
 Block       = "{" { Stmt } "}" .
-Stmt        = Decl? | Assign | If | Loop | Return | Send | Go | Select | ExprStmt
+Stmt        = Decl? | Assign | If | Loop | Return | Send | Go | Select | Arena | ExprStmt
             | "break" | "continue" .
 Assign      = identList ( ":=" | "=" ) exprList .
 If          = "if" Expr Block [ "else" ( If | Block ) ] .
@@ -520,6 +520,7 @@ Loop        = ( "while" | "for" ) [ Expr ] Block
 Return      = "return" [ exprList ] .
 Send        = Expr "<-" Expr .
 Go          = "go" Call .
+Arena       = "arena" Block .
 Select      = "select" "{" { "case" Comm ":" { Stmt } } [ "default" ":" { Stmt } ] "}" .
 Comm        = ident [ "," ident ] ":=" "<-" Expr | "<-" Expr | Expr "<-" Expr .
 Expr        = ... operators, calls, indexing, field access, literals,


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #74: "docs: SPEC.md is stamped \"Version 0.3.0\" and its keyword list + grammar omit `arena`")

ISSUE DESCRIPTION:
`SPEC.md` is the reference the README points to as the "full reference" ([README.md:21](README.md)), but it has drifted from the implemented language in two concrete ways.

### 1. Stale version header
`SPEC.md:3` reads:

> Version 0.3.0

The project is at **v0.4.1** (README version badge `README.md:2`, top of `CHANGELOG.md`). SPEC.md already documents the 0.4.0 features (`--safe` §12, by-reference closure capture §11.1, scoped `arena { }` §12, named returns, variadics), so the spec body is current but the version stamp is two minor releases behind. A reader checking which language version the spec describes gets the wrong answer.

**Fix:** bump the header to the current release (0.4.1) and keep it in sync on release.

### 2. `arena` missing from the lexical keyword list and the grammar
§12 fully documents the scoped `arena { ... }` block, but:

- The keyword list in **§3 Lexical elements** (`SPEC.md:69-70`) is:
  `func return if else while for range true false nil var go type struct chan make map` — it does **not** include `arena`.
- The informal grammar in **§14** (`SPEC.md:344-365`) has no production for the `arena` block; `Stmt` (`SPEC.md:354`) lists `Assign | If | Loop | Return | Send | Go | ExprStmt` with no `arena` block, and `arena` never appears in the grammar.

So a reader who only reads §3/§14 would conclude `arena` is an ordinary identifier, contradicting §12.

**Fix:** add `arena` to the §3 keyword list and add an `Arena = "arena" Block .` production to §14 (and to the `Stmt` alternation).

Why it matters: SPEC.md is the designated source of truth for the language surface; an internally inconsistent reference (keyword documented in one section, absent from the lexical/grammar sections) and a stale version stamp undermine its authority.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#74): <brief description>
5. The PR body MUST include 'Fixes #74' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnjc4`

## Summary

Issue #74 reported SPEC.md as stamped Version 0.3.0 and missing `arena` from the §3 keyword list and §14 grammar. On inspection, the repo had already moved past that stale state — the version header is 0.106.0 (matches README/current release) and `arena` was already in the §3 keyword list. The one remaining gap was the §14 informal grammar: the `Stmt` alternation had no `Arena` production for the scoped `arena { ... }` block documented in §12. Added `Arena = "arena" Block .` and included it in `Stmt`, closing the last inconsistency the issue described.

**Diff:**
```
SPEC.md | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```
