### PR TITLE
chore(tighten_test): fix comment alignment via gofmt

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -21,7 +21,9 @@ type GlobalVar struct {
 }
 
 // ExternDecl declares foreign C functions and how to compile/link against them:
-//   extern "m" { header "math.h" link "m" fn sqrt(float) float }
+//
+//	extern "m" { header "math.h" link "m" fn sqrt(float) float }
+//
 // Calls to the declared names compile to direct C calls; the header supplies the
 // real prototype and `link`/`cflags` are threaded into the cc invocation.
 type ExternDecl struct {
@@ -34,7 +36,9 @@ type ExternDecl struct {
 }
 
 // ExternStruct declares a C struct's layout for by-value marshaling:
-//   cstruct Color { r u8  g u8  b u8  a u8 }
+//
+//	cstruct Color { r u8  g u8  b u8  a u8 }
+//
 // machin synthesizes a matching MFL struct (int/float fields) and marshals
 // between the MFL value and the C struct at the FFI boundary.
 type ExternStruct struct {
@@ -94,8 +98,8 @@ type NilLit struct{}
 type Ident struct{ Name string }
 
 type Unary struct {
-	Op  string
-	X   Expr
+	Op string
+	X  Expr
 }
 
 type Binary struct {
@@ -166,15 +170,15 @@ type MakeMap struct{ Key, Val string }
 // Recv receives from a channel: <-ch.
 type Recv struct{ Ch Expr }
 
-func (IntLit) node()    {}
-func (FloatLit) node()  {}
-func (StringLit) node() {}
-func (BoolLit) node()   {}
-func (NilLit) node()    {}
-func (Ident) node()     {}
-func (Unary) node()     {}
-func (Binary) node()    {}
-func (Call) node()      {}
+func (IntLit) node()      {}
+func (FloatLit) node()    {}
+func (StringLit) node()   {}
+func (BoolLit) node()     {}
+func (NilLit) node()      {}
+func (Ident) node()       {}
+func (Unary) node()       {}
+func (Binary) node()      {}
+func (Call) node()        {}
 func (SliceLit) node()    {}
 func (Index) node()       {}
 func (StructLit) node()   {}
@@ -193,9 +197,9 @@ type Stmt interface{ Node }
 type ExprStmt struct{ X Expr }
 
 type AssignStmt struct {
-	Name    string
-	Op      string // ":=" or "="
-	Val     Expr
+	Name string
+	Op   string // ":=" or "="
+	Val  Expr
 }
 
 type ReturnStmt struct{ Vals []Expr } // empty for a bare return
@@ -242,7 +246,9 @@ type SendStmt struct {
 }
 
 // RangeStmt iterates a slice, map, or string:
-//   for i, v := range xs   for k, v := range m   for c := range s
+//
+//	for i, v := range xs   for k, v := range m   for c := range s
+//
 // Key is the index/key var; Val is the value var ("" if absent). Either may be
 // "_" to ignore.
 type RangeStmt struct {
@@ -256,12 +262,14 @@ type RangeStmt struct {
 type GoStmt struct{ Call *Call }
 
 // SelectStmt waits on multiple channel operations:
-//   select {
-//     case v := <-ch1: ...      // receive into a new var (Name); RecvCh = ch1
-//     case <-ch2: ...           // receive and discard (Name == "" / "_")
-//     case ch3 <- x: ...        // send (SendCh = ch3, SendVal = x)
-//     default: ...              // runs if no case is ready (HasDefault)
-//   }
+//
+//	select {
+//	  case v := <-ch1: ...      // receive into a new var (Name); RecvCh = ch1
+//	  case <-ch2: ...           // receive and discard (Name == "" / "_")
+//	  case ch3 <- x: ...        // send (SendCh = ch3, SendVal = x)
+//	  default: ...              // runs if no case is ready (HasDefault)
+//	}
+//
 // The first ready case runs; with no default and nothing ready, it blocks.
 type SelectCase struct {
 	// receive case: RecvCh set; Name is the binding ("" / "_" to discard);
@@ -287,21 +295,21 @@ type SelectStmt struct {
 // block (the machine author guarantees no escape, as with a stack frame).
 type ArenaStmt struct{ Body []Stmt }
 
-func (ExprStmt) node()    {}
-func (AssignStmt) node()  {}
-func (MultiAssign) node() {}
-func (ReturnStmt) node()  {}
-func (BreakStmt) node()   {}
+func (ExprStmt) node()     {}
+func (AssignStmt) node()   {}
+func (MultiAssign) node()  {}
+func (ReturnStmt) node()   {}
+func (BreakStmt) node()    {}
 func (ContinueStmt) node() {}
-func (IfStmt) node()      {}
-func (WhileStmt) node()   {}
-func (IndexAssign) node() {}
-func (FieldAssign) node() {}
-func (SendStmt) node()    {}
-func (RangeStmt) node()   {}
-func (GoStmt) node()      {}
-func (ArenaStmt) node()   {}
-func (SelectStmt) node()  {}
+func (IfStmt) node()       {}
+func (WhileStmt) node()    {}
+func (IndexAssign) node()  {}
+func (FieldAssign) node()  {}
+func (SendStmt) node()     {}
+func (RangeStmt) node()    {}
+func (GoStmt) node()       {}
+func (ArenaStmt) node()    {}
+func (SelectStmt) node()   {}
 
 // ---- Top level ----
 

--- a/bson_test.go
+++ b/bson_test.go
@@ -45,8 +45,9 @@ func main() {
 }
 
 // Live MongoDB client (gated). Run with:
-//   docker run -d --name machin-mongo -p 27017:27017 mongo:7
-//   MACHIN_MONGO_TEST=1 go test -run TestMongo -v
+//
+//	docker run -d --name machin-mongo -p 27017:27017 mongo:7
+//	MACHIN_MONGO_TEST=1 go test -run TestMongo -v
 func TestMongoClient(t *testing.T) {
 	if os.Getenv("MACHIN_MONGO_TEST") == "" {
 		t.Skip("set MACHIN_MONGO_TEST=1 (and run a MongoDB) to exercise the wire client")
@@ -97,8 +98,9 @@ func main() {
 
 // Mongo v2 against an AUTHENTICATED Mongo: SCRAM-SHA-256 login, a double field, and
 // cursor pagination (250 docs > one batch). Gated. Run with:
-//   docker run -d --name m -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=secret -p 27018:27017 mongo:7
-//   MACHIN_MONGO_AUTH_TEST=1 go test -run TestMongoV2 -v
+//
+//	docker run -d --name m -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=secret -p 27018:27017 mongo:7
+//	MACHIN_MONGO_AUTH_TEST=1 go test -run TestMongoV2 -v
 func TestMongoV2(t *testing.T) {
 	if os.Getenv("MACHIN_MONGO_AUTH_TEST") == "" {
 		t.Skip("set MACHIN_MONGO_AUTH_TEST=1 (auth Mongo on :27018) to exercise SCRAM + pagination")
@@ -129,9 +131,9 @@ func main() {
 		t.Fatalf("run: %v", err)
 	}
 	for _, want := range []string{
-		"auth=1",       // SCRAM-SHA-256 succeeded
-		"found=250",    // pagination returned all 250 docs (> one batch)
-		"v0=2.5",       // the double round-tripped
+		"auth=1",    // SCRAM-SHA-256 succeeded
+		"found=250", // pagination returned all 250 docs (> one batch)
+		"v0=2.5",    // the double round-tripped
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in:\n%s", want, out)

--- a/codegen.go
+++ b/codegen.go
@@ -64,33 +64,33 @@ func cTypeName(t string) string {
 }
 
 type cgen struct {
-	c        *Checker
-	buf      strings.Builder // function bodies
-	tramp    strings.Builder // goroutine trampolines
-	goID     int
-	jsonFns   strings.Builder   // generated per-type JSON serializers + parsers
-	jsonMemo  map[string]string // type string -> serializer function name
-	parseMemo map[string]string // type string -> parser function name
+	c            *Checker
+	buf          strings.Builder // function bodies
+	tramp        strings.Builder // goroutine trampolines
+	goID         int
+	jsonFns      strings.Builder      // generated per-type JSON serializers + parsers
+	jsonMemo     map[string]string    // type string -> serializer function name
+	parseMemo    map[string]string    // type string -> parser function name
 	chanJSONMemo map[string][2]string // type string -> {serWrapper, desWrapper}
-	jsonID    int
-	rangeID   int    // unique temp names for for-range loops
-	tmpID     int    // unique temp names for multi-assignment
-	arenaID   int    // unique temp names for scoped-arena blocks
-	curFn     string // name of the function currently being emitted
-	safe      bool   // emit runtime bounds / div-by-zero / overflow checks
-	usesTLS   bool   // program calls https_get/https_post -> emit + link OpenSSL
-	usesWSS   bool   // program calls wss_* -> emit WebSocket runtime + link OpenSSL
-	usesRegex bool   // program calls regex_* -> emit POSIX regex runtime
-	usesSQLite bool  // program calls sqlite_* -> emit SQLite runtime + link -lsqlite3
-	usesCrypto bool  // program calls crypto builtins -> emit crypto runtime + link -lcrypto
-	usesXEdDSA bool  // program calls xeddsa_* -> emit XEdDSA runtime + link -lsodium -lcrypto
-	usesMath  bool   // program calls math builtins (sin/cos/sqrt/...) -> emit math runtime + link -lm
-	usesNoise bool   // program calls noise2/noise3 -> emit Perlin noise runtime + link -lm
-	usesNet   bool   // program calls dial/listen/accept/read/write/close(fd) -> emit POSIX socket runtime
-	usesTTY   bool   // program calls raw_mode/read_key -> emit termios/select runtime
-	target    string // "" or "native" (default) -> cc; "wasm" -> zig cc, lean runtime, FFI as imports, exports
-	globals   map[string]bool // package-global names (emitted as C statics, mfl_g_<name>)
-	bodyOnly  bool   // oracle mode: emit only the program-specific C (skip the static runtime blocks)
+	jsonID       int
+	rangeID      int             // unique temp names for for-range loops
+	tmpID        int             // unique temp names for multi-assignment
+	arenaID      int             // unique temp names for scoped-arena blocks
+	curFn        string          // name of the function currently being emitted
+	safe         bool            // emit runtime bounds / div-by-zero / overflow checks
+	usesTLS      bool            // program calls https_get/https_post -> emit + link OpenSSL
+	usesWSS      bool            // program calls wss_* -> emit WebSocket runtime + link OpenSSL
+	usesRegex    bool            // program calls regex_* -> emit POSIX regex runtime
+	usesSQLite   bool            // program calls sqlite_* -> emit SQLite runtime + link -lsqlite3
+	usesCrypto   bool            // program calls crypto builtins -> emit crypto runtime + link -lcrypto
+	usesXEdDSA   bool            // program calls xeddsa_* -> emit XEdDSA runtime + link -lsodium -lcrypto
+	usesMath     bool            // program calls math builtins (sin/cos/sqrt/...) -> emit math runtime + link -lm
+	usesNoise    bool            // program calls noise2/noise3 -> emit Perlin noise runtime + link -lm
+	usesNet      bool            // program calls dial/listen/accept/read/write/close(fd) -> emit POSIX socket runtime
+	usesTTY      bool            // program calls raw_mode/read_key -> emit termios/select runtime
+	target       string          // "" or "native" (default) -> cc; "wasm" -> zig cc, lean runtime, FFI as imports, exports
+	globals      map[string]bool // package-global names (emitted as C statics, mfl_g_<name>)
+	bodyOnly     bool            // oracle mode: emit only the program-specific C (skip the static runtime blocks)
 }
 
 // build targets.

--- a/lexer.go
+++ b/lexer.go
@@ -13,8 +13,8 @@ const (
 	TInt
 	TFloat
 	TString
-	TPunct  // ( ) { } , ;
-	TOp     // + - * / % == != < <= > >= && || ! = :=
+	TPunct // ( ) { } , ;
+	TOp    // + - * / % == != < <= > >= && || ! = :=
 	TKeyword
 )
 
@@ -39,9 +39,9 @@ type Lexer struct {
 	toks []Token
 }
 
-func isDigit(c byte) bool  { return c >= '0' && c <= '9' }
-func isAlpha(c byte) bool  { return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') }
-func isAlnum(c byte) bool  { return isAlpha(c) || isDigit(c) }
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+func isAlpha(c byte) bool { return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') }
+func isAlnum(c byte) bool { return isAlpha(c) || isDigit(c) }
 
 func Lex(src string) ([]Token, error) {
 	l := &Lexer{src: src}

--- a/machweb_test.go
+++ b/machweb_test.go
@@ -50,9 +50,9 @@ func main() {
 		"ctype=application/json", // header name is case-insensitive
 		"clen=7",
 		"host=ex",
-		"missing=[]",   // absent header -> ""
-		"param=42",     // segment after the prefix
-		"noprefix=[]",  // prefix that doesn't match -> ""
+		"missing=[]",  // absent header -> ""
+		"param=42",    // segment after the prefix
+		"noprefix=[]", // prefix that doesn't match -> ""
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in:\n%s", want, out)
@@ -139,9 +139,9 @@ func main() {
 	}
 	for _, want := range []string{
 		"sid=abc", "theme=dark", "missing=[]",
-		"verify=user:42:1", // intact cookie verifies, value recovered
-		"tampered=0",       // a flipped tag byte fails
-		"wrongsecret=0",    // a different secret fails
+		"verify=user:42:1",                   // intact cookie verifies, value recovered
+		"tampered=0",                         // a flipped tag byte fails
+		"wrongsecret=0",                      // a different secret fails
 		"setcookie=Set-Cookie: sid=user:42.", // signed value embeds the cleartext
 		"HttpOnly; SameSite=Lax",             // safe defaults
 	} {

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 // The MySQL/MariaDB client (framework/mysql.src): mysql_native_password auth (SHA-1)
-// + text-protocol queries returning typed JSON rows. Gated — needs a live server:
-//   docker run -d --name m -e MARIADB_ROOT_PASSWORD=secret -e MARIADB_DATABASE=cms -p 3307:3306 mariadb:11
-//   MACHIN_MYSQL_TEST=1 go test -run TestMySQL -v
+//   - text-protocol queries returning typed JSON rows. Gated — needs a live server:
+//     docker run -d --name m -e MARIADB_ROOT_PASSWORD=secret -e MARIADB_DATABASE=cms -p 3307:3306 mariadb:11
+//     MACHIN_MYSQL_TEST=1 go test -run TestMySQL -v
 func TestMySQLClient(t *testing.T) {
 	if os.Getenv("MACHIN_MYSQL_TEST") == "" {
 		t.Skip("set MACHIN_MYSQL_TEST=1 (and run a MariaDB/MySQL) to exercise the wire client")
@@ -39,7 +39,7 @@ func main() {
 		t.Fatalf("run: %v", err)
 	}
 	for _, want := range []string{
-		"connect=1",            // mysql_native_password auth succeeded
+		"connect=1", // mysql_native_password auth succeeded
 		"inserted=2",
 		"n=2 s0=3.5 name1=O'Brien", // typed (double) decode + an escaped quote round-trip
 	} {

--- a/parser.go
+++ b/parser.go
@@ -185,7 +185,8 @@ func isExternDirective(s string) bool {
 }
 
 // parseExternDecl parses:
-//   extern "lib" { header "h.h" link "l" cflags "..." fn Name(t, t) ret ... }
+//
+//	extern "lib" { header "h.h" link "l" cflags "..." fn Name(t, t) ret ... }
 func (p *Parser) parseExternDecl() (*ExternDecl, error) {
 	if _, err := p.expect(TKeyword, "extern"); err != nil {
 		return nil, err
@@ -874,8 +875,9 @@ func (p *Parser) parseRange() (Stmt, error) {
 }
 
 // parseFor handles Go's looping forms, desugared onto WhileStmt:
-//   for { ... }        infinite loop
-//   for cond { ... }   loop while cond
+//
+//	for { ... }        infinite loop
+//	for cond { ... }   loop while cond
 func (p *Parser) parseFor() (Stmt, error) {
 	p.next() // for
 	if p.peek().Val == "{" {

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -11,8 +11,8 @@ import (
 // MACHIN_PG_TEST so the normal suite (and CI, which has no database) skips it and
 // never blocks on dial. Run locally with a server up:
 //
-//   docker run -d --name machin-pg -e POSTGRES_PASSWORD=machin -e POSTGRES_DB=machindb -p 5432:5432 postgres:16
-//   MACHIN_PG_TEST=1 go test -run TestPostgres -v
+//	docker run -d --name machin-pg -e POSTGRES_PASSWORD=machin -e POSTGRES_DB=machindb -p 5432:5432 postgres:16
+//	MACHIN_PG_TEST=1 go test -run TestPostgres -v
 //
 // Override creds via MACHIN_PG_{HOST,PORT,USER,PASS,DB} (defaults match the line above).
 func TestPostgresScramQuery(t *testing.T) {
@@ -70,10 +70,10 @@ func main() {
 		`"id":1,"name":"Ada","active":true`, // numeric/bool unquoted, string quoted
 		`"name":"O'Brien"`,                  // a quote round-trips through the wire + JSON
 		"n=2",
-		"r0=1:Ada",        // parse([]Row{}) decoded the typed fields
-		"r1active=false",  // bool column decoded
+		"r0=1:Ada",       // parse([]Row{}) decoded the typed fields
+		"r1active=false", // bool column decoded
 		`hit=[{"id":1,"name":"Ada","active":true}]`, // pg_exec bound $1
-		"inj=[]",          // injection param matched nothing...
+		"inj=[]",             // injection param matched nothing...
 		`survived=[{"n":2}]`, // ...and the table is intact (DROP did not run)
 	} {
 		if !strings.Contains(out, want) {

--- a/reactive_test.go
+++ b/reactive_test.go
@@ -284,9 +284,9 @@ func reactiveProg(t *testing.T, host, app string) *Program {
 }
 
 // The three load-bearing reactivity guarantees, in one run:
-//   1. change detection — set(id, sameValue) emits NO patch;
-//   2. dependency isolation — only reactions that READ a signal re-run;
-//   3. computed transitivity — set(base) updates a computed, which patches its slot.
+//  1. change detection — set(id, sameValue) emits NO patch;
+//  2. dependency isolation — only reactions that READ a signal re-run;
+//  3. computed transitivity — set(base) updates a computed, which patches its slot.
 func TestReactiveChangeAndIsolation(t *testing.T) {
 	host := `func dom_patch(slot, val) { println("patch " + slot + "=" + val) }`
 	app := `

--- a/redis_test.go
+++ b/redis_test.go
@@ -61,10 +61,10 @@ func main() {
 		t.Fatalf("run: %v", err)
 	}
 	for _, want := range []string{
-		"set=1",          // simple-string reply -> ok
-		"get=hello:1",    // bulk string
-		"miss=0",         // $-1 nil -> ok 0
-		"incr=7",         // integer reply
+		"set=1",           // simple-string reply -> ok
+		"get=hello:1",     // bulk string
+		"miss=0",          // $-1 nil -> ok 0
+		"incr=7",          // integer reply
 		`arr=["a","bbb"]`, // array -> JSON, composes with parse
 		"n=2 e1=bbb",
 	} {
@@ -75,8 +75,9 @@ func main() {
 }
 
 // Integration test against a LIVE Redis (gated, like the Postgres one). Run with:
-//   docker run -d --name machin-redis -p 6379:6379 redis:7
-//   MACHIN_REDIS_TEST=1 go test -run TestRedisLive -v
+//
+//	docker run -d --name machin-redis -p 6379:6379 redis:7
+//	MACHIN_REDIS_TEST=1 go test -run TestRedisLive -v
 func TestRedisLive(t *testing.T) {
 	if os.Getenv("MACHIN_REDIS_TEST") == "" {
 		t.Skip("set MACHIN_REDIS_TEST=1 (and run a Redis) to exercise the live client")

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -35,9 +35,9 @@ func main() {
 		t.Fatal("sqlite_open(\":memory:\") returned 0")
 	}
 	for _, want := range []string{
-		`name0="Ada"`,  // json_get returns the raw JSON token (a quoted string)
+		`name0="Ada"`, // json_get returns the raw JSON token (a quoted string)
 		`active1=0`,
-		`count=2`,      // count(*) aliased to n -> both rows
+		`count=2`, // count(*) aliased to n -> both rows
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in:\n%s", want, out)

--- a/tighten_test.go
+++ b/tighten_test.go
@@ -14,10 +14,10 @@ func TestTighten(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"func fib(n) { return fib(n - 1) + fib(n - 2) }", "func fib(n){return fib(n-1)+fib(n-2)}"},
 		{"acc := acc * i", "acc:=acc*i"},
-		{"return n", "return n"},                 // word-word space is significant — kept
-		{"else if i % 3 == 0", "else if i%3==0"}, // keyword spaces kept; operator spaces dropped
+		{"return n", "return n"},                     // word-word space is significant — kept
+		{"else if i % 3 == 0", "else if i%3==0"},     // keyword spaces kept; operator spaces dropped
 		{`println("a, b  c")`, `println("a, b  c")`}, // spaces inside a string are preserved
-		{`x := "hi" + "  y"`, `x:="hi"+"  y"`},        // tighten around +, keep string interiors
+		{`x := "hi" + "  y"`, `x:="hi"+"  y"`},       // tighten around +, keep string interiors
 	}
 	for _, c := range cases {
 		if got := tighten(c.in); got != c.want {

--- a/types.go
+++ b/types.go
@@ -16,8 +16,8 @@ import (
 type Kind int
 
 const (
-	KVar    Kind = iota // unbound
-	KNum                // numeric literal, int unless unified with float
+	KVar Kind = iota // unbound
+	KNum             // numeric literal, int unless unified with float
 	KInt
 	KFloat
 	KBool
@@ -68,11 +68,11 @@ func isNumeric(k Kind) bool { return k == KInt || k == KFloat || k == KNum }
 type Checker struct {
 	parent []int
 	kind   []Kind
-	elem   []int    // for KSlice/KChan slots: the element slot; -1 otherwise
-	sname  []string // for KStruct slots: the struct type name; "" otherwise
-	mkey   []int       // for KMap slots: the key slot; -1 otherwise
-	mval   []int       // for KMap slots: the value slot; -1 otherwise
-	fsig   []*funcSig  // for KFunc slots: the signature; nil otherwise
+	elem   []int      // for KSlice/KChan slots: the element slot; -1 otherwise
+	sname  []string   // for KStruct slots: the struct type name; "" otherwise
+	mkey   []int      // for KMap slots: the key slot; -1 otherwise
+	mval   []int      // for KMap slots: the value slot; -1 otherwise
+	fsig   []*funcSig // for KFunc slots: the signature; nil otherwise
 
 	structs map[string]*TypeDecl // declared struct types
 
@@ -82,7 +82,7 @@ type Checker struct {
 
 	vars       map[string]map[string]int // func -> var name -> slot
 	localOrder map[string][]string       // func -> locals in declaration order
-	nodeSlot   map[string]map[Node]int // instance -> expr node -> slot
+	nodeSlot   map[string]map[Node]int   // instance -> expr node -> slot
 
 	// shared concrete slots (no inner type vars, safe to share)
 	cBool, cString, cVoid, cInt, cFloat, cBytes int
@@ -100,18 +100,18 @@ type Checker struct {
 
 	// monomorphization: each call instantiates a fresh copy of the callee, so a
 	// function is specialized per concrete call-site type (deduped at codegen).
-	instFn      map[string]*FuncDecl              // instance name -> source function
-	instStack   map[string]string                // source name -> instance being generated (recursion)
-	instOrder   []string                         // instances in creation order
-	instCounter int                              // unique instance ids
-	callInst    map[string]map[*Call]string       // enclosing instance -> call node -> callee instance
+	instFn      map[string]*FuncDecl               // instance name -> source function
+	instStack   map[string]string                  // source name -> instance being generated (recursion)
+	instOrder   []string                           // instances in creation order
+	instCounter int                                // unique instance ids
+	callInst    map[string]map[*Call]string        // enclosing instance -> call node -> callee instance
 	closureInst map[string]map[*MakeClosure]string // enclosing instance -> closure node -> lambda instance
-	cnameOf     map[string]string                 // instance -> C function name (deduped)
-	reps        []string                          // representative instances (one C function each)
-	exportSrc   map[string]bool                   // source names declared `export func`
-	hasMainFn   bool                              // program defines a main function
-	globalSlot  map[string]int                    // package-global name -> type slot
-	globalOrder []string                          // package globals in declaration order
+	cnameOf     map[string]string                  // instance -> C function name (deduped)
+	reps        []string                           // representative instances (one C function each)
+	exportSrc   map[string]bool                    // source names declared `export func`
+	hasMainFn   bool                               // program defines a main function
+	globalSlot  map[string]int                     // package-global name -> type slot
+	globalOrder []string                           // package globals in declaration order
 }
 
 // IsLocal reports whether name is a parameter or local of the given instance (so
@@ -615,18 +615,18 @@ func (c *Checker) instantiate(name string) (string, error) {
 // Check infers types for the program, returning an error on a type clash.
 func Check(p *Program) (*Checker, error) {
 	c := &Checker{
-		funcs:      map[string]*FuncDecl{},
-		funcParam:  map[string][]int{},
-		funcRets:   map[string][]int{},
-		vars:       map[string]map[string]int{},
-		localOrder: map[string][]string{},
-		nodeSlot:   map[string]map[Node]int{},
-		structs:    map[string]*TypeDecl{},
-		instFn:     map[string]*FuncDecl{},
-		instStack:  map[string]string{},
-		callInst:   map[string]map[*Call]string{},
+		funcs:       map[string]*FuncDecl{},
+		funcParam:   map[string][]int{},
+		funcRets:    map[string][]int{},
+		vars:        map[string]map[string]int{},
+		localOrder:  map[string][]string{},
+		nodeSlot:    map[string]map[Node]int{},
+		structs:     map[string]*TypeDecl{},
+		instFn:      map[string]*FuncDecl{},
+		instStack:   map[string]string{},
+		callInst:    map[string]map[*Call]string{},
 		closureInst: map[string]map[*MakeClosure]string{},
-		externs:    map[string]*ExternFunc{},
+		externs:     map[string]*ExternFunc{},
 	}
 	c.cBool = newSlot(c, KBool)
 	c.cString = newSlot(c, KString)
@@ -1362,7 +1362,7 @@ func (c *Checker) genExprInner(fn *FuncDecl, e Expr) (int, error) {
 			c.addPair(xs, c.cBool)
 			return c.cBool, nil
 		}
-		if ex.Op == "^" {              // bitwise complement: int-only
+		if ex.Op == "^" { // bitwise complement: int-only
 			c.addPair(xs, c.cInt)
 			return xs, nil
 		}
@@ -2656,9 +2656,9 @@ func (c *Checker) ctypeSlot(slot int) string {
 	return "int64_t"
 }
 
-func (c *Checker) RetCTypeAt(fn string, i int) string { return c.ctypeSlot(c.funcRets[fn][i]) }
-func (c *Checker) ParamCType(fn string, i int) string { return c.ctypeSlot(c.funcParam[fn][i]) }
-func (c *Checker) VarCType(fn, name string) string  { return c.ctypeSlot(c.vars[fn][name]) }
+func (c *Checker) RetCTypeAt(fn string, i int) string   { return c.ctypeSlot(c.funcRets[fn][i]) }
+func (c *Checker) ParamCType(fn string, i int) string   { return c.ctypeSlot(c.funcParam[fn][i]) }
+func (c *Checker) VarCType(fn, name string) string      { return c.ctypeSlot(c.vars[fn][name]) }
 func (c *Checker) NodeCType(inst string, n Node) string { return c.ctypeSlot(c.slotOf(inst, n)) }
 
 // ElemCType renders the C type of a slice- or channel-node's element.
@@ -2731,8 +2731,12 @@ func (c *Checker) sigCTypes(slot int) ([]string, string) {
 	return nil, "int64_t"
 }
 
-func (c *Checker) NodeFuncSig(inst string, n Node) ([]string, string) { return c.sigCTypes(c.slotOf(inst, n)) }
-func (c *Checker) VarFuncSig(fn, name string) ([]string, string)      { return c.sigCTypes(c.vars[fn][name]) }
+func (c *Checker) NodeFuncSig(inst string, n Node) ([]string, string) {
+	return c.sigCTypes(c.slotOf(inst, n))
+}
+func (c *Checker) VarFuncSig(fn, name string) ([]string, string) {
+	return c.sigCTypes(c.vars[fn][name])
+}
 
 // TypeString renders a node's resolved type as a canonical string (int, float,
 // bool, string, a struct name, []T, map[K]V) — used to key JSON serializers.
@@ -2762,9 +2766,13 @@ func (c *Checker) typeStringSlot(slot int) string {
 }
 
 // map key/value accessors for a map-typed node (used by codegen).
-func (c *Checker) MapKeyKind(inst string, n Node) Kind    { return c.mapPart(inst, n, true, true).(Kind) }
-func (c *Checker) MapValCType(inst string, n Node) string { return c.mapPart(inst, n, false, false).(string) }
-func (c *Checker) MapKeyCType(inst string, n Node) string { return c.mapPart(inst, n, true, false).(string) }
+func (c *Checker) MapKeyKind(inst string, n Node) Kind { return c.mapPart(inst, n, true, true).(Kind) }
+func (c *Checker) MapValCType(inst string, n Node) string {
+	return c.mapPart(inst, n, false, false).(string)
+}
+func (c *Checker) MapKeyCType(inst string, n Node) string {
+	return c.mapPart(inst, n, true, false).(string)
+}
 
 func (c *Checker) mapPart(inst string, n Node, key bool, asKind bool) interface{} {
 	r := c.find(c.slotOf(inst, n))

--- a/ws_test.go
+++ b/ws_test.go
@@ -29,8 +29,8 @@ func wsProg(t *testing.T, app string) *Program {
 // *unmasked* echo frame. Proves the handshake accept key, client-frame unmasking, and
 // server-frame building all in the real socket path.
 //
-//   masked "hi": 81 82 | 01020304 (mask) | 69 6b  ('h'^01, 'i'^02)
-//   key "dGhlIHNhbXBsZSBub25jZQ==" -> accept "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" (the RFC example)
+//	masked "hi": 81 82 | 01020304 (mask) | 69 6b  ('h'^01, 'i'^02)
+//	key "dGhlIHNhbXBsZSBub25jZQ==" -> accept "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" (the RFC example)
 func TestWebSocketEchoRoundTrip(t *testing.T) {
 	app := `
 func serve_one(srv, handler) { conn := accept(srv)  machweb_handle(conn, handler) }


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thomlg`

> ℹ️ **Possible mislabel** — a `chore`-titled PR also edits source files: `ast.go`, `bson_test.go`, `codegen.go`, `lexer.go`, `machweb_test.go`, `mysql_test.go`, `parser.go`, `postgres_test.go`, `reactive_test.go`, `redis_test.go`, `sqlite_test.go`, `tighten_test.go`, `types.go`, `ws_test.go`. Consider splitting so each PR is one concern with an accurate title.


## Summary

Three small gofmt-cleanup commits closing out the gap left by the prior "gofmt cleanup" pass (9833b5b), which didn't cover every file: (1) tighten_test.go comment alignment, (2) eight remaining _test.go files (bson/machweb/mysql/postgres/reactive/redis/ws/sqlite) with godoc list-comment and column-alignment fixes, (3) the core compiler files ast.go/codegen.go/lexer.go/parser.go/types.go with the same. All changes are mechanical (gofmt -w output only), no behavior change; full `go build ./...` and `go test ./...` pass after each commit.

**Diff:**
```
ast.go           | 82 +++++++++++++++++++++++++++++------------------------
 bson_test.go     | 16 ++++++-----
 codegen.go       | 52 +++++++++++++++++-----------------
 lexer.go         | 10 +++----
 machweb_test.go  | 12 ++++----
 mysql_test.go    |  8 +++---
 parser.go        |  8 ++++--
 postgres_test.go | 10 +++----
 reactive_test.go |  6 ++--
 redis_test.go    | 13 +++++----
 sqlite_test.go   |  4 +--
 tighten_test.go  |  6 ++--
 types.go         | 86 +++++++++++++++++++++++++++++++-------------------------
 ws_test.go       |  4 +--
 14 files changed, 169 insertions(+), 148 deletions(-)
```
