### PR TITLE
fix(#84): document manual release binary download in README Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ by default — set `CC` to override it, e.g. `CC=clang machin build app.mfl -o a
 `--target wasm` web target additionally needs [`zig`](https://ziglang.org). Building
 web apps? See the [`machin-web` skill](skills/machin-web/SKILL.md).
 
+Prefer to fetch the binary yourself? Every [release](https://github.com/javimosch/machin/releases)
+ships static `linux`/`darwin` × `amd64`/`arm64` binaries plus a `SHA256SUMS.txt`:
+
+```bash
+curl -fsSLO https://github.com/javimosch/machin/releases/latest/download/machin-<tag>-<os>-<arch>
+curl -fsSLO https://github.com/javimosch/machin/releases/latest/download/SHA256SUMS.txt
+sha256sum -c SHA256SUMS.txt --ignore-missing        # verify before running
+chmod +x machin-<tag>-<os>-<arch>
+```
+
+The C compiler requirement above still applies to a downloaded binary — it's needed
+at `run`/`build` time regardless of how `machin` itself got installed.
+
 ## Use it from Claude Code
 
 Install machin's agent skills as a [Claude Code plugin](https://code.claude.com/docs/en/plugins),


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #84: "docs: README install section doesn't mention prebuilt release binaries (only build-from-source)")

ISSUE DESCRIPTION:
## Problem

As of **v0.4.1**, pushing a `v*` tag cross-compiles `machin` for linux/macOS × amd64/arm64 and attaches the static binaries (plus `SHA256SUMS.txt`) to the GitHub release (see `.github/workflows/release.yml` and the v0.4.1 CHANGELOG entry). However, the README's **📦 Build & Install** section only documents building from source:

```bash
make build        # → bin/machin
make install      # install to $(PREFIX)/bin
```

There is no mention anywhere in `README.md` that a user can simply download a prebuilt binary from the releases page. (`docs/index.html` has a "Releases" link, but the README — the primary entry point — does not.)

## Where

- `README.md`, `## 📦 Build & Install` section (around lines 268–276)

## Why it matters

The project went to the trouble of shipping prebuilt, dependency-free static binaries, but the README still tells every reader to install Go and build from source. New users have no signal that a faster install path exists.

## Suggested fix

Add a short "Download a release binary" subsection to Build & Install, e.g. pointing to https://github.com/javimosch/machin/releases and showing the SHA256SUMS verification step. 

Worth noting in the same place: the downloaded `machin` binary still shells out to a C compiler (`cc`, overridable via `$CC`) at `run`/`build` time, so `cc`/`gcc`/`clang` must still be on PATH even when using a prebuilt binary.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#84): <brief description>
5. The PR body MUST include 'Fixes #84' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-thnlng`

## Summary

Added a "download a release binary directly" subsection to README's Install section, since it previously only documented the install.sh curl-pipe workflow without mentioning that release binaries (with SHA256SUMS.txt) can be fetched manually from the GitHub releases page. Includes the sha256sum verification command and a reminder that a C compiler is still required at run/build time even with a prebuilt binary. Fixes #84.

**Diff:**
```
README.md | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```
