### PR TITLE
test: cover substr/charat out-of-range and negative index clamping

### DIFF
--- a/split_join_replace_edge_test.go
+++ b/split_join_replace_edge_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// mfl_replace/mfl_split in codegen.go each special-case an empty
+// separator/pattern (replace: return s unchanged; split: split into
+// individual characters) but neither edge case had test coverage — a
+// future rewrite of the loop logic could silently regress into an
+// infinite loop or an out-of-bounds read.
+func TestSplitJoinReplaceEdgeCases(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("replace_empty_pat=[" + replace("abc", "", "X") + "]")
+    parts := split("hi", "")
+    println("split_empty_sep_len=" + str(len(parts)))
+    println("split_empty_sep_joined=[" + join(parts, "-") + "]")
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"replace_empty_pat=[abc]",
+		"split_empty_sep_len=2",
+		"split_empty_sep_joined=[h-i]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/substr_bounds_test.go
+++ b/substr_bounds_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// mfl_substr/mfl_charat in codegen.go clamp negative and out-of-range indices
+// rather than reading out of bounds, but that safety net had no test locking
+// it in place — a future edit to the clamping logic could silently reintroduce
+// an out-of-bounds read.
+func TestSubstrAndCharatBounds(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("neg_start=[" + substr("hello", -3, 2) + "]")
+    println("past_end=[" + substr("hello", 2, 100) + "]")
+    println("start_gt_end=[" + substr("hello", 4, 1) + "]")
+    println("all_negative=[" + substr("hello", -5, -1) + "]")
+    println("neg_idx=[" + charat("hello", -1) + "]")
+    println("oob_idx=[" + charat("hello", 99) + "]")
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"neg_start=[he]",
+		"past_end=[llo]",
+		"start_gt_end=[]",
+		"all_negative=[]",
+		"neg_idx=[]",
+		"oob_idx=[]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/url_decode_malformed_test.go
+++ b/url_decode_malformed_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// mfl_url_decode in codegen.go degrades a truncated or invalid %-escape to a
+// literal '%' rather than reading past the end of the string or decoding
+// garbage, but that safety net only had round-trip coverage (encode then
+// decode) — no test ever fed it malformed input directly.
+func TestURLDecodeMalformedInput(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("trunc1=[" + url_decode("abc%") + "]")
+    println("trunc2=[" + url_decode("abc%4") + "]")
+    println("badhex=[" + url_decode("abc%zz") + "]")
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"trunc1=[abc%]",
+		"trunc2=[abc%4]",
+		"badhex=[abc%zz]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thopgs`

## Summary

Added 3 focused test files locking in existing safe-degrade behavior in string builtins that had no coverage: substr/charat bounds clamping (negative/out-of-range indices), replace/split empty-separator special cases, and url_decode's handling of truncated/malformed percent-escapes. These are pure regression tests — no production code changed — guarding C codegen paths (codegen.go) where a future edit to the clamping/loop logic could silently reintroduce an out-of-bounds read or infinite loop.

**Diff:**
```
split_join_replace_edge_test.go | 34 ++++++++++++++++++++++++++++++++++
 substr_bounds_test.go           | 38 ++++++++++++++++++++++++++++++++++++++
 url_decode_malformed_test.go    | 32 ++++++++++++++++++++++++++++++++
 3 files changed, 104 insertions(+)
```
