### PR TITLE
test(racecheck): cover clonePath/pathEq/mapValType/copyIntMap helpers

### DIFF
--- a/cbyteslit_test.go
+++ b/cbyteslit_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestCBytesLiteralEmpty(t *testing.T) {
+	got := cBytesLiteral("blob", nil)
+	want := "const unsigned char blob[] = {\n\n};\nconst unsigned long blob_len = 0UL;\n"
+	if got != want {
+		t.Fatalf("cBytesLiteral(empty) = %q, want %q", got, want)
+	}
+}
+
+func TestCBytesLiteralContents(t *testing.T) {
+	data := []byte{0x00, 0x01, 0xff, 0x10}
+	got := cBytesLiteral("blob", data)
+
+	if !strings.HasPrefix(got, "const unsigned char blob[] = {\n") {
+		t.Fatalf("cBytesLiteral missing array header, got %q", got)
+	}
+	if !strings.Contains(got, "0x00,0x01,0xff,0x10,") {
+		t.Fatalf("cBytesLiteral missing expected byte sequence, got %q", got)
+	}
+	wantLen := fmt.Sprintf("const unsigned long blob_len = %dUL;\n", len(data))
+	if !strings.HasSuffix(got, wantLen) {
+		t.Fatalf("cBytesLiteral(%v) length trailer = %q, want suffix %q", data, got, wantLen)
+	}
+}
+
+// Every 20th byte (indices 19, 39, ...) ends a line, so 21 bytes must wrap
+// onto a second line inside the array body.
+func TestCBytesLiteralLineWrap(t *testing.T) {
+	data := make([]byte, 21)
+	got := cBytesLiteral("blob", data)
+
+	body := strings.TrimSuffix(strings.TrimPrefix(got, "const unsigned char blob[] = {\n"), "\n};\nconst unsigned long blob_len = 21UL;\n")
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("cBytesLiteral(21 bytes) body has %d lines, want 2: %q", len(lines), body)
+	}
+	if got := strings.Count(lines[0], "0x"); got != 20 {
+		t.Fatalf("first line has %d bytes, want 20: %q", got, lines[0])
+	}
+	if got := strings.Count(lines[1], "0x"); got != 1 {
+		t.Fatalf("second line has %d bytes, want 1: %q", got, lines[1])
+	}
+}

--- a/declfromline_test.go
+++ b/declfromline_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestDeclFromLinePlainText(t *testing.T) {
+	line := "func main() { println(\"hi\") }"
+	got, err := declFromLine(line)
+	if err != nil {
+		t.Fatalf("declFromLine(%q) error = %v", line, err)
+	}
+	if got != line {
+		t.Fatalf("declFromLine(%q) = %q, want unchanged", line, got)
+	}
+}
+
+func TestDeclFromLinePacked(t *testing.T) {
+	src := "func f() { return 1 }"
+	packed := base64.StdEncoding.EncodeToString([]byte(src))
+	got, err := declFromLine(packed)
+	if err != nil {
+		t.Fatalf("declFromLine(%q) error = %v", packed, err)
+	}
+	if got != src {
+		t.Fatalf("declFromLine(%q) = %q, want %q", packed, got, src)
+	}
+}
+
+func TestDeclFromLineInvalid(t *testing.T) {
+	_, err := declFromLine("not-valid-base64!!!")
+	if err == nil {
+		t.Fatalf("declFromLine(invalid) expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "neither plain MFL nor base64") {
+		t.Fatalf("declFromLine(invalid) error = %v, want mention of plain/base64", err)
+	}
+}

--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -1,0 +1,89 @@
+package main
+
+import "testing"
+
+func TestClonePath(t *testing.T) {
+	if got := clonePath(nil); got != nil {
+		t.Fatalf("clonePath(nil) = %v, want nil", got)
+	}
+	if got := clonePath(accPath{}); got != nil {
+		t.Fatalf("clonePath(empty) = %v, want nil", got)
+	}
+
+	orig := accPath{{field: "a"}, {field: ""}, {field: "b"}}
+	clone := clonePath(orig)
+	if !pathEq(orig, clone) {
+		t.Fatalf("clonePath(%v) = %v, want equal path", orig, clone)
+	}
+
+	// Mutating the clone must not affect the original — it's a deep copy of the slice.
+	clone[0].field = "z"
+	if orig[0].field != "a" {
+		t.Fatalf("mutating clone affected original: %v", orig)
+	}
+}
+
+func TestPathEq(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b accPath
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"nil vs empty", nil, accPath{}, true},
+		{"equal single field", accPath{{field: "x"}}, accPath{{field: "x"}}, true},
+		{"equal index step", accPath{{field: ""}}, accPath{{field: ""}}, true},
+		{"different field name", accPath{{field: "x"}}, accPath{{field: "y"}}, false},
+		{"different length", accPath{{field: "x"}}, accPath{{field: "x"}, {field: "y"}}, false},
+		{"different order", accPath{{field: "x"}, {field: "y"}}, accPath{{field: "y"}, {field: "x"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathEq(tt.a, tt.b); got != tt.want {
+				t.Fatalf("pathEq(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapValType(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"map[string]int", "int"},
+		{"map[int]string", "string"},
+		{"map[string]map[int]bool", "map[int]bool"},
+		{"map[string][]int", "[]int"},
+		{"map[string]", ""},
+		{"nope", "?"},
+	}
+	for _, tt := range tests {
+		if got := mapValType(tt.in); got != tt.want {
+			t.Fatalf("mapValType(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCopyIntMap(t *testing.T) {
+	orig := map[string]int{"a": 1, "b": 2}
+	clone := copyIntMap(orig)
+	if len(clone) != len(orig) {
+		t.Fatalf("copyIntMap(%v) = %v, want same length", orig, clone)
+	}
+	for k, v := range orig {
+		if clone[k] != v {
+			t.Fatalf("copyIntMap(%v)[%q] = %d, want %d", orig, k, clone[k], v)
+		}
+	}
+
+	// Mutating the clone must not affect the original.
+	clone["a"] = 99
+	if orig["a"] != 1 {
+		t.Fatalf("mutating clone affected original: %v", orig)
+	}
+
+	empty := copyIntMap(nil)
+	if len(empty) != 0 {
+		t.Fatalf("copyIntMap(nil) = %v, want empty map", empty)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thoqo4`

## Summary

Added focused unit tests for three previously-uncovered pure helper functions: clonePath/pathEq/mapValType/copyIntMap in the data-race analysis (racecheck.go), cBytesLiteral's C byte-array rendering used to embed the CA bundle (build.go), and declFromLine's plain-vs-base64-packed MFL decl parsing (main.go). These are small, self-contained internal utilities with no existing direct tests, so the new tests lock in their edge-case behavior (nil/empty inputs, nested types, line-wrap boundaries, invalid input errors) without touching any files claimed by other in-flight PRs. All new tests pass and the full existing test suite (`go test .`) still passes.

**Diff:**
```
cbyteslit_test.go         | 50 ++++++++++++++++++++++++++
 declfromline_test.go      | 40 +++++++++++++++++++++
 racecheck_helpers_test.go | 89 +++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 179 insertions(+)
```
