### PR TITLE
test(transform): cover localNames/collectDeclared/freeIdents closure-lift helpers

### DIFF
--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -87,3 +87,72 @@ func TestCopyIntMap(t *testing.T) {
 		t.Fatalf("copyIntMap(nil) = %v, want empty map", empty)
 	}
 }
+
+func TestSigCompleteParams(t *testing.T) {
+	if got := sigCompleteParams(nil); len(got) != 0 {
+		t.Fatalf("sigCompleteParams(nil) = %v, want empty", got)
+	}
+	if got := sigCompleteParams(&FuncDecl{}); len(got) != 0 {
+		t.Fatalf("sigCompleteParams(empty body) = %v, want empty", got)
+	}
+
+	// Last statement isn't a send: no param is signal-complete.
+	notSend := &FuncDecl{Params: []string{"ch"}, Body: []Stmt{&ExprStmt{X: &Ident{Name: "ch"}}}}
+	if got := sigCompleteParams(notSend); len(got) != 0 {
+		t.Fatalf("sigCompleteParams(no trailing send) = %v, want empty", got)
+	}
+
+	// Last statement sends on a param: that param's index is marked complete.
+	fn := &FuncDecl{
+		Params: []string{"a", "ch", "b"},
+		Body: []Stmt{
+			&AssignStmt{Name: "x", Op: ":=", Val: &Ident{Name: "a"}},
+			&SendStmt{Ch: &Ident{Name: "ch"}, Val: &Ident{Name: "x"}},
+		},
+	}
+	got := sigCompleteParams(fn)
+	if !got[1] || len(got) != 1 {
+		t.Fatalf("sigCompleteParams(%v) = %v, want {1: true}", fn, got)
+	}
+
+	// Sending on a non-param channel expression yields no matches.
+	notParam := &FuncDecl{
+		Params: []string{"a"},
+		Body:   []Stmt{&SendStmt{Ch: &Ident{Name: "other"}, Val: &Ident{Name: "a"}}},
+	}
+	if got := sigCompleteParams(notParam); len(got) != 0 {
+		t.Fatalf("sigCompleteParams(send on non-param) = %v, want empty", got)
+	}
+}
+
+func TestRecvChanName(t *testing.T) {
+	name, ok := recvChanName(&Recv{Ch: &Ident{Name: "ch"}})
+	if !ok || name != "ch" {
+		t.Fatalf("recvChanName(<-ch) = (%q, %v), want (\"ch\", true)", name, ok)
+	}
+
+	if _, ok := recvChanName(&Ident{Name: "notarecv"}); ok {
+		t.Fatalf("recvChanName(non-Recv expr) should return ok=false")
+	}
+
+	if _, ok := recvChanName(&Recv{Ch: &Call{Callee: "getch"}}); ok {
+		t.Fatalf("recvChanName(<-getch()) should return ok=false: channel isn't a bare ident")
+	}
+}
+
+func TestBlockOf(t *testing.T) {
+	then := []Stmt{&AssignStmt{Name: "a", Op: ":=", Val: &Ident{Name: "1"}}}
+	els := []Stmt{&AssignStmt{Name: "b", Op: ":=", Val: &Ident{Name: "2"}}}
+	if body, ok := blockOf(&IfStmt{Then: then, Else: els}); !ok || len(body) != 2 {
+		t.Fatalf("blockOf(IfStmt) = (%v, %v), want 2 combined stmts", body, ok)
+	}
+
+	whileBody := []Stmt{&AssignStmt{Name: "c", Op: ":=", Val: &Ident{Name: "3"}}}
+	if body, ok := blockOf(&WhileStmt{Body: whileBody}); !ok || len(body) != 1 {
+		t.Fatalf("blockOf(WhileStmt) = (%v, %v), want its body", body, ok)
+	}
+
+	if _, ok := blockOf(&ReturnStmt{}); ok {
+		t.Fatalf("blockOf(ReturnStmt) should return ok=false: not a block-bearing stmt")
+	}
+}

--- a/tighten_test.go
+++ b/tighten_test.go
@@ -26,6 +26,23 @@ func TestTighten(t *testing.T) {
 	}
 }
 
+// normalize joins a multi-line function into one canonical line: blank lines
+// and line comments drop, real lines join with a single space, and the result
+// is tightened. It must not treat `//` inside a string literal as a comment.
+func TestNormalize(t *testing.T) {
+	src := "func add(a, b) {\n" +
+		"    // adds two numbers\n" +
+		"    sum := a + b\n" +
+		"\n" +
+		`    println("a//b")` + "\n" +
+		"    return sum\n" +
+		"}"
+	want := `func add(a,b){sum:=a+b println("a//b")return sum}`
+	if got := normalize(src); got != want {
+		t.Errorf("normalize(%q) = %q, want %q", src, got, want)
+	}
+}
+
 // Every committed example is already in canonical (tight) form: tighten is a
 // no-op on it. This guards the repo's source of truth against drift.
 func TestExamplesAreCanonical(t *testing.T) {

--- a/transform_test.go
+++ b/transform_test.go
@@ -1,0 +1,113 @@
+package main
+
+import "testing"
+
+func TestLocalNames(t *testing.T) {
+	body := []Stmt{
+		&AssignStmt{Name: "x", Op: ":=", Val: &Ident{Name: "y"}},
+		&MultiAssign{Names: []string{"a", "_", "b"}, Op: ":=", Rhs: []Expr{&Ident{Name: "z"}}},
+		&IfStmt{
+			Cond: &Ident{Name: "cond"},
+			Then: []Stmt{&AssignStmt{Name: "inner", Op: ":=", Val: &Ident{Name: "w"}}},
+		},
+	}
+	got := localNames([]string{"p", "q"}, body)
+	want := []string{"p", "q", "x", "a", "b", "inner"}
+	for _, n := range want {
+		if !got[n] {
+			t.Errorf("localNames missing %q: %v", n, got)
+		}
+	}
+	if got["_"] {
+		t.Errorf("localNames must not bind the blank identifier")
+	}
+	if got["z"] {
+		t.Errorf("localNames must not bind rhs-only identifiers")
+	}
+}
+
+func TestCollectDeclaredNestedFuncLitNotRecursed(t *testing.T) {
+	// collectDeclared must not descend into a nested FuncLit's own body — it has
+	// no case for *FuncLit, so a := inside it must not leak into the outer set.
+	body := []Stmt{
+		&AssignStmt{Name: "outer", Op: ":=", Val: &FuncLit{
+			Params: []string{"n"},
+			Body:   []Stmt{&AssignStmt{Name: "leaked", Op: ":=", Val: &Ident{Name: "n"}}},
+		}},
+	}
+	set := map[string]bool{}
+	collectDeclared(body, set)
+	if !set["outer"] {
+		t.Errorf("expected outer to be declared: %v", set)
+	}
+	if set["leaked"] {
+		t.Errorf("collectDeclared must not recurse into nested FuncLit bodies: %v", set)
+	}
+}
+
+func TestCollectDeclaredRangeKeyValAndPlainWhile(t *testing.T) {
+	body := []Stmt{
+		&RangeStmt{Key: "i", Val: "_", X: &Ident{Name: "xs"}, Body: []Stmt{
+			&AssignStmt{Name: "sq", Op: ":=", Val: &Ident{Name: "i"}},
+		}},
+		&WhileStmt{Cond: &Ident{Name: "cond"}, Body: []Stmt{
+			&AssignStmt{Name: "acc", Op: ":=", Val: &Ident{Name: "i"}},
+		}},
+	}
+	set := map[string]bool{}
+	collectDeclared(body, set)
+	for _, n := range []string{"i", "sq", "acc"} {
+		if !set[n] {
+			t.Errorf("expected %q declared: %v", n, set)
+		}
+	}
+	if set["_"] {
+		t.Errorf("collectDeclared must not bind the blank range value")
+	}
+}
+
+func TestFreeIdentsCapturesOuterOnly(t *testing.T) {
+	// A lambda referencing its own param, its own local, and an outer name: only
+	// the outer name should come back free.
+	body := []Stmt{
+		&AssignStmt{Name: "local", Op: ":=", Val: &Ident{Name: "n"}},
+		&ReturnStmt{Vals: []Expr{
+			&Binary{Op: "+", L: &Ident{Name: "local"}, R: &Ident{Name: "outer"}},
+		}},
+	}
+	free := freeIdents(body, []string{"n"})
+	if free["n"] || free["local"] {
+		t.Errorf("freeIdents must not free bound params/locals: %v", free)
+	}
+	if !free["outer"] {
+		t.Errorf("freeIdents must free references to outer names: %v", free)
+	}
+}
+
+func TestFreeIdentsCallCalleeCapturedWhenNotBound(t *testing.T) {
+	// A Call's Callee is treated as a potential captured closure variable unless
+	// it is bound locally — this lets `fn()` capture a param/local named fn.
+	body := []Stmt{
+		&ExprStmt{X: &Call{Callee: "fn", Args: []Expr{&Ident{Name: "n"}}}},
+	}
+	free := freeIdents(body, []string{"n"})
+	if !free["fn"] {
+		t.Errorf("expected unbound call callee %q to be free: %v", "fn", free)
+	}
+	if free["n"] {
+		t.Errorf("bound param must not be free: %v", free)
+	}
+}
+
+func TestFreeIdentsNestedFuncLitRecursion(t *testing.T) {
+	// A free identifier inside a nested lambda that isn't bound by either lambda
+	// must propagate up as free.
+	inner := &FuncLit{Params: []string{}, Body: []Stmt{
+		&ReturnStmt{Vals: []Expr{&Ident{Name: "captured"}}},
+	}}
+	body := []Stmt{&ReturnStmt{Vals: []Expr{inner}}}
+	free := freeIdents(body, []string{})
+	if !free["captured"] {
+		t.Errorf("expected nested lambda's free identifier to propagate up: %v", free)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thori4`

## Summary

Added focused unit tests for previously-untested pure Go helper functions in the compiler: closure-lifting helpers (localNames/collectDeclared/freeIdents in transform.go), the normalize() line-join/comment-strip helper in main.go, and race-detector helpers (sigCompleteParams/recvChanName/blockOf in racecheck.go). These functions were only covered indirectly via full compile/run tests before; the new tests pin down edge cases like blank-identifier exclusion, non-recursion into nested closures, and non-ident channel expressions. No production code changed; full test suite (`go test ./...`) passes.

**Diff:**
```
racecheck_helpers_test.go |  69 ++++++++++++++++++++++++++++
 tighten_test.go           |  17 +++++++
 transform_test.go         | 113 ++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 199 insertions(+)
```
