### PR TITLE
test(bytes_io): cover write_file_bytes/read_file_bytes NUL round-trip

### DIFF
--- a/bytes_io_test.go
+++ b/bytes_io_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -79,5 +82,39 @@ func TestBinaryIOTypeErrors(t *testing.T) {
 		if _, err := Check(&Program{Funcs: []*FuncDecl{fn}}); err == nil {
 			t.Fatalf("expected a type error for: %s", s)
 		}
+	}
+}
+
+// write_file_bytes must round-trip an embedded NUL byte unscathed — write_file
+// would truncate at the NUL since it writes a C string via strlen, which is
+// exactly the binary-asset gap write_file_bytes/read_file_bytes exist to close.
+func TestWriteFileBytesRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "roundtrip.bin")
+	src := fmt.Sprintf(`func main() {
+		b := from_hex("48650061ff")
+		n := write_file_bytes(%q, b)
+		println(str(n))
+		back := read_file_bytes(%q)
+		println(str(len(back)))
+		println(to_hex(back))
+	}`, path, path)
+	fn, err := ParseFunc(normalize(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := RunCaptured(&Program{Funcs: []*FuncDecl{fn}})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := "5\n5\n48650061ff\n"
+	if out != want {
+		t.Fatalf("write_file_bytes round-trip = %q, want %q", out, want)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading back written file: %v", err)
+	}
+	if len(raw) != 5 || raw[2] != 0 {
+		t.Fatalf("on-disk bytes = %x, want embedded NUL at index 2", raw)
 	}
 }

--- a/operators_net_test.go
+++ b/operators_net_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/base64"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -330,6 +331,59 @@ func TestDialOutbound(t *testing.T) {
 	}
 	if got := string(out); got != "pong-from-server" {
 		t.Fatalf("dial round trip: got %q, want \"pong-from-server\"", got)
+	}
+}
+
+// TestPeerAddr exercises peer_addr(fd): once a connection is accepted, the
+// server must be able to read back the client's remote IP via getpeername,
+// which is what lets a handler log or rate-limit by caller address.
+func TestPeerAddr(t *testing.T) {
+	const port = 47657
+	fns := parseFuncs(t,
+		`func main() { s := listen(`+itoa(port)+`) conn := accept(s) print(peer_addr(conn)) close(conn) }`)
+	bin, err := os.CreateTemp("", "mfl-peeraddr-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fns}, bin.Name(), false); err != nil {
+		t.Fatalf("server failed to compile: %v", err)
+	}
+
+	cmd := exec.Command(bin.Name())
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	var conn net.Conn
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", "127.0.0.1:"+itoa(port), 200*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("could not connect to MFL server: %v", err)
+	}
+	defer conn.Close()
+
+	out, err := io.ReadAll(stdout)
+	if err != nil {
+		t.Fatalf("reading server output: %v", err)
+	}
+	if got := string(out); got != "127.0.0.1" {
+		t.Fatalf("peer_addr: got %q, want \"127.0.0.1\"", got)
 	}
 }
 

--- a/operators_net_test.go
+++ b/operators_net_test.go
@@ -387,6 +387,73 @@ func TestPeerAddr(t *testing.T) {
 	}
 }
 
+// TestSocketTimeout exercises socket_timeout(fd, ms): a connected client that
+// never sends data must make the server's read(conn) give up after the
+// configured timeout instead of blocking forever, which is the whole point of
+// the builtin (bounding a slow/hostile client's hold on a connection).
+func TestSocketTimeout(t *testing.T) {
+	const port = 47658
+	fns := parseFuncs(t,
+		`func main() { s := listen(`+itoa(port)+`) conn := accept(s) socket_timeout(conn, 200) r := read(conn) print("["+r+"]") close(conn) }`)
+	bin, err := os.CreateTemp("", "mfl-socktimeout-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fns}, bin.Name(), false); err != nil {
+		t.Fatalf("server failed to compile: %v", err)
+	}
+
+	cmd := exec.Command(bin.Name())
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	var conn net.Conn
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", "127.0.0.1:"+itoa(port), 200*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("could not connect to MFL server: %v", err)
+	}
+	defer conn.Close()
+	connected := time.Now()
+
+	done := make(chan []byte, 1)
+	go func() {
+		out, _ := io.ReadAll(stdout)
+		done <- out
+	}()
+
+	var out []byte
+	select {
+	case out = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not exit — read(conn) ignored socket_timeout and blocked")
+	}
+	elapsed := time.Since(connected)
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("read returned after %v, before the 200ms socket_timeout could have fired", elapsed)
+	}
+	if got := string(out); got != "[]" {
+		t.Fatalf("socket_timeout read: got %q, want \"[]\" (empty read on timeout)", got)
+	}
+}
+
 // itoa is a tiny dependency-free int->string for embedding ports in MFL source.
 func itoa(n int) string {
 	if n == 0 {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thooms`

## Summary

Added execution-level test coverage for three builtins that previously had none: write_file_bytes/read_file_bytes (verifies an embedded NUL byte survives a real file round trip, unlike write_file's strlen-based write), peer_addr (verifies the server reads back a live client's real remote IP), and socket_timeout (verifies a stalled read on a socket with no data gives up after the configured timeout instead of blocking forever). All three use the existing listen/accept/dial test harness pattern already established in operators_net_test.go and bytes_io_test.go. No production code changed; these are pure test additions closing coverage gaps.

**Diff:**
```
bytes_io_test.go      |  37 +++++++++++++++
 operators_net_test.go | 121 ++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 158 insertions(+)
```
