### PR TITLE
fix(#76): document nil as reserved but not implemented

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -184,7 +184,10 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 
 ## 6. Expressions
 
-- **Literals:** integer, float, string, `true`, `false`.
+- **Literals:** integer, float, string, `true`, `false`. `nil` is a reserved
+  keyword and parses as a literal expression, but it is **not yet implemented**:
+  it types as `void` and does not unify with slice/map/chan/func values. Do not
+  use it — see §16.
 - **Composite literals:** `[]T{...}`, `T{f: v, ...}` / `T{v, ...}`.
 - **Construction:** `make(map[K]V)`, `make(chan T)`, `func(params){...}`.
 - **Operators**, by increasing precedence:
@@ -616,4 +619,6 @@ scoped `arena { }` blocks (§12), named return values (§9), variadic parameters
 (§5.2), by-reference closure capture (§11.1), opt-in bounds/overflow checks
 (`--safe`), and C FFI scalars + by-value structs + opaque handles (§15). Not yet
 implemented: polymorphic recursion, an automatic tracing GC, and FFI callbacks
-(MFL closures as C function pointers). These are refinements, not core gaps.
+(MFL closures as C function pointers). `nil` is reserved and parses as a
+literal (§6) but is **not implemented**: it types as `void` and cannot be used
+as a slice/map/chan/func value. These are refinements, not core gaps.

--- a/SPEC.md
+++ b/SPEC.md
@@ -186,8 +186,8 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 
 - **Literals:** integer, float, string, `true`, `false`. `nil` is a reserved
   keyword and parses as a literal expression, but it is **not yet implemented**:
-  it types as `void` and does not unify with slice/map/chan/func values. Do not
-  use it — see §16.
+  it is rejected with a type-check error wherever it appears, since no value
+  type accepts it yet (no slice/map/chan/func-optional support). See §16.
 - **Composite literals:** `[]T{...}`, `T{f: v, ...}` / `T{v, ...}`.
 - **Construction:** `make(map[K]V)`, `make(chan T)`, `func(params){...}`.
 - **Operators**, by increasing precedence:
@@ -620,5 +620,6 @@ scoped `arena { }` blocks (§12), named return values (§9), variadic parameters
 (`--safe`), and C FFI scalars + by-value structs + opaque handles (§15). Not yet
 implemented: polymorphic recursion, an automatic tracing GC, and FFI callbacks
 (MFL closures as C function pointers). `nil` is reserved and parses as a
-literal (§6) but is **not implemented**: it types as `void` and cannot be used
-as a slice/map/chan/func value. These are refinements, not core gaps.
+literal (§6) but is **not implemented**: it is rejected at type-check, reserved
+for future slice/map/chan/func-optional support. These are refinements, not
+core gaps.

--- a/check_test.go
+++ b/check_test.go
@@ -23,6 +23,17 @@ func TestCheckTypeMismatch(t *testing.T) {
 	}
 }
 
+func TestCheckNilRejectedAtTypecheck(t *testing.T) {
+	r := analyzeSource(`func main(){ x := nil  println(x) }`+"\n", []string{"<t>"})
+	if r.OK || r.ErrorCount != 1 {
+		t.Fatalf("expected one error for nil, got %+v", r)
+	}
+	d := r.Diagnostics[0]
+	if d.Phase != "typecheck" {
+		t.Fatalf("expected a typecheck error, got phase=%q", d.Phase)
+	}
+}
+
 func TestCheckParseErrorDeclAndLine(t *testing.T) {
 	src := "func good(a)(b){b=a+1}\n\nfunc broken(x)(y){\n    y = compute(x x)\n}\n"
 	r := analyzeSource(src, []string{"<t>"})

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -53,10 +53,11 @@ Each value's type is determined by how it is used; mixing incompatible types is
 a **compile-time error**, not a runtime surprise.
 
 > **`nil` is reserved but not usable.** It is a keyword and parses as a literal
-> expression, but it types as `void` and does not unify with any slice, map,
-> `chan`, or `func` value. Don't reach for it as an empty/optional value — use
-> a type's zero value instead (see the zero-value column of each section
+> expression, but it is rejected with a type-check error wherever it appears —
+> no value type accepts it yet. Don't reach for it as an empty/optional value —
+> use a type's zero value instead (see the zero-value column of each section
 > below, e.g. `[]int{}` for an empty slice, `make(map[K]V)` for an empty map).
+> See `SPEC.md` §16.
 
 ---
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -52,6 +52,12 @@ Types are inferred by unification — there are **no type annotations**.
 Each value's type is determined by how it is used; mixing incompatible types is
 a **compile-time error**, not a runtime surprise.
 
+> **`nil` is reserved but not usable.** It is a keyword and parses as a literal
+> expression, but it types as `void` and does not unify with any slice, map,
+> `chan`, or `func` value. Don't reach for it as an empty/optional value — use
+> a type's zero value instead (see the zero-value column of each section
+> below, e.g. `[]int{}` for an empty slice, `make(map[K]V)` for an empty map).
+
 ---
 
 ## Functions

--- a/types.go
+++ b/types.go
@@ -1344,7 +1344,7 @@ func (c *Checker) genExprInner(fn *FuncDecl, e Expr) (int, error) {
 	case *BoolLit:
 		return c.cBool, nil
 	case *NilLit:
-		return c.cVoid, nil
+		return 0, fmt.Errorf("%s: nil is reserved but not implemented (no value type accepts nil yet)", fn.Name)
 	case *Ident:
 		if s, ok := c.vars[fn.Name][ex.Name]; ok {
 			return s, nil


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #76: "docs: `nil` is a reserved keyword and parseable literal but is undocumented and typed as `void`")

ISSUE DESCRIPTION:
## Problem

`nil` is listed as a keyword in the language spec and is accepted by the parser as a literal expression, but it is **documented nowhere** and its implementation appears incomplete — it is typed as `void`, which no real value type can unify with.

## Where

- `SPEC.md:69` — the keyword list includes `nil`:
  > **Keywords.** `func return if else while for range true false nil var go type struct chan make map`.
  …yet `nil` is never described anywhere else in `SPEC.md` (no entry in §4 Types, §4.1 Zero values, or §6 Expressions).
- `docs/LANGUAGE.md` and `README.md` — **no mention of `nil` at all**.
- `parser.go:642-644` — `nil` parses into a `NilLit{}` expression, so it is part of the surface syntax.
- `types.go:1090` — `NilLit` is typed as `c.cVoid` (void).
- `codegen.go:959` — `NilLit` emits the C literal `0`.

## Why it matters

Because `nil` types as `void`, `x := nil` gives `x` a void type, and `nil` cannot be unified with a slice/map/chan/func value (each is a distinct C type). So `nil` is effectively a non-functional keyword that nonetheless:
- is reserved (you cannot use `nil` as an identifier), and
- silently parses, misleading anyone (human or machine) who reaches for Go's `nil` for an empty slice/map/channel/optional.

The keyword is exposed in the spec's grammar with zero guidance on what it does.

## Suggested fix

Pick one and document it:
- If `nil` is intended to be usable: define its type and semantics in `SPEC.md` §4/§6 and `docs/LANGUAGE.md` (what types accept it, what it produces), and make it unify with slice/map/chan/func instead of `void`.
- If `nil` is not yet implemented: mark it explicitly as **reserved / not implemented** in `SPEC.md` (e.g. in §15 Status and non-goals) so its presence in the keyword list isn't read as a usable feature, or have the parser reject it with a clear "nil is not supported" error rather than producing a void-typed literal.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#76): <brief description>
5. The PR body MUST include 'Fixes #76' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnjss`

## Summary

Fixes #76: `nil` was a reserved keyword documented nowhere, parsing into a `NilLit` that silently typed as `void` (which no real value unifies with). Per architect's plan, `nil` now fails with a clear type-check error wherever it's used ("nil is reserved but not implemented") instead of silently producing a broken void-typed binding, and SPEC.md/docs/LANGUAGE.md now document it explicitly as reserved-but-unimplemented. Added a check_test.go case asserting the typecheck error; full test suite (`go test .`) passes.

**Diff:**
```
SPEC.md          | 10 ++++++++--
 check_test.go    | 11 +++++++++++
 docs/LANGUAGE.md |  7 +++++++
 types.go         |  2 +-
 4 files changed, 27 insertions(+), 3 deletions(-)
```
