### PR TITLE
test(netio): cover https_post/tls_read_bytes/tls_write_bytes/wss_send/wss_close codegen gating

### DIFF
--- a/netio_gating_test.go
+++ b/netio_gating_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHTTPSPostRuntimeGating mirrors TestHTTPSRuntimeGating (mfl_test.go) for
+// https_post: a program calling it must emit both the OpenSSL TLS runtime and
+// the mfl_https_post entry point, and must not leak WSS framing it never used.
+func TestHTTPSPostRuntimeGating(t *testing.T) {
+	prog := &Program{Funcs: parseFuncs(t, `func main() { println(https_post("https://example.com", "body")) }`)}
+	c, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_https_post") || !strings.Contains(c, "openssl/ssl.h") {
+		t.Fatal("a program using https_post must emit mfl_https_post atop the OpenSSL TLS runtime")
+	}
+	if strings.Contains(c, "mfl_wss_") {
+		t.Fatal("an https_post-only program must not emit the WebSocket runtime")
+	}
+}
+
+// TestTLSBytesRuntimeGating covers tls_read_bytes/tls_write_bytes: both must
+// compile down to their *_h helper entry points atop the shared TLS core, same
+// as the string-flavored tls_read/tls_write already exercised elsewhere.
+func TestTLSBytesRuntimeGating(t *testing.T) {
+	prog := &Program{Funcs: parseFuncs(t, `func main() {
+		fd := tls_client_fd(0, "example.com")
+		tls_write_bytes(fd, from_hex("00ff"))
+		b := tls_read_bytes(fd)
+		println(to_hex(b))
+	}`)}
+	c, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(c, "mfl_tls_read_bytes_h(") {
+		t.Fatal("tls_read_bytes must emit mfl_tls_read_bytes_h")
+	}
+	if !strings.Contains(c, "mfl_tls_write_bytes_h(") {
+		t.Fatal("tls_write_bytes must emit mfl_tls_write_bytes_h")
+	}
+}
+
+// TestWSSSendCloseRuntimeGating covers wss_send/wss_close: a program that
+// opens a socket, sends a text frame, and closes it must emit all three
+// mfl_wss_* entry points atop the WSS runtime (already gated by
+// TestWSSRuntimeGating for wss_open/wss_recv).
+func TestWSSSendCloseRuntimeGating(t *testing.T) {
+	prog := &Program{Funcs: parseFuncs(t, `func main() {
+		c := wss_open("wss://x")
+		wss_send(c, "hi")
+		wss_close(c)
+	}`)}
+	out, err := CompileToC(prog, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "mfl_wss_send(") {
+		t.Fatal("wss_send must emit mfl_wss_send")
+	}
+	if !strings.Contains(out, "mfl_wss_close(") {
+		t.Fatal("wss_close must emit mfl_wss_close")
+	}
+	if !strings.Contains(out, "mfl_wss_open") || !strings.Contains(out, "openssl/ssl.h") {
+		t.Fatal("a program using wss_* must still emit the WebSocket runtime atop the TLS core")
+	}
+}

--- a/selfhost/bench/mb_int/main.go
+++ b/selfhost/bench/mb_int/main.go
@@ -1,11 +1,22 @@
 package main
-import ("fmt";"os";"strconv";"time")
-func main(){
- n,_:=strconv.Atoi(os.Args[1])
- acc:=0
- for i:=0;i<n;i++{acc=(acc+(i*31+7))%1000003}
- t0:=time.Now()
- acc=0
- for i:=0;i<n;i++{acc=(acc+(i*31+7))%1000003}
- fmt.Printf("int acc=%d ms=%d\n",acc,time.Since(t0).Milliseconds())
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	n, _ := strconv.Atoi(os.Args[1])
+	acc := 0
+	for i := 0; i < n; i++ {
+		acc = (acc + (i*31 + 7)) % 1000003
+	}
+	t0 := time.Now()
+	acc = 0
+	for i := 0; i < n; i++ {
+		acc = (acc + (i*31 + 7)) % 1000003
+	}
+	fmt.Printf("int acc=%d ms=%d\n", acc, time.Since(t0).Milliseconds())
 }

--- a/selfhost/bench/mb_str/main.go
+++ b/selfhost/bench/mb_str/main.go
@@ -1,15 +1,22 @@
 package main
-import ("fmt";"os";"strconv";"time")
-func main(){
- n,_:=strconv.Atoi(os.Args[1])
- s:="the quick brown fox jumps over the lazy dog 0123456789"
- cnt:=0
- t0:=time.Now()
- for i:=0;i<n;i++{
-  for j:=0;j<len(s)-5;j++{
-   sub:=s[j:j+5]   // zero-copy in Go
-   cnt+=len(sub)
-  }
- }
- fmt.Printf("str cnt=%d ms=%d\n",cnt,time.Since(t0).Milliseconds())
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	n, _ := strconv.Atoi(os.Args[1])
+	s := "the quick brown fox jumps over the lazy dog 0123456789"
+	cnt := 0
+	t0 := time.Now()
+	for i := 0; i < n; i++ {
+		for j := 0; j < len(s)-5; j++ {
+			sub := s[j : j+5] // zero-copy in Go
+			cnt += len(sub)
+		}
+	}
+	fmt.Printf("str cnt=%d ms=%d\n", cnt, time.Since(t0).Milliseconds())
 }

--- a/tls_bytes_test.go
+++ b/tls_bytes_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"net"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestTLSReadWriteBytesRoundTrip: tls_read_bytes/tls_write_bytes are the
+// binary-safe counterparts of tls_read/tls_write (already exercised by
+// TestServerTLS). An MFL TLS server echoes back whatever bytes it reads,
+// including an embedded NUL — proving the byte path doesn't truncate at NUL
+// the way a C-string-based tls_read/tls_write would.
+func TestTLSReadWriteBytesRoundTrip(t *testing.T) {
+	const port = 47662
+	dir := t.TempDir()
+	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
+
+	src := `func main() {
+	ctx := tls_server_ctx(` + quoteGo(certPath) + `, ` + quoteGo(keyPath) + `)
+	if ctx == 0 { println("ctx fail") exit(1) }
+	srv := listen(` + itoa(port) + `)
+	fd := accept(srv)
+	tls := tls_accept(ctx, fd)
+	if tls == 0 { println("handshake fail") exit(1) }
+	b := tls_read_bytes(tls)
+	tls_write_bytes(tls, b)
+	tls_close(tls)
+}`
+	bin, err := os.CreateTemp("", "mfl-tls-bytes-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: parseFuncs(t, src)}, bin.Name(), false); err != nil {
+		t.Fatalf("tls-bytes server program failed to compile: %v", err)
+	}
+
+	cmd := exec.Command(bin.Name())
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	var conn *tls.Conn
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		c, dialErr := tls.DialWithDialer(&net.Dialer{Timeout: 200 * time.Millisecond}, "tcp", "127.0.0.1:"+itoa(port),
+			&tls.Config{InsecureSkipVerify: true})
+		if dialErr == nil {
+			conn = c
+			break
+		}
+		err = dialErr
+		time.Sleep(50 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("could not connect to the MFL TLS server: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte{0x48, 0x65, 0x00, 0x61, 0xff}
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write to server: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 64)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read from server: %v", err)
+	}
+	if got := buf[:n]; !bytes.Equal(got, payload) {
+		t.Fatalf("tls_read_bytes/tls_write_bytes round trip = %x, want %x (embedded NUL at index 2)", got, payload)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thop3g`

## Summary

Closed the last networking-builtin test gap tracked in shared memory: added codegen-emission gating tests for https_post, tls_read_bytes, tls_write_bytes, wss_send, and wss_close (netio_gating_test.go, mirroring the existing TestHTTPSRuntimeGating/TestWSSRuntimeGating pattern), plus a real functional TLS round-trip test proving tls_read_bytes/tls_write_bytes survive an embedded NUL byte that the string-based tls_read/tls_write would truncate (tls_bytes_test.go, extending tls_server_test.go's TestServerTLS harness). Also gofmt'd two drifted selfhost benchmark files (mb_int/mb_str) with no behavior change. Full `go test .` suite passes.

**Diff:**
```
netio_gating_test.go          | 70 ++++++++++++++++++++++++++++++++++++
 selfhost/bench/mb_int/main.go | 29 ++++++++++-----
 selfhost/bench/mb_str/main.go | 33 ++++++++++-------
 tls_bytes_test.go             | 83 +++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 193 insertions(+), 22 deletions(-)
```
