### PR TITLE
test: cover byte_at/bytes_sub/bytes_index bounds clamping

### DIFF
--- a/bytes_bounds_edge_test.go
+++ b/bytes_bounds_edge_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+// TestByteAtOutOfRange covers mfl_byte_at (codegen.go): a negative index or an
+// index at/past len must yield -1 rather than reading out of bounds.
+func TestByteAtOutOfRange(t *testing.T) {
+	got := runNative(t, `func main(){ b := from_hex("aabb") println(byte_at(b, -1)) println(byte_at(b, 2)) println(byte_at(b, 0)) }`)
+	if want := "-1\n-1\n170\n"; got != want {
+		t.Fatalf("byte_at out-of-range: got %q, want %q", got, want)
+	}
+}
+
+// TestBytesSubClamping covers mfl_bytes_sub (codegen.go): a negative start
+// clamps to 0, an end past len clamps to len, and end < start yields an empty
+// (not negative-length) slice.
+func TestBytesSubClamping(t *testing.T) {
+	got := runNative(t, `func main(){
+		b := from_hex("aabbcc")
+		println(to_hex(bytes_sub(b, -5, 2)))
+		println(to_hex(bytes_sub(b, 1, 99)))
+		println(len(bytes_sub(b, 2, 0)))
+	}`)
+	if want := "aabb\nbbcc\n0\n"; got != want {
+		t.Fatalf("bytes_sub clamping: got %q, want %q", got, want)
+	}
+}
+
+// TestBytesIndexEmptyNeedleAndAbsent covers mfl_bytes_index (codegen.go): an
+// empty needle matches at the (clamped) from offset, and an absent needle
+// yields -1.
+func TestBytesIndexEmptyNeedleAndAbsent(t *testing.T) {
+	got := runNative(t, `func main(){
+		h := from_hex("aabbcc")
+		println(bytes_index(h, bytes(""), 1))
+		println(bytes_index(h, from_hex("ddee"), 0))
+		println(bytes_index(h, from_hex("bb"), -3))
+	}`)
+	if want := "1\n-1\n1\n"; got != want {
+		t.Fatalf("bytes_index edge cases: got %q, want %q", got, want)
+	}
+}

--- a/bytes_bounds_edge_test.go
+++ b/bytes_bounds_edge_test.go
@@ -40,3 +40,17 @@ func TestBytesIndexEmptyNeedleAndAbsent(t *testing.T) {
 		t.Fatalf("bytes_index edge cases: got %q, want %q", got, want)
 	}
 }
+
+// TestFromHexSkipsNonHexAndDropsTrailingNibble covers mfl_bytes_unhex
+// (codegen.go): separators like spaces/colons are skipped rather than
+// erroring, and a dangling odd hex digit at the end is silently dropped.
+func TestFromHexSkipsNonHexAndDropsTrailingNibble(t *testing.T) {
+	got := runNative(t, `func main(){
+		println(to_hex(from_hex("aa:bb cc")))
+		println(to_hex(from_hex("aabbc")))
+		println(len(from_hex("")))
+	}`)
+	if want := "aabbcc\naabb\n0\n"; got != want {
+		t.Fatalf("from_hex edge cases: got %q, want %q", got, want)
+	}
+}

--- a/bytes_bounds_edge_test.go
+++ b/bytes_bounds_edge_test.go
@@ -54,3 +54,17 @@ func TestFromHexSkipsNonHexAndDropsTrailingNibble(t *testing.T) {
 		t.Fatalf("from_hex edge cases: got %q, want %q", got, want)
 	}
 }
+
+// TestBytesConcatAndHexEmptyBuffers covers mfl_bytes_concat/mfl_bytes_hex
+// (codegen.go) with zero-length operands: their `mfl_alloc(n ? n : 1)` guard
+// against a zero-size allocation must still produce a correct, empty result.
+func TestBytesConcatAndHexEmptyBuffers(t *testing.T) {
+	got := runNative(t, `func main(){
+		println(to_hex(bytes_concat(bytes(""), bytes(""))))
+		println(to_hex(bytes_concat(from_hex("aa"), bytes(""))))
+		println(bytes_str(bytes_concat(bytes(""), bytes("hi"))))
+	}`)
+	if want := "\naa\nhi\n"; got != want {
+		t.Fatalf("bytes_concat/to_hex empty buffers: got %q, want %q", got, want)
+	}
+}

--- a/map_contains_edge_test.go
+++ b/map_contains_edge_test.go
@@ -1,0 +1,50 @@
+package main
+
+import "testing"
+
+// TestMapDeleteNonexistentAndTwiceIsNoop covers mfl_map_del (codegen.go):
+// deleting a key that was never present, and deleting the same key twice,
+// must both be safe no-ops rather than freeing an already-freed entry.
+func TestMapDeleteNonexistentAndTwiceIsNoop(t *testing.T) {
+	got := runProg(t,
+		`func main() { m := make(map[int]string) m[1] = "one" delete(m, 99) delete(m, 1) delete(m, 1) println(len(m), has(m, 1)) }`)
+	if want := "0 false\n"; got != want {
+		t.Fatalf("map delete no-op: got %q, want %q", got, want)
+	}
+}
+
+// TestMapHasAfterDeleteThenReinsert covers mfl_map_has/mfl_map_del/mfl_map_set
+// (codegen.go): has() must flip to false right after delete(), and the same
+// key must be insertable again afterward.
+func TestMapHasAfterDeleteThenReinsert(t *testing.T) {
+	got := runProg(t,
+		`func main() { m := make(map[string]int) m["a"] = 1 delete(m, "a") println(has(m, "a")) m["a"] = 2 println(has(m, "a"), m["a"]) }`)
+	if want := "false\ntrue 2\n"; got != want {
+		t.Fatalf("map has/delete/reinsert: got %q, want %q", got, want)
+	}
+}
+
+// TestMapHasOnEmptyMap covers mfl_map_has (codegen.go) on a just-created,
+// never-populated map.
+func TestMapHasOnEmptyMap(t *testing.T) {
+	got := runProg(t,
+		`func main() { m := make(map[int]int) println(has(m, 0), len(m)) }`)
+	if want := "false 0\n"; got != want {
+		t.Fatalf("map has on empty map: got %q, want %q", got, want)
+	}
+}
+
+// TestContainsEdgeCases covers mfl_contains (codegen.go, strstr-backed):
+// an empty needle always matches, the whole string matches itself, an
+// absent substring doesn't match, and matching is case-sensitive.
+func TestContainsEdgeCases(t *testing.T) {
+	got := runNative(t, `func main(){
+		println(contains("hello", ""))
+		println(contains("hello", "hello"))
+		println(contains("hello", "zz"))
+		println(contains("hello", "HELLO"))
+	}`)
+	if want := "true\ntrue\nfalse\nfalse\n"; got != want {
+		t.Fatalf("contains edge cases: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thor4s`

## Summary

Added two new test files covering previously-untested edge cases in codegen.go's C runtime builtins. bytes_bounds_edge_test.go covers byte_at/bytes_sub/bytes_index out-of-range and negative-index clamping, from_hex's separator-skipping and odd-length-nibble truncation, and bytes_concat/to_hex zero-length buffer handling. map_contains_edge_test.go covers mfl_map_del's no-op-on-nonexistent/double-delete safety (verified this guard is load-bearing: removing it causes a segfault), has()/delete()/reinsert sequencing, has() on an empty map, and mfl_contains (strstr) empty/whole/absent/case-sensitive matching. No production code was changed — nine new tests were added, all passing.

**Diff:**
```
bytes_bounds_edge_test.go | 70 +++++++++++++++++++++++++++++++++++++++++++++++
 map_contains_edge_test.go | 50 +++++++++++++++++++++++++++++++++
 2 files changed, 120 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added edge-case coverage for byte helper behavior, including out-of-range access, slice boundaries, hex parsing, empty results, and concatenation output.
  * Added map and string-search tests covering missing-key deletes, delete/reinsert flows, empty maps, and `contains` behavior for empty, exact, absent, and case-sensitive matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->