### PR TITLE
test: cover index/has_prefix/has_suffix boundary cases

### DIFF
--- a/base64_decode_edge_test.go
+++ b/base64_decode_edge_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// TestBase64DecodeLenientEdgeCases covers mfl_base64_decode (codegen.go), a
+// lenient decoder that accepts both standard and URL-safe alphabets and
+// silently skips padding/whitespace/invalid bytes rather than erroring. These
+// properties are what let it double as a JWT-segment decoder, but weren't
+// exercised beyond the single happy-path round trip in mfl_test.go.
+func TestBase64DecodeLenientEdgeCases(t *testing.T) {
+	raw := "a?/b+c" // contains bytes that b64-encode to both '+' and '/'
+	std := base64.StdEncoding.EncodeToString([]byte(raw))
+	urlSafe := strings.NewReplacer("+", "-", "/", "_").Replace(std)
+	unpadded := strings.TrimRight(std, "=")
+	spaced := strings.Join(strings.Split(std, ""), " ")
+
+	got := runNative(t, `func main(){
+        println(base64_decode(""))
+        println(base64_decode("`+std+`"))
+        println(base64_decode("`+urlSafe+`"))
+        println(base64_decode("`+unpadded+`"))
+        println(base64_decode("`+spaced+`"))
+    }`)
+	want := "\n" + raw + "\n" + raw + "\n" + raw + "\n" + raw + "\n"
+	if got != want {
+		t.Fatalf("base64_decode edge cases: got %q, want %q", got, want)
+	}
+}

--- a/index_prefix_suffix_edge_test.go
+++ b/index_prefix_suffix_edge_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// TestIndexNotFoundAndEmptyNeedle covers mfl_index (codegen.go) edge cases not
+// exercised by the happy-path assertions in mfl_test.go: a substring that
+// isn't present must yield -1, and an empty needle must match at position 0.
+func TestIndexNotFoundAndEmptyNeedle(t *testing.T) {
+	got := runNative(t, `func main(){ println(index("hello", "zz")) println(index("hello", "")) println(index("", "")) println(index("", "a")) }`)
+	if want := "-1\n0\n0\n-1\n"; got != want {
+		t.Fatalf("index edge cases: got %q, want %q", got, want)
+	}
+}
+
+// TestHasPrefixSuffixEdgeCases covers mfl_has_prefix/mfl_has_suffix (codegen.go)
+// boundary behavior: an empty prefix/suffix always matches, and a prefix/suffix
+// longer than the subject string must not match (guards against strncmp/strcmp
+// reading past the shorter buffer).
+func TestHasPrefixSuffixEdgeCases(t *testing.T) {
+	got := runNative(t, `func main(){ println(has_prefix("hi", "")) println(has_suffix("hi", "")) println(has_prefix("hi", "hello")) println(has_suffix("hi", "hello")) println(has_prefix("", "")) println(has_suffix("", "")) }`)
+	if want := "true\ntrue\nfalse\nfalse\ntrue\ntrue\n"; got != want {
+		t.Fatalf("has_prefix/has_suffix edge cases: got %q, want %q", got, want)
+	}
+}

--- a/regex_no_match_test.go
+++ b/regex_no_match_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+// TestRegexValidPatternNoMatch covers the valid-pattern-but-no-match path for
+// the regex builtins (codegen.go mfl_regex_match/_find/_groups/_replace),
+// distinct from the malformed-pattern path already covered by
+// TestRegexBadPattern in mfl_test.go: regcomp succeeds here, but regexec finds
+// nothing, so each builtin must fall back the same way it does on a bad
+// pattern (match->false, find->"", groups->empty slice, replace->unchanged).
+func TestRegexValidPatternNoMatch(t *testing.T) {
+	main := `func main() {
+	ok := "false"  if regex_match("abc", "[0-9]+") { ok = "true" }
+	g := regex_groups("abc", "[0-9]+")
+	println(ok + "|" + regex_find("abc", "[0-9]+") + "|" + str(len(g)) + "|" + regex_replace("abc", "[0-9]+", "x"))
+}`
+	out, _ := buildRun(t, main)
+	if out != "false||0|abc\n" {
+		t.Fatalf("regex no-match: got %q", out)
+	}
+}
+
+// TestRegexGroupsOptionalUnmatched covers mfl_regex_groups' documented
+// behavior that an unmatched optional capture group reports "" rather than
+// being omitted from the slice.
+func TestRegexGroupsOptionalUnmatched(t *testing.T) {
+	main := `func main() {
+	g := regex_groups("abc", "(abc)(x)?")
+	println(str(len(g)) + "|" + g[0] + "|" + g[1] + "|" + g[2])
+}`
+	out, _ := buildRun(t, main)
+	if out != "3|abc|abc|\n" {
+		t.Fatalf("regex optional group: got %q", out)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thopu4`

## Summary

Added three small test files closing edge-case gaps in existing string/regex builtins that only had happy-path coverage: index/has_prefix/has_suffix boundary behavior (not-found, empty needle, empty/oversized prefix-suffix), base64_decode's lenient URL-safe/whitespace/padding handling, and the regex builtins' valid-pattern-but-no-match path plus unmatched optional capture groups. No production code changed — pure test additions guarding documented runtime behavior in codegen.go.

**Diff:**
```
base64_decode_edge_test.go       | 32 ++++++++++++++++++++++++++++++++
 index_prefix_suffix_edge_test.go | 24 ++++++++++++++++++++++++
 regex_no_match_test.go           | 35 +++++++++++++++++++++++++++++++++++
 3 files changed, 91 insertions(+)
```
