### PR TITLE
fix(#79): document var declaration form in LANGUAGE.md

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -88,10 +88,14 @@ func main() { println(add(2, 3)) }
 
 ```go
 x := 10      // declare + infer type
+var y = 5    // same: declare + infer type
 x = x + 1    // reassign (type must match)
 ```
 
 - `:=` declares a new variable and infers its type from the initializer.
+- `var name = expr` is equivalent to `:=` — it also declares a new variable
+  and infers its type from the initializer. See `SPEC.md` §5.3 and
+  `examples/basic/variables.mfl`.
 - `=` reassigns an existing variable.
 
 ---


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #79: "docs: LANGUAGE.md omits the `var` declaration form")

ISSUE DESCRIPTION:
## Problem
`docs/LANGUAGE.md` is presented as the full language reference (README:123: "See `docs/LANGUAGE.md` for the full reference"), but its **Variables** section (lines ~63–72) documents only `:=` (declare + infer) and `=` (reassign). It never mentions the `var` declaration form.

`var` is a real, shipped part of the language:
- It is a reserved keyword — `lexer.go:30` (`"var": true`).
- It is parsed as a declaration statement — `parser.go:310` (`case "var":`).
- It is documented in the spec — `SPEC.md:69` lists `var` in the keyword list, and `SPEC.md:149` shows the grammar `var x = expr   // same` (equivalent to `:=`).
- It is exercised by an example — `examples/basic/variables.mfl` decodes to `... x := 10 var y = 5 x = x + y ...`.
- `examples/README.md:23` even advertises that the `variables` example "shows" `var`.

So a reader who decodes `examples/basic/variables.mfl` (or reads `examples/README.md`) sees `var`, turns to the "full reference" `docs/LANGUAGE.md` to learn it, and finds nothing.

## Where
`docs/LANGUAGE.md` §Variables (lines ~63–72) — `grep -n '\bvar\b' docs/LANGUAGE.md` returns no matches.

## Why it matters
The reference and the implementation/spec have drifted. `var` is the only declaration form not covered by LANGUAGE.md, leaving the reference incomplete and inconsistent with `SPEC.md` and the shipped examples.

## Suggested fix
Add the `var name = expr` form to the Variables section of `docs/LANGUAGE.md`, noting it is equivalent to `:=` (declare + infer), mirroring `SPEC.md:149`. Cross-reference `examples/basic/variables.mfl`.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#79): <brief description>
5. The PR body MUST include 'Fixes #79' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnkms`

## Summary

Documented the `var name = expr` variable declaration form in docs/LANGUAGE.md's Variables section, noting it is equivalent to `:=` (declare + infer). This closes a gap where `var` was a shipped keyword (used by examples/basic/variables.mfl and advertised by examples/README.md) but absent from the reference doc that README.md calls "the full reference". Cross-referenced SPEC.md §5.3 and the example file.

**Diff:**
```
docs/LANGUAGE.md | 4 ++++
 1 file changed, 4 insertions(+)
```
