### PR TITLE
refactor(skillcmd): build embedded skills map once instead of per-call

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -415,6 +415,10 @@ first := users[0]                                // value copy
 | `base64_decode_bytes(s)`    | base64-decode → raw `bytes` (lenient; binary-safe; e.g. SCRAM salt or binary token) |
 | `sha256(s)`                 | SHA-256 of string `s` → lowercase hex string (byte-exact against `sha256sum`) |
 | `hmac_sha256(key, msg)`     | HMAC-SHA256(key, msg) → lowercase hex string (RFC 2104; use for webhook signature verification) |
+| `regex_match(s, pattern)`   | whether POSIX extended regex `pattern` matches anywhere in `s` → `bool` (a bad pattern fails safe: `false`) |
+| `regex_find(s, pattern)`    | the first match of `pattern` in `s`, or `""` if none / on a bad pattern |
+| `regex_groups(s, pattern)`  | the first match's capture groups → `[]string` (index `0` is the whole match, `1..n` the subgroups; `""` for an unmatched optional group; empty slice if no match) |
+| `regex_replace(s, pattern, repl)` | replace all matches of `pattern` in `s` with `repl` (a bad pattern returns `s` unchanged) |
 | `sleep(ms)`                 | suspend the current goroutine (milliseconds) |
 | `listen(port)`              | open a TCP listening socket                  |
 | `accept(fd)`                | accept a connection, return its socket fd    |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -507,6 +507,15 @@ when any crypto builtin is used.
 | `aes_gcm_decrypt(key, iv12, ct_tag, aad)`      | AES-GCM decrypt → plaintext (**empty `bytes` on auth failure**) |
 | `aes_cbc_encrypt(key, iv, pt)`                 | AES-CBC encrypt, PKCS#7 padded (key 16 or 32 bytes)             |
 | `aes_cbc_decrypt(key, iv, ct)`                 | AES-CBC decrypt → plaintext (**empty `bytes` on bad padding**)  |
+| `keccak256(b)`                                 | Keccak-256 (pre-SHA3, the Ethereum variant) of `b` → 32-byte digest |
+| `secp256k1_pubkey(priv32)`                     | secp256k1 public key from a 32-byte private key → 65-byte uncompressed point (empty on invalid input) |
+| `secp256k1_sign_recoverable(priv32, hash32)`   | secp256k1 ECDSA sign (low-S) → 65 bytes: `r\|\|s\|\|v` (`v` is 27 or 28) |
+| `secp256k1_recover(hash32, sig65)`             | recover the 65-byte uncompressed public key from a `secp256k1_sign_recoverable` signature (empty on invalid input) |
+| `xeddsa_sign(priv32, msg, random64)`           | XEdDSA sign over a Curve25519 key (the Signal Protocol scheme) → 64-byte signature |
+| `xeddsa_verify(pub32, msg, sig64)`             | XEdDSA verify → `bool`                                          |
+
+XEdDSA additionally requires libsodium (`-lsodium`, alongside libcrypto); the
+linker flag is added automatically when `xeddsa_sign`/`xeddsa_verify` is used.
 
 ---
 

--- a/skillcmd.go
+++ b/skillcmd.go
@@ -15,14 +15,19 @@ import (
 // skillOrder is the install/list order; machin-start (the decision skill) is first.
 var skillOrder = []string{"machin-start", "machin-web", "machin-gamedev", "machin-backend", "machin-deploy"}
 
+// embeddedSkillsMap is built once; embeddedSkills is a thin, allocation-free
+// accessor so callers (resolveSkill, cmdSkill, skillList, skillInstall) don't
+// each rebuild the map on every call.
+var embeddedSkillsMap = map[string]string{
+	"machin-start":   skillStart,
+	"machin-web":     skillWeb,
+	"machin-gamedev": skillGamedev,
+	"machin-backend": skillBackend,
+	"machin-deploy":  skillDeploy,
+}
+
 func embeddedSkills() map[string]string {
-	return map[string]string{
-		"machin-start":   skillStart,
-		"machin-web":     skillWeb,
-		"machin-gamedev": skillGamedev,
-		"machin-backend": skillBackend,
-		"machin-deploy":  skillDeploy,
-	}
+	return embeddedSkillsMap
 }
 
 // skillAliases maps the short `--skill` names (and "machin") to the full skill dir name.
@@ -33,7 +38,8 @@ var skillAliases = map[string]string{
 }
 
 func resolveSkill(name string) string {
-	if _, ok := embeddedSkills()[name]; ok {
+	skills := embeddedSkills()
+	if _, ok := skills[name]; ok {
 		return name
 	}
 	if full, ok := skillAliases[name]; ok {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-tholks`

## Summary

Three small, independent improvements: (1) skillcmd.go now builds the embedded-skills map once at package init instead of reallocating it on every resolveSkill/cmdSkill/skillInstall call; (2) docs/LANGUAGE.md's Crypto builtins table gained the 6 implemented-but-undocumented builtins (keccak256, secp256k1_pubkey/sign_recoverable/recover, xeddsa_sign/verify); (3) docs/LANGUAGE.md's string builtins table gained the 4 regex_* builtins (match/find/groups/replace), which were fully implemented and tested but missing from the docs entirely. No behavior changes to compiled programs — build, vet, and the full test suite pass.

**Diff:**
```
docs/LANGUAGE.md | 13 +++++++++++++
 skillcmd.go      | 22 ++++++++++++++--------
 2 files changed, 27 insertions(+), 8 deletions(-)
```
