### PR TITLE
test(convert): cover f64_bits/f64_from_bits sign bit and zero round trip

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -36,8 +36,8 @@ func TestCLIBuiltins(t *testing.T) {
 // TestParseIntAndNowMs covers parse_int (string -> int, 0 on garbage) and now_ms
 // (monotone-ish wall-clock ms) — surfaced while building a real CLI tool.
 func TestParseIntAndNowMs(t *testing.T) {
-	got := runNative(t, `func main(){ println(parse_int("8080")) println(parse_int("x")) a := now_ms() sleep(20) println((now_ms() - a) >= 15) }`)
-	if want := "8080\n0\ntrue\n"; got != want {
+	got := runNative(t, `func main(){ println(parse_int("8080")) println(parse_int("x")) println(parse_int("-42")) a := now_ms() sleep(20) println((now_ms() - a) >= 15) }`)
+	if want := "8080\n0\n-42\ntrue\n"; got != want {
 		t.Fatalf("parse_int/now_ms: got %q, want %q", got, want)
 	}
 }

--- a/convert_test.go
+++ b/convert_test.go
@@ -27,3 +27,24 @@ func main() {
 		}
 	}
 }
+
+// The 2.5 round trip above never exercises the sign bit or the zero bit
+// pattern, both easy to get wrong in a hand-rolled IEEE-754 reinterpret.
+func TestF64BitsRoundTripNegativeAndZero(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    neg := f64_bits(-2.5)
+    println("neg=" + str(f64_from_bits(neg) == -2.5))
+    zero := f64_bits(0.0)
+    println("zero=" + str(f64_from_bits(zero) == 0.0))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"neg=true", "zero=true"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -1419,6 +1419,20 @@ func TestRegex(t *testing.T) {
 	}
 }
 
+// A malformed pattern must fail safe per docs/LANGUAGE.md rather than crash:
+// match->false, find->"", groups->empty slice, replace->input unchanged.
+func TestRegexBadPattern(t *testing.T) {
+	main := `func main() {
+	ok := "false"  if regex_match("abc", "[a-z") { ok = "true" }
+	g := regex_groups("abc", "[a-z")
+	println(ok + "|" + regex_find("abc", "[a-z") + "|" + str(len(g)) + "|" + regex_replace("abc", "[a-z", "x"))
+}`
+	out, _ := buildRun(t, main)
+	if out != "false||0|abc\n" {
+		t.Fatalf("regex bad pattern: got %q", out)
+	}
+}
+
 // Operands and arguments evaluate left-to-right (Go semantics), even when they
 // have side effects — `g() + g()` on a counter yields 1 then 2, not 2 then 1.
 func TestEvalOrderLeftToRight(t *testing.T) {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thomys`

## Summary

Added three small regression tests for edge cases that were documented but unverified: f64_bits/f64_from_bits round-tripping negative numbers and zero (sign-bit/zero-pattern handling in the hand-rolled IEEE-754 reinterpret), parse_int handling a leading minus sign, and the documented fail-safe behavior of all four regex_* builtins (match/find/groups/replace) when given a malformed pattern. These close gaps where the documented contract (docs/LANGUAGE.md) wasn't backed by a test, without touching any files already claimed by open PR #355.

**Diff:**
```
cli_test.go     |  4 ++--
 convert_test.go | 21 +++++++++++++++++++++
 mfl_test.go     | 14 ++++++++++++++
 3 files changed, 37 insertions(+), 2 deletions(-)
```
