### PR TITLE
docs(#148): document raw memory, TTY, dial/socket, and noise builtins

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -269,6 +269,9 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 | `time_format_utc` | `(int, string) -> string` | like `time_format` but in UTC (`gmtime`) — the form iCalendar / RFC-3339 timestamps want |
 | `time_make` | `(int, int, int, int, int, int) -> int` | build a Unix timestamp from local calendar fields `(year, month, day, hour, minute, second)` — inverse of `time_fields`; `mktime(3)` normalizes out-of-range fields |
 | `parse_int` | `(string) -> int` | parse an integer (0 if not numeric) |
+| `parse_float` | `(string) -> float` | parse a float (0 if not numeric) |
+| `f64_bits` | `(float) -> int` | reinterpret a `float`'s IEEE-754 bits as an `int` (for byte serialization) |
+| `f64_from_bits` | `(int) -> float` | the inverse: an `int` bit pattern → `float` |
 | `exit` | `(int) -> ` | terminate the process with a status code |
 | `flush` | `() -> ` | flush buffered stdout (for prompt output through a pipe) |
 | `raw_mode` | `(int) -> int` | put the terminal in cbreak/no-echo mode (`1`) or restore it (`0`); pair them and restore before exit (TUIs/games) |
@@ -343,6 +346,8 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 An invalid ERE pattern (a `regcomp` failure) is not an error — there's no error channel, so each `regex_*` builtin silently falls back to its benign default: `regex_match`→`false`, `regex_find`→`""`, `regex_groups`→`[]`, `regex_replace`→`s` unchanged. See `examples/complex/grep.mfl`.
 | `sleep` | `(int) -> ` | pause (milliseconds) |
 | `dial` | `(string, int) -> int` | connect to host:port; an fd, or -1 on failure |
+| `peer_addr` | `(int) -> string` | the remote address of a connected socket fd |
+| `socket_timeout` | `(int, int) -> int` | set a read/write timeout (milliseconds) on a socket fd |
 | `listen`, `accept` | `(int) -> int` | open / accept on a TCP socket |
 | `read`, `write` | `(int[, string]) -> string\|int` | socket/fd I/O — `read` is one `read(2)` of up to 65535 bytes, not a whole message; loop `read_bytes` (NUL-safe) to reassemble a complete request (see `framework/machweb.src`'s `read_request_bytes`, and issue #91) |
 | `close` | `(int\|chan) -> ` | close a socket/fd, or a channel (dispatched by argument) |
@@ -593,7 +598,8 @@ extern "m" { header "math.h" link "m" fn sqrt(float) float fn pow(float, float) 
 **Raw memory** (pointers are `int`s, like `ptr`) lets MFL build C buffers and
 structs to hand to a foreign function: `alloc(n) -> int` (n **zeroed** bytes),
 `free(p)`, `poke_f32`/`poke_i32`/`poke_u8`/`poke_u16`/`poke_ptr(p, byteOffset, v)`,
-and `peek_f32`/`peek_i32(p, byteOffset)`. The pattern for a GPU mesh: `poke` the
+`peek_f32`/`peek_i32(p, byteOffset)`, and `ptr_str(p) -> string` (read a
+NUL-terminated C string at `p`). The pattern for a GPU mesh: `poke` the
 vertex/colour arrays and a `Mesh` struct into `alloc`'d memory, `UploadMesh(p, ...)`
 (a `ptr` param — `void*` converts to `Mesh*`, and the call writes the VAO/VBO ids
 back), then `LoadModelFromMesh(p)` (a `*Mesh` param). Struct offsets are

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -428,6 +428,7 @@ first := users[0]                                // value copy
 | `peer_addr(fd)`             | the remote address of a connected socket `fd` |
 | `socket_timeout(fd, ms)`    | set a read/write timeout (milliseconds) on socket `fd` |
 | `read(fd)` / `write(fd, s)` | read from / write to a socket — **one `read(2)` of up to 65535 bytes, not a whole message** (see note below) |
+| `read_bytes(fd)` / `write_bytes(fd, b)` | NUL-safe binary read/write on a socket `fd` — for binary protocols / HTTP bodies |
 | `close(fd)`                 | close a socket                               |
 | `https_get(url)`            | GET over TLS (or plain http://) → body string (`""` on error) |
 | `https_post(url, body)`     | POST with string body over TLS (or plain http://) → body string |
@@ -450,6 +451,7 @@ first := users[0]                                // value copy
 | `byte_at(b, i)`             | byte value 0–255 at index `i` (−1 if out of range) |
 | `bytes_sub(b, start, end)`  | sub-range `[start, end)` of a `bytes` value  |
 | `bytes_concat(a, b)`        | concatenate two `bytes` values               |
+| `bytes_index(b, needle, from)` | find `needle` in `b` at/after index `from`, NUL-safe (`-1` if absent); for binary protocols / multipart boundaries |
 | `alloc(n)` / `free(p)`      | allocate/free `n` zeroed raw bytes on the heap → pointer (an `int`); for building C buffers/structs to pass over FFI |
 | `poke_f32(p, off, v)` / `peek_f32(p, off)` | write/read a 4-byte float at byte offset `off` from pointer `p` |
 | `poke_i32(p, off, v)` / `peek_i32(p, off)` | write/read a 4-byte int at byte offset `off` from pointer `p` |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -407,6 +407,8 @@ first := users[0]                                // value copy
 | `join(xs, sep)`             | join a `[]string` with `sep`                 |
 | `str(n)`                    | convert an `int` or `float` to its `string`  |
 | `int(n)`                    | convert a numeric value to `int` (truncates) |
+| `parse_int(s)` / `parse_float(s)` | parse a `string` to `int` / `float`      |
+| `f64_bits(f)` / `f64_from_bits(i)` | reinterpret a `float`'s IEEE-754 bits as an `int` and back (for byte serialization) |
 | `url_encode(s)`             | percent-encode a string for URLs (RFC 3986: keeps `A-Za-z0-9-._~`, encodes everything else, space → `%20`) |
 | `url_decode(s)`             | percent-decode a URL component (lenient: `+` → space, malformed `%XX` passes through unchanged) |
 | `base64_encode(s)`          | base64-encode a string → standard padded output (`A-Za-z0-9+/=`) |
@@ -422,6 +424,9 @@ first := users[0]                                // value copy
 | `sleep(ms)`                 | suspend the current goroutine (milliseconds) |
 | `listen(port)`              | open a TCP listening socket                  |
 | `accept(fd)`                | accept a connection, return its socket fd    |
+| `dial(host, port)`          | open an outbound TCP connection, return its socket fd |
+| `peer_addr(fd)`             | the remote address of a connected socket `fd` |
+| `socket_timeout(fd, ms)`    | set a read/write timeout (milliseconds) on socket `fd` |
 | `read(fd)` / `write(fd, s)` | read from / write to a socket — **one `read(2)` of up to 65535 bytes, not a whole message** (see note below) |
 | `close(fd)`                 | close a socket                               |
 | `https_get(url)`            | GET over TLS (or plain http://) → body string (`""` on error) |
@@ -445,6 +450,14 @@ first := users[0]                                // value copy
 | `byte_at(b, i)`             | byte value 0–255 at index `i` (−1 if out of range) |
 | `bytes_sub(b, start, end)`  | sub-range `[start, end)` of a `bytes` value  |
 | `bytes_concat(a, b)`        | concatenate two `bytes` values               |
+| `alloc(n)` / `free(p)`      | allocate/free `n` zeroed raw bytes on the heap → pointer (an `int`); for building C buffers/structs to pass over FFI |
+| `poke_f32(p, off, v)` / `peek_f32(p, off)` | write/read a 4-byte float at byte offset `off` from pointer `p` |
+| `poke_i32(p, off, v)` / `peek_i32(p, off)` | write/read a 4-byte int at byte offset `off` from pointer `p` |
+| `poke_u8(p, off, v)` / `poke_u16(p, off, v)` / `poke_ptr(p, off, v)` | write a 1-byte / 2-byte / pointer-sized value at byte offset `off` from pointer `p` |
+| `ptr_str(p)`                | read a NUL-terminated C string at pointer `p` → `string` |
+| `raw_mode(on)`              | toggle terminal raw mode (`1` enable, `0` restore) for uncooked keyboard input |
+| `read_key()`                | read one keypress from stdin (requires `raw_mode(1)`) |
+| `noise2(x, y)` / `noise3(x, y, z)` | 2D/3D Perlin noise, returns `float` in `[-1, 1]` |
 
 ### Raw sockets (`listen` / `accept` / `read` / `write`)
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-tholy4`

## Summary

Closed remaining documentation drift between the implementation (codegen.go/types.go, and the canonical `machin guide` catalog) and the two hand-maintained reference docs. Added missing Builtins rows to docs/LANGUAGE.md (parse_int/parse_float, f64_bits/f64_from_bits, dial/peer_addr/socket_timeout, alloc/free/poke_*/peek_*/ptr_str, raw_mode/read_key, noise2/noise3, read_bytes/write_bytes, bytes_index) and filled the same gaps (parse_float, f64_bits/f64_from_bits, peer_addr, socket_timeout, ptr_str) in SPEC.md section 8. No code behavior changed — pure documentation accuracy fixes across 3 commits.

**Diff:**
```
SPEC.md          |  8 +++++++-
 docs/LANGUAGE.md | 15 +++++++++++++++
 2 files changed, 22 insertions(+), 1 deletion(-)
```
