### PR TITLE
fix: compile with -fno-strict-aliasing to stop silent peek/poke miscompiles

### DIFF
--- a/build.go
+++ b/build.go
@@ -105,7 +105,10 @@ func BuildBinaryStatic(prog *Program, outPath string, safe, static bool) error {
 	bundleSqlite := static && usesSqlite
 
 	// foreign linkage: extern cflags go before the source; -l libs after it
-	args := []string{"-O2", "-std=c11", "-pthread"}
+	// -fno-strict-aliasing: the raw-memory peek_*/poke_* builtins (and other
+	// runtime helpers) type-pun through pointer casts, which -O2's strict
+	// aliasing otherwise treats as UB and can silently miscompile.
+	args := []string{"-O2", "-fno-strict-aliasing", "-std=c11", "-pthread"}
 	var srcs []string // extra C source files compiled alongside the generated one
 	if static {
 		args = append(args, "-static")
@@ -253,7 +256,7 @@ func BuildWasm(prog *Program, outPath string, safe bool) error {
 	// Each exported function carries an export_name attribute (emitted by codegen),
 	// which forces its export under the clean source name — so no --export flags.
 	_ = exports
-	args := []string{"cc", "-target", "wasm32-wasi", "-mexec-model=reactor", "-O2", "-std=c11", "-o", outPath, tmp.Name()}
+	args := []string{"cc", "-target", "wasm32-wasi", "-mexec-model=reactor", "-O2", "-fno-strict-aliasing", "-std=c11", "-o", outPath, tmp.Name()}
 
 	cmd := exec.Command(zigPath(), args...)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -1210,6 +1210,26 @@ func TestRawMemory(t *testing.T) {
 	}
 }
 
+// poke_u16 and poke_ptr had no test coverage. There's no matching peek_u16 /
+// peek_ptr builtin, so verify each write via peek_i32 against a zeroed
+// region: on a little-endian host the untouched high bytes stay 0, so the
+// wrong width or a swapped store would show up as a mismatched readback.
+func TestRawMemoryU16AndPtr(t *testing.T) {
+	main := `func main() {
+	p := alloc(16)
+	poke_i32(p, 0, 0)
+	poke_i32(p, 8, 0)
+	poke_u16(p, 0, 4660)
+	poke_ptr(p, 8, 305419896)
+	println(str(peek_i32(p, 0)) + " " + str(peek_i32(p, 8)))
+	free(p)
+}`
+	out, _ := buildRun(t, main)
+	if out != "4660 305419896\n" {
+		t.Fatalf("raw memory u16/ptr: got %q, want %q", out, "4660 305419896\n")
+	}
+}
+
 // The `*Name` FFI param convention: deref an MFL int (pointer) and pass the
 // pointed-to C struct by value (e.g. LoadModelFromMesh(*Mesh)). Codegen-level.
 func TestFFIDerefParam(t *testing.T) {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thonzg`

**Diff:**
```
build.go    |  7 +++++--
 mfl_test.go | 20 ++++++++++++++++++++
 2 files changed, 25 insertions(+), 2 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary and WebAssembly build settings to avoid strict aliasing issues during compilation, which can help prevent hard-to-diagnose build or runtime problems.
  * Added coverage for low-level memory write behavior to reduce the chance of regressions in pointer and integer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->