### PR TITLE
fix(#83): add v0.4.0 and v0.4.1 entries to June 2026 changelog pages

### DIFF
--- a/docs/changelog-2026-06-product.md
+++ b/docs/changelog-2026-06-product.md
@@ -73,12 +73,24 @@
 
         <div class="feature-card rounded-xl p-6">
           <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-red-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🛡️</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">--safe mode, real closures, and scoped arenas</h3>
+              <p class="text-slate-400 leading-relaxed">`machin run|build --safe` catches out-of-range indexing, divide-by-zero, and integer overflow at runtime. Closures now capture by reference (Go semantics), so the counter/accumulator idiom just works. And `arena { }` blocks reclaim everything allocated inside them when the block ends, keeping long-lived loops memory-flat.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
             <div class="w-12 h-12 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
               <span class="text-2xl">📦</span>
             </div>
             <div>
-              <h3 class="text-xl font-semibold text-white mb-2">Released v0.1.0 → v0.3.0</h3>
-              <p class="text-slate-400 leading-relaxed">Three tagged releases this month, a formal language specification (SPEC.md), 35+ runnable examples, and a self-hosted server that serves the project's own catalog — the language is now capable enough to host part of its own tooling.</p>
+              <h3 class="text-xl font-semibold text-white mb-2">Released v0.1.0 → v0.4.1</h3>
+              <p class="text-slate-400 leading-relaxed">Five tagged releases this month, a formal language specification (SPEC.md), 35+ runnable examples, a self-hosted server that serves the project's own catalog, and release automation — pushing a `v*` tag now cross-compiles machin for linux/macOS × amd64/arm64 and attaches the binaries to the GitHub release.</p>
             </div>
           </div>
         </div>

--- a/docs/changelog-2026-06.html
+++ b/docs/changelog-2026-06.html
@@ -113,12 +113,24 @@
 
         <div class="feature-card rounded-xl p-6">
           <div class="flex items-start gap-4">
+            <div class="w-12 h-12 rounded-lg bg-red-500/10 flex items-center justify-center flex-shrink-0">
+              <span class="text-2xl">🛡️</span>
+            </div>
+            <div>
+              <h3 class="text-xl font-semibold text-white mb-2">--safe mode, real closures, and scoped arenas</h3>
+              <p class="text-slate-400 leading-relaxed">`machin run|build --safe` catches out-of-range indexing, divide-by-zero, and integer overflow at runtime. Closures now capture by reference (Go semantics), so the counter/accumulator idiom just works. And `arena { }` blocks reclaim everything allocated inside them when the block ends, keeping long-lived loops memory-flat.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="feature-card rounded-xl p-6">
+          <div class="flex items-start gap-4">
             <div class="w-12 h-12 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
               <span class="text-2xl">📦</span>
             </div>
             <div>
-              <h3 class="text-xl font-semibold text-white mb-2">Released v0.1.0 → v0.3.0</h3>
-              <p class="text-slate-400 leading-relaxed">Three tagged releases this month, a formal language specification (SPEC.md), 35+ runnable examples, and a self-hosted server that serves the project's own catalog — the language is now capable enough to host part of its own tooling.</p>
+              <h3 class="text-xl font-semibold text-white mb-2">Released v0.1.0 → v0.4.1</h3>
+              <p class="text-slate-400 leading-relaxed">Five tagged releases this month, a formal language specification (SPEC.md), 35+ runnable examples, a self-hosted server that serves the project's own catalog, and release automation — pushing a `v*` tag now cross-compiles machin for linux/macOS × amd64/arm64 and attaches the binaries to the GitHub release.</p>
             </div>
           </div>
         </div>
@@ -143,6 +155,8 @@
             <span>💼</span> Other
           </h2>
           <ul class="space-y-2 text-slate-300">
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Release v0.4.1: release automation (cross-compiled binaries + SHA256SUMS.txt on `v*` tag push)</li>
+            <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Release v0.4.0: --safe build mode, by-reference closure capture, scoped arenas (arena { }), the machweb framework, and the func type</li>
             <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add docs/ landing page and update CHANGELOG</li>
             <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add a map-based router to machweb (+ the func type) (#62)</li>
             <li><span class="text-slate-500 text-sm mr-3">[21/06]</span>Add machweb: a backend web framework written in MFL (#61)</li>


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #83: "docs: monthly changelog pages omit v0.4.0 and v0.4.1 (stop at v0.3.0)")

ISSUE DESCRIPTION:
## Problem

The published changelog pages are stale. The site changelog index (`docs/changelog.html`) links to a single monthly page, `docs/changelog-2026-06.html` ("June 2026"), and there is a parallel product changelog at `docs/changelog-2026-06-product.md`. Both stop at **v0.3.0**:

- `docs/changelog-2026-06.html` — only mentions 0.1.0, 0.2.0, 0.2.1, 0.3.0
- `docs/changelog-2026-06-product.md` — only mentions v0.1 … v0.3

But `CHANGELOG.md` (the source of truth) shows two further releases that both shipped in **June 2026**:

- **v0.4.0** — `--safe` build mode, by-reference closure capture, scoped arenas (`arena { }`), the machweb framework, `func` type
- **v0.4.1** — release automation (cross-compiled binaries on `v*` tags)

So the "June 2026" changelog page is missing the two biggest June releases.

## Where

- `docs/changelog-2026-06.html` (linked from `docs/changelog.html`)
- `docs/changelog-2026-06-product.md`

## Why it matters

These are the public-facing changelog pages served from the docs site. Readers landing on the June 2026 changelog see nothing about `--safe`, real (by-reference) closures, scoped arenas, the machweb framework, or the prebuilt-binary releases — all of which are this month's headline work.

## Suggested fix

Add v0.4.0 and v0.4.1 entries to both `docs/changelog-2026-06.html` and `docs/changelog-2026-06-product.md`, mirroring the v0.4.0 / v0.4.1 sections already written in `CHANGELOG.md`.

> Note: this is separate from #80, which tracks the stale `docs/index.html` landing page (v0.3.0 badge / feature grid).

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#83): <brief description>
5. The PR body MUST include 'Fixes #83' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnldg`

## Summary

Fixes #83: the June 2026 changelog pages (docs/changelog-2026-06.html and docs/changelog-2026-06-product.md) stopped at v0.3.0 and were missing the month's two biggest releases. Added a product-facing feature card and technical changelog entries for v0.4.0 (--safe build mode, by-reference closure capture, scoped arenas, the machweb framework, the func type) and v0.4.1 (release automation with cross-compiled binaries on v* tags), mirroring the content already in CHANGELOG.md. Updated the "Released v0.1.0 → v0.3.0" summary card to "v0.1.0 → v0.4.1" on both pages.

**Diff:**
```
docs/changelog-2026-06-product.md | 16 ++++++++++++++--
 docs/changelog-2026-06.html       | 18 ++++++++++++++++--
 2 files changed, 30 insertions(+), 4 deletions(-)
```
