### PR TITLE
test: cover asin/cbrt/exp/log/fmod/to_lower builtins

### DIFF
--- a/crypto_sha1_test.go
+++ b/crypto_sha1_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// sha1_bytes had no test coverage at all — check it against the well-known
+// SHA-1("abc") test vector so a broken digest implementation can't slip
+// through silently.
+func TestSha1Bytes(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    digest := sha1_bytes(bytes("abc"))
+    println("len=" + str(len(digest)))
+    println("hex=" + to_hex(digest))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"len=20", "hex=a9993e364706816aba3e25717850c26c9cd0d89",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/mathstr2_builtins_test.go
+++ b/mathstr2_builtins_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// asin/cbrt/exp/log/fmod and to_lower had no test coverage at all — each is
+// a small pure builtin, but a broken codegen case (wrong arg order, wrong
+// libm function) would otherwise slip through silently.
+func TestMoreMathAndStringBuiltins(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("asin1=" + str(asin(1.0)))
+    println("cbrt27=" + str(cbrt(27.0)))
+    println("exp0=" + str(exp(0.0)))
+    println("log1=" + str(log(1.0)))
+    println("fmod=" + str(fmod(7.0, 3.0)))
+    println("lower=" + to_lower("HeLLo"))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"asin1=1.5708", "cbrt27=3", "exp0=1", "log1=0", "fmod=1", "lower=hello",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/mathstr3_builtins_test.go
+++ b/mathstr3_builtins_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// log2/log10/acos/trunc/pow/atan2/hypot and to_upper had no test coverage —
+// each is a small pure builtin, but a broken codegen case (wrong libm
+// function, swapped arg order) would otherwise slip through silently.
+func TestEvenMoreMathAndStringBuiltins(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("log2_8=" + str(log2(8.0)))
+    println("log10_100=" + str(log10(100.0)))
+    println("acos1=" + str(acos(1.0)))
+    println("trunc=" + str(trunc(3.9)))
+    println("pow=" + str(pow(2.0, 10.0)))
+    println("atan2=" + str(atan2(0.0, 1.0)))
+    println("hypot=" + str(hypot(3.0, 4.0)))
+    println("upper=" + to_upper("HeLLo"))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"log2_8=3", "log10_100=2", "acos1=0", "trunc=3", "pow=1024", "atan2=0", "hypot=5", "upper=HELLO",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thonpg`

## Summary

Added test coverage for 15 previously-untested pure builtins: asin, cbrt, exp, log, fmod, to_lower, log2, log10, acos, trunc, pow, atan2, hypot, to_upper, and sha1_bytes (checked against the known SHA-1("abc") vector). These builtins had zero test coverage, meaning a broken codegen case (wrong libm function, swapped arg order, or a broken digest implementation) could slip through silently. Three small, self-contained commits, each adding one new _test.go file with no changes to production code.

**Diff:**
```
crypto_sha1_test.go       | 29 +++++++++++++++++++++++++++++
 mathstr2_builtins_test.go | 32 ++++++++++++++++++++++++++++++++
 mathstr3_builtins_test.go | 34 ++++++++++++++++++++++++++++++++++
 3 files changed, 95 insertions(+)
```
