### PR TITLE
test: cover sin/pi/charat/bytes_index builtins

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -87,6 +87,22 @@ func TestReadFileOnDirectory(t *testing.T) {
 	}
 }
 
+// TestRemove covers remove(path): 0 on success (file actually gone), -1 on a
+// missing path. Had no test coverage anywhere in the suite.
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+	src := `func main(){
+	write_file("` + dir + `/a.txt", "bye")
+	println(str(remove("` + dir + `/a.txt")))
+	println(read_file("` + dir + `/a.txt"))
+	println(str(remove("` + dir + `/missing.txt")))
+}`
+	got := runNative(t, src)
+	if want := "0\n\n-1\n"; got != want {
+		t.Fatalf("remove: got %q, want %q", got, want)
+	}
+}
+
 // loadMFL (used by `machin run`/`build` on a .mfl FILE) used to only accept
 // canonical one-declaration-per-line text or the packed base64 form, so a
 // hand-written .mfl with ordinary Go-like multi-line formatting failed with a

--- a/crypto_builtins_test.go
+++ b/crypto_builtins_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// aes_cbc_encrypt/aes_cbc_decrypt and hkdf_sha256 had no test coverage at
+// all — round-trip the AES pair and check hkdf_sha256 produces a
+// deterministic, length-correct output.
+func TestCryptoBuiltins(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    key := from_hex("000102030405060708090a0b0c0d0e0f")
+    iv := from_hex("101112131415161718191a1b1c1d1e1f")
+    pt := bytes("hello aes cbc world")
+    ct := aes_cbc_encrypt(key, iv, pt)
+    rt := aes_cbc_decrypt(key, iv, ct)
+    println("roundtrip=" + str(bytes_str(rt) == "hello aes cbc world"))
+    println("ctlen=" + str(len(ct) >= len(pt)))
+
+    ikm := bytes("input key material")
+    salt := bytes("salt")
+    info := bytes("info")
+    k1 := hkdf_sha256(ikm, salt, info, 32)
+    k2 := hkdf_sha256(ikm, salt, info, 32)
+    println("hkdflen=" + str(len(k1)))
+    println("hkdfdeterministic=" + str(to_hex(k1) == to_hex(k2)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"roundtrip=true", "ctlen=true", "hkdflen=32", "hkdfdeterministic=true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/mathstr_builtins_test.go
+++ b/mathstr_builtins_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// sin/pi and charat/bytes_index had no test coverage at all — each is a
+// small pure builtin, but a broken codegen case (wrong arg order, wrong
+// index base) would otherwise slip through silently.
+func TestMathAndStringBuiltins(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("sin0=" + str(sin(0.0)))
+    half := pi() / 2.0
+    println("sinhalfpi=" + str(sin(half)))
+    println("c0=" + charat("hello", 0))
+    println("c4=" + charat("hello", 4))
+    h := bytes("hello world")
+    needle := bytes("world")
+    println("idx=" + str(bytes_index(h, needle, 0)))
+    println("missing=" + str(bytes_index(h, bytes("xyz"), 0)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"sin0=0", "sinhalfpi=1", "c0=h", "c4=o", "idx=6", "missing=-1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thonc4`

## Summary

Added test coverage for eight builtins that had zero test references anywhere in the suite: sin/pi (math), charat/bytes_index (string/bytes), aes_cbc_encrypt/aes_cbc_decrypt/hkdf_sha256 (crypto), and remove (file I/O). These are pure, deterministic functions so tests use simple assertions (sin(0)/sin(pi/2), an AES-CBC round trip, hkdf_sha256 determinism/length, and remove's success/missing-path return codes) — a silent codegen regression (wrong arg order, off-by-one) in any of these would previously ship undetected. Three separate commits, each independently buildable and non-overlapping with the in-flight PR #355 (skillcmd tests).

**Diff:**
```
cli_test.go              | 16 ++++++++++++++++
 crypto_builtins_test.go  | 41 +++++++++++++++++++++++++++++++++++++++++
 mathstr_builtins_test.go | 35 +++++++++++++++++++++++++++++++++++
 3 files changed, 92 insertions(+)
```
