### PR TITLE
test(build): cover gunzip round-trip and ccPath/zigPath env overrides

### DIFF
--- a/build_helpers_test.go
+++ b/build_helpers_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"os"
+	"testing"
+)
+
+// TestGunzip covers the round trip (data survives compress/decompress) and the
+// error path (gunzip must reject non-gzip input rather than panic or hang).
+func TestGunzip(t *testing.T) {
+	want := []byte("hello from the sqlite amalgamation embed, repeated repeated repeated")
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(want); err != nil {
+		t.Fatalf("gzip.Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip.Close: %v", err)
+	}
+
+	got, err := gunzip(buf.Bytes())
+	if err != nil {
+		t.Fatalf("gunzip: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("gunzip round trip: got %q, want %q", got, want)
+	}
+
+	if _, err := gunzip([]byte("not gzip data")); err == nil {
+		t.Fatal("gunzip: expected an error for non-gzip input, got nil")
+	}
+}
+
+// TestCCPath covers both branches of ccPath: the CC env override and the "cc"
+// fallback used when CC is unset.
+func TestCCPath(t *testing.T) {
+	old, hadOld := os.LookupEnv("CC")
+	t.Cleanup(func() {
+		if hadOld {
+			os.Setenv("CC", old)
+		} else {
+			os.Unsetenv("CC")
+		}
+	})
+
+	os.Unsetenv("CC")
+	if got := ccPath(); got != "cc" {
+		t.Fatalf("ccPath with CC unset: got %q, want %q", got, "cc")
+	}
+
+	os.Setenv("CC", "musl-gcc")
+	if got := ccPath(); got != "musl-gcc" {
+		t.Fatalf("ccPath with CC=musl-gcc: got %q, want %q", got, "musl-gcc")
+	}
+}
+
+// TestZigPath covers both branches of zigPath: the ZIG env override and the
+// "zig" fallback used when ZIG is unset.
+func TestZigPath(t *testing.T) {
+	old, hadOld := os.LookupEnv("ZIG")
+	t.Cleanup(func() {
+		if hadOld {
+			os.Setenv("ZIG", old)
+		} else {
+			os.Unsetenv("ZIG")
+		}
+	})
+
+	os.Unsetenv("ZIG")
+	if got := zigPath(); got != "zig" {
+		t.Fatalf("zigPath with ZIG unset: got %q, want %q", got, "zig")
+	}
+
+	os.Setenv("ZIG", "/opt/zig/zig")
+	if got := zigPath(); got != "/opt/zig/zig" {
+		t.Fatalf("zigPath with ZIG=/opt/zig/zig: got %q, want %q", got, "/opt/zig/zig")
+	}
+}

--- a/check.go
+++ b/check.go
@@ -250,7 +250,12 @@ func seedStructNames(decl string, structs map[string]bool) {
 		return
 	}
 	for i := 0; i+1 < len(toks); i++ {
-		if toks[i].Kind == TKeyword && (toks[i].Val == "type" || toks[i].Val == "cstruct") && toks[i+1].Kind == TIdent {
+		// "type" is a lexer keyword, but "cstruct" is only a soft keyword (parsed
+		// contextually inside `extern` blocks — see isExternKeyword) and so is
+		// always lexed as a plain identifier, never TKeyword.
+		isType := toks[i].Kind == TKeyword && toks[i].Val == "type"
+		isCstruct := toks[i].Kind == TIdent && toks[i].Val == "cstruct"
+		if (isType || isCstruct) && toks[i+1].Kind == TIdent {
 			structs[toks[i+1].Val] = true
 		}
 	}

--- a/check_helpers_test.go
+++ b/check_helpers_test.go
@@ -1,0 +1,109 @@
+package main
+
+import "testing"
+
+// TestDeclName covers declName's three declaration shapes: plain, exported,
+// and a decl with no ident (which must fall back to "").
+func TestDeclName(t *testing.T) {
+	cases := []struct{ decl, want string }{
+		{`func add(a int, b int) int { return a + b }`, "add"},
+		{`export func mul(a int, b int) int { return a * b }`, "mul"},
+		{`type Point struct { x int y int }`, "Point"},
+		{`var count int`, "count"},
+		{``, ""},
+	}
+	for _, c := range cases {
+		if got := declName(c.decl); got != c.want {
+			t.Errorf("declName(%q): got %q, want %q", c.decl, got, c.want)
+		}
+	}
+}
+
+// TestFirstMeaningfulLine covers blank/comment-line skipping and the
+// long-line truncation branch.
+func TestFirstMeaningfulLine(t *testing.T) {
+	got := firstMeaningfulLine("\n  \n// a comment\nfunc main() {}\n")
+	if want := "func main() {}"; got != want {
+		t.Errorf("firstMeaningfulLine: got %q, want %q", got, want)
+	}
+
+	if got := firstMeaningfulLine("\n  \n// only comments\n"); got != "" {
+		t.Errorf("firstMeaningfulLine on all-blank/comment input: got %q, want \"\"", got)
+	}
+
+	long := ""
+	for i := 0; i < 130; i++ {
+		long += "x"
+	}
+	got = firstMeaningfulLine(long)
+	if len(got) != 120 {
+		t.Errorf("firstMeaningfulLine truncation: got len %d, want 120", len(got))
+	}
+	if got[117:] != "..." {
+		t.Errorf("firstMeaningfulLine truncation: got suffix %q, want \"...\"", got[117:])
+	}
+}
+
+// TestSeedStructNames covers both type and cstruct declarations, and that
+// unrelated declarations don't seed anything.
+func TestSeedStructNames(t *testing.T) {
+	structs := map[string]bool{}
+	seedStructNames(`type Point struct { x int y int }`, structs)
+	seedStructNames(`cstruct div_t { quot i32 rem i32 }`, structs)
+	seedStructNames(`func add(a int, b int) int { return a + b }`, structs)
+
+	if !structs["Point"] {
+		t.Error("seedStructNames: expected \"Point\" to be seeded from a type decl")
+	}
+	if !structs["div_t"] {
+		t.Error("seedStructNames: expected \"div_t\" to be seeded from a cstruct decl")
+	}
+	if len(structs) != 2 {
+		t.Errorf("seedStructNames: got %d entries, want 2 (func decl must not seed anything): %v", len(structs), structs)
+	}
+}
+
+// TestCheckCstructLiteral is a regression test for a bug where seedStructNames
+// required `cstruct` to be lexed as TKeyword, which it never is (it's only a
+// soft keyword recognized inside `extern` blocks — see isExternKeyword in
+// parser.go). That made `machin check` falsely report a parse error for any
+// program constructing a cstruct literal (e.g. `div_t{...}`), even though the
+// same program built fine via the real ParseProgram path.
+func TestCheckCstructLiteral(t *testing.T) {
+	src := `
+extern "c" {
+    header "stdlib.h"
+    cstruct div_t { quot i32 rem i32 }
+    fn div(i32, i32) div_t
+}
+
+func main() {
+    d := div_t{quot: 1, rem: 2}
+    println(d.quot)
+}
+`
+	res := analyzeSource(src, []string{"probe.mfl"})
+	if !res.OK {
+		t.Fatalf("analyzeSource on a valid cstruct-literal program: got errors %+v, want OK", res.Diagnostics)
+	}
+}
+
+// TestLocateCheckError covers the match and no-match paths: a message quoting
+// a declared name resolves to that decl's line, otherwise ("", 0).
+func TestLocateCheckError(t *testing.T) {
+	decls := []string{
+		`func add(a int, b int) int { return a + b }`,
+		`func mul(a int, b int) int { return a * b }`,
+	}
+	lines := []int{10, 20}
+
+	name, line := locateCheckError(`function "mul" has a type error`, decls, lines)
+	if name != "mul" || line != 20 {
+		t.Errorf("locateCheckError: got (%q, %d), want (\"mul\", 20)", name, line)
+	}
+
+	name, line = locateCheckError(`function "unknown" has a type error`, decls, lines)
+	if name != "" || line != 0 {
+		t.Errorf("locateCheckError with no matching decl: got (%q, %d), want (\"\", 0)", name, line)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thorys`

**Diff:**
```
build_helpers_test.go |  80 ++++++++++++++++++++++++++++++++++++
 check.go              |   7 +++-
 check_helpers_test.go | 109 ++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 195 insertions(+), 1 deletion(-)
```
