### PR TITLE
fix(#78): add map, chan, func, and struct rows to LANGUAGE.md Types table

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -40,14 +40,18 @@ A dense base64 "packed" form is available for distribution via `machin pack`;
 
 Types are inferred by unification — there are **no type annotations**.
 
-| Type      | Literals / construction        | Notes                                  |
-|-----------|--------------------------------|----------------------------------------|
-| `int`     | `0`, `42`, `-7`                | 64-bit signed integer                  |
-| `float`   | `3.14`, `0.5`                  | double-precision                       |
-| `string`  | `"hello"`                      | concatenate with `+`                   |
-| `bool`    | `true`, `false`                | produced by comparisons                |
-| `[]int`   | `[]int{}`, `[]int{1, 2, 3}`    | grow with `append`, index with `xs[i]` |
-| `bytes`   | `bytes("hi")`, `from_hex("ff00")` | NUL-safe binary buffer; `len(b)` counts raw bytes; `println(b)` prints hex; strings truncate at NUL, bytes do not |
+| Type       | Literals / construction           | Notes                                  |
+|------------|------------------------------------|-----------------------------------------|
+| `int`      | `0`, `42`, `-7`                | 64-bit signed integer                  |
+| `float`    | `3.14`, `0.5`                  | double-precision                       |
+| `string`   | `"hello"`                      | concatenate with `+`                   |
+| `bool`     | `true`, `false`                | produced by comparisons                |
+| `[]T`      | `[]int{}`, `[]int{1, 2, 3}`    | grow with `append`, index with `xs[i]`; see [Slices](#slices) |
+| `map[K]V`  | `map[string]int{}`            | keyed lookup with `m[k]`; see [Maps](#maps) |
+| `chan T`   | `make(chan int)`               | typed channel for goroutine communication; see [Concurrency](#concurrency) |
+| `func`     | `func(x) { return x + 1 }`     | function values / closures; see [Functions as values](#functions-as-values-closures) |
+| `struct`   | `type Point struct { x int; y int }` | named record type; see [Structs](#structs) |
+| `bytes`    | `bytes("hi")`, `from_hex("ff00")` | NUL-safe binary buffer; `len(b)` counts raw bytes; `println(b)` prints hex; strings truncate at NUL, bytes do not |
 
 Each value's type is determined by how it is used; mixing incompatible types is
 a **compile-time error**, not a runtime surprise.


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #78: "docs: LANGUAGE.md \"Types\" table omits map, chan, func, and struct types")

ISSUE DESCRIPTION:
## Problem

The canonical **Types** table in `docs/LANGUAGE.md` lists only `int`, `float`, `string`, `bool`, and `[]int`. It omits `map`, `chan`, `func`, and `struct` — all of which are core MFL types with their own sections later in the same document, and all of which `SPEC.md` and `README.md` list as first-class types.

## Where

`docs/LANGUAGE.md` §Types (lines ~31-38):

| Type      | Literals / construction        | Notes                                  |
|-----------|--------------------------------|----------------------------------------|
| `int`     | `0`, `42`, `-7`                | 64-bit signed integer                  |
| `float`   | `3.14`, `0.5`                  | double-precision                       |
| `string`  | `"hello"`                      | concatenate with `+`                   |
| `bool`    | `true`, `false`                | produced by comparisons                |
| `[]int`   | `[]int{}`, `[]int{1, 2, 3}`    | grow with `append`, index with `xs[i]` |

The document goes on to fully document **Maps**, **Structs**, and **Channels** in later sections, and the **func** type (function values) under "Functions as values". But the top-level Types table — the first thing a reader consults for "what types does this language have" — silently excludes them.

For comparison, `SPEC.md` §4 lists all of: `int`, `float`, `bool`, `string`, `[]T`, `map[K]V`, `chan T`, `func(...) R`, and named `struct`.

## Why it matters

The Types table reads as the authoritative enumeration of MFL's type system. A reader (human or machine) consulting it gets an incomplete picture and may conclude maps/channels/structs/function values aren't types. The omission is also internally inconsistent — the same doc documents these types in dedicated sections.

## Suggested fix

Add rows for `[]T` (generalize the `[]int` row), `map[K]V`, `chan T`, `func`, and named `struct` to the Types table in `docs/LANGUAGE.md`, each linking to / consistent with its dedicated section, mirroring `SPEC.md` §4.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#78): <brief description>
5. The PR body MUST include 'Fixes #78' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnkg4`

## Summary

Fixes #78: docs/LANGUAGE.md's Types table only listed int/float/string/bool/[]int, silently omitting map, chan, func, and struct even though each has a dedicated section later in the same doc and SPEC.md §4 lists all of them as first-class types. Generalized []int to []T and added rows for map[K]V, chan T, func, and struct, each linking to its dedicated section, mirroring SPEC.md's enumeration.

**Diff:**
```
docs/LANGUAGE.md | 20 ++++++++++++--------
 1 file changed, 12 insertions(+), 8 deletions(-)
```
