### PR TITLE
fix(#81): document the machin encode authoring workflow

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -67,6 +67,16 @@ The toolchain commands:
 | `machin pack <file.mfl>` | emit the dense base64 form (distribution) |
 | `machin guide [--text]` | print the full feature catalog (JSON by default) — keywords, builtins, idioms, gotchas — for agents to load in one call |
 
+`machin encode <src...>` is the authoring path: it accepts one or more `.src`
+files of loose, Go-like declaration text (any whitespace, comments allowed),
+concatenates them in the order given, splits the combined text into
+per-function blocks, strips comments, and normalizes each block to one
+canonical line. The result is parsed and type-checked before being printed, so
+`encode` fails on a type error instead of emitting a broken `.mfl`. Passing
+multiple files lets a shared module (e.g. a framework) precede an
+app-specific file — see [`docs/LANGUAGE.md`](docs/LANGUAGE.md#authoring-machin-encode)
+and [`framework/`](framework/) for a worked example.
+
 ---
 
 ## 3. Lexical elements

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -34,6 +34,28 @@ grep -l fizzbuzz examples/*.mfl
 A dense base64 "packed" form is available for distribution via `machin pack`;
 `machin run` reads either form.
 
+### Authoring: `machin encode`
+
+You don't hand-write canonical `.mfl` — you author readable, Go-like text in a
+`.src` file (loose whitespace, comments, multiple declarations however you
+like to lay them out) and run:
+
+```bash
+machin encode file1.src file2.src ... > program.mfl
+```
+
+`encode` concatenates the given `.src` files in order (so a shared module can
+precede an app-specific file), splits the combined text into per-function
+blocks, strips comments, and normalizes each block to the single-line
+canonical form described above. The result is parsed and type-checked before
+it is printed — `encode` fails loudly on a type error rather than emitting a
+broken `.mfl`.
+
+`framework/` is a worked example of this workflow: `framework/run.sh` builds
+an app's `.mfl` with exactly this pattern —
+`./machin encode framework/machweb.src "$app" > framework/app.mfl` — layering
+an app's `.src` on top of the shared `machweb.src` framework module.
+
 ---
 
 ## Types
@@ -767,3 +789,6 @@ to the C compiler. See `examples/gui/` for a working raylib desktop application.
 - [`../README.md`](../README.md) — project overview and the toolchain
 - [`../examples/`](../examples/) — runnable programs (`machin run <file>.mfl`)
 - `machin build <file>.mfl --emit-c` — inspect the C the compiler emits
+- `machin encode file.src... > file.mfl` — author readable `.src` text and
+  compile it to canonical `.mfl` (see [Authoring](#authoring-machin-encode)
+  above); [`../framework/`](../framework/) is a worked example


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #81: "docs: the `machin encode` authoring workflow is undocumented in the language reference")

ISSUE DESCRIPTION:
## Problem
The whole premise of MFL is *\"you author intent; the machine emits the `.mfl`\"* (README:40, README:88–98). The documented mechanism for producing a `.mfl` from readable Go-like text is `machin encode` (`main.go:170` `cmdEncode`, which concatenates one or more `.src` files, splits them into functions, strips comments, normalizes each to one line, base64-encodes, and type-checks the result). The framework's `run.sh` relies entirely on it:

```sh
./machin encode framework/machweb.src "$app" > framework/app.mfl   # framework/run.sh
```

But the **language reference does not document this authoring path**:

- `docs/LANGUAGE.md` is pointed to as *\"the full reference\"* (README:123) and *\"language tour\"* (README:21). Its **Encoding** section (`docs/LANGUAGE.md:12–25`) only explains the on-disk format and how to **decode** a program for inspection (`base64 -d` one-liner). It never explains how a `.mfl` is **produced**.
- The **See also** section (`docs/LANGUAGE.md:405–409`) lists `machin run` and `machin build --emit-c` but omits `machin encode` entirely. The word `encode` does not appear anywhere in `docs/LANGUAGE.md`.
- `SPEC.md:55` mentions `machin encode <src>` only as a one-line table row (\"encode loose declaration text into canonical `.mfl`\") — no description of the `.src` → `encode` → `.mfl` workflow, multi-file concatenation, or comment-stripping behavior.

The only place the workflow is actually shown is `framework/README.md`, which a reader learning the language is unlikely to find first.

## Why it matters
A reader who follows the README to LANGUAGE.md as the canonical reference has **no documented path** from \"I want to write a program\" to \"I have a runnable `.mfl`\". For a language whose central claim is that humans author source which a tool turns into the canonical base64 form, the authoring command being absent from the reference is a significant gap.

## Suggested fix
- Add an **Authoring / `machin encode`** subsection to `docs/LANGUAGE.md` (near the existing **Encoding** section) describing: writing Go-like `.src` text, `machin encode <src...>` concatenating multiple sources in order (`main.go:170–207`), comment stripping (`main.go:223`), one-line normalization (`main.go:212`), and that the output is type-checked before emission (`main.go:202`). Cross-link `framework/` as a worked example.
- Add `machin encode` to the **See also** list (`docs/LANGUAGE.md:408–409`).
- Optionally expand the `SPEC.md:55` row into a short prose paragraph in §2.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#81): <brief description>
5. The PR body MUST include 'Fixes #81' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnl3g`

## Summary

Documents the previously-undocumented `machin encode` authoring workflow (issue #81). Adds an "Authoring: machin encode" subsection to docs/LANGUAGE.md right after the Source form section, explaining the .src -> encode -> .mfl pipeline (multi-file concatenation, comment stripping, normalization, type-checking before emission) with framework/ as a worked example, and adds encode to the See also list. Expands the SPEC.md §2 table row into a short prose paragraph with the same detail.

**Diff:**
```
SPEC.md          | 10 ++++++++++
 docs/LANGUAGE.md | 25 +++++++++++++++++++++++++
 2 files changed, 35 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the `machin encode` authoring workflow, including how to turn readable `.src` files into canonical `.mfl` output.
  * Clarified support for combining multiple `.src` files in order, making it easier to layer shared code before app-specific content.
  * Expanded references to the language guide and framework example for a complete end-to-end workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->