### PR TITLE
fix(#80): bump landing page version badge and cover v0.4.0+ features

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -57,12 +57,12 @@
 </head>
 <body>
 <header><div class="wrap">
-  <div class="badge">v0.84.0 · the compiler now compiles itself</div>
+  <div class="badge">v0.106.0 · the compiler now compiles itself</div>
   <h1>machin ⎯ MFL</h1>
   <p class="tag">A language <b>optimized for the AI agent writing it</b>, not the human reading it.<br>
     As terse as Python to write, compiled through C to a tiny native binary. <i>Write it like a script, ship it like C.</i></p>
   <div class="announce">
-    🧬 <b>New in v0.84.0 — machin now compiles itself.</b> The machin compiler
+    🧬 <b>machin compiles itself.</b> The machin compiler
     (<span class="k">lexer → parser → type-checker → C codegen</span>) is now written
     <i>in machin</i>, and it emits the same machine code as the original compiler
     <b>byte-for-byte</b>. It even compiles its own source into a native binary that
@@ -134,7 +134,9 @@ machin build --static app.mfl -o app                    <span class="cm"># stati
   <div class="grid">
     <div class="card"><h3>HTTP + router</h3><p>machweb: a native server, JSON, cookies, signed sessions, SSO, SSE, WebSockets.</p></div>
     <div class="card"><h3>Databases</h3><p>SQLite built in (bundled with <code>--static</code>); pure-MFL Postgres / MySQL / Redis / Mongo drivers, pooled.</p></div>
-    <div class="card"><h3>Concurrency</h3><p>goroutines, channels, <code>select</code>; a per-goroutine arena that keeps servers memory-bounded.</p></div>
+    <div class="card"><h3>Concurrency</h3><p>goroutines, channels, <code>select</code>; a per-goroutine arena plus scoped <code>arena{ }</code> blocks that bound a long-lived loop's memory.</p></div>
+    <div class="card"><h3>Closures</h3><p>func literals capture by reference — mutable state across calls, the counter idiom, no boilerplate.</p></div>
+    <div class="card"><h3><code>--safe</code> mode</h3><p>opt-in bounds, div-zero, and overflow checks for when you want guardrails over raw speed.</p></div>
     <div class="card"><h3>Crypto</h3><p>SHA-256, HMAC, HKDF, Ed25519, X25519, AES-GCM — binary and text paths.</p></div>
     <div class="card"><h3>Frontend &amp; games</h3><p>a reactive WebAssembly UI target; raylib GUI/audio/3D via C FFI.</p></div>
     <div class="card"><h3>One artifact</h3><p>compiles to a single native binary — no Node, no interpreter, no runtime.</p></div>


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #80: "docs: landing page (docs/index.html) is stale — v0.3.0 badge, feature grid missing all v0.4.0 features")

ISSUE DESCRIPTION:
## Problem
The public landing page `docs/index.html` — linked prominently from `README.md:21` ("📖 [Landing page](https://javimosch.github.io/machin/)") — is stuck at the v0.3.0 era while the project is at **v0.4.1** (`README.md:2`, `CHANGELOG.md`).

Concretely:
- **`docs/index.html:55`** — the hero badge reads `v0.3.0 · compiled to native code`. Current version is v0.4.1.
- The **"The whole Go-flavored core" feature grid** (`docs/index.html:102–109`) predates v0.4.0 and omits every feature shipped since:
  - **`--safe` mode** — bounds / div-zero / overflow checks (v0.4.0).
  - **By-reference closure capture** — mutable captured state / counter idiom (v0.4.0). The grid (line 105) still describes closures generically as "capturing function values".
  - **Scoped arenas (`arena { }`)** — bound a long-lived loop's memory (v0.4.0). The grid (line 104) only mentions the older per-goroutine arena.
  - **machweb framework** — the web framework written in MFL (v0.4.0, `framework/`).

This is the same class of staleness already reported for the self-hosted server (#75, stale "0.2.1") and SPEC.md (#74, stamped "0.3.0"), but at a different and more visible location — the marketing/landing page users hit first.

## Where
- `docs/index.html:55` (version badge)
- `docs/index.html:102–109` (feature grid)

## Why it matters
The landing page is the first impression for both humans and machines arriving at the project. Showing v0.3.0 and omitting the headline v0.4.0 work (safety mode, real mutable closures, scoped arenas, the framework) understates the project and contradicts the README/CHANGELOG.

## Suggested fix
- Bump the badge at `docs/index.html:55` to the current version (`v0.4.1`), or make it version-agnostic.
- Update the feature grid to cover `--safe`, by-reference closures, scoped `arena { }`, and the machweb framework, consistent with the README feature/status tables and `CHANGELOG.md`.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#80): <brief description>
5. The PR body MUST include 'Fixes #80' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnktg`

## Summary

Updated docs/index.html to fix staleness reported in issue #80: bumped the hero badge from v0.84.0 to the current v0.106.0, and expanded the "Batteries included" feature grid to explicitly call out `--safe` mode (bounds/div-zero/overflow checks), by-reference closure capture, and scoped `arena{ }` blocks — features that shipped in v0.4.0 but were never surfaced on the landing page. The machweb framework was already covered by the existing "HTTP + router" card.

**Diff:**
```
docs/index.html | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```
