### PR TITLE
test(types): cover splitMapType and reconcile helpers

### DIFF
--- a/funcarity_test.go
+++ b/funcarity_test.go
@@ -1,0 +1,66 @@
+package main
+
+import "testing"
+
+func TestReturnArity(t *testing.T) {
+	cases := []struct {
+		name string
+		body []Stmt
+		want int
+	}{
+		{"empty body", nil, 0},
+		{"bare return", []Stmt{&ReturnStmt{}}, 0},
+		{"direct return with values", []Stmt{&ReturnStmt{Vals: []Expr{nil, nil}}}, 2},
+		{
+			"nested in if-then",
+			[]Stmt{&IfStmt{Then: []Stmt{&ReturnStmt{Vals: []Expr{nil}}}}},
+			1,
+		},
+		{
+			"nested in if-else",
+			[]Stmt{&IfStmt{Else: []Stmt{&ReturnStmt{Vals: []Expr{nil, nil, nil}}}}},
+			3,
+		},
+		{
+			"nested in while",
+			[]Stmt{&WhileStmt{Body: []Stmt{&ReturnStmt{Vals: []Expr{nil}}}}},
+			1,
+		},
+		{
+			"nested in range",
+			[]Stmt{&RangeStmt{Body: []Stmt{&ReturnStmt{Vals: []Expr{nil, nil}}}}},
+			2,
+		},
+		{
+			"nested in arena",
+			[]Stmt{&ArenaStmt{Body: []Stmt{&ReturnStmt{Vals: []Expr{nil}}}}},
+			1,
+		},
+	}
+	for _, c := range cases {
+		if got := returnArity(c.body); got != c.want {
+			t.Errorf("%s: returnArity() = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFuncArity(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   *FuncDecl
+		want int
+	}{
+		{"named returns win", &FuncDecl{Returns: []string{"a", "b"}}, 2},
+		{
+			"falls back to inferred body arity",
+			&FuncDecl{Body: []Stmt{&ReturnStmt{Vals: []Expr{nil, nil, nil}}}},
+			3,
+		},
+		{"no returns at all", &FuncDecl{}, 0},
+	}
+	for _, c := range cases {
+		if got := funcArity(c.fn); got != c.want {
+			t.Errorf("%s: funcArity() = %d, want %d", c.name, got, c.want)
+		}
+	}
+}

--- a/types_helpers_test.go
+++ b/types_helpers_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitMapType(t *testing.T) {
+	cases := []struct {
+		in      string
+		key     string
+		val     string
+		wantErr bool
+	}{
+		{"map[int]string", "int", "string", false},
+		{"map[string]map[int]bool", "string", "map[int]bool", false},
+		{"map[map[int]string]bool", "map[int]string", "bool", false},
+		{"map[int", "", "", true},
+	}
+	for _, c := range cases {
+		kt, vt, err := splitMapType(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("splitMapType(%q): expected error, got nil", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("splitMapType(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if kt != c.key || vt != c.val {
+			t.Errorf("splitMapType(%q) = (%q, %q), want (%q, %q)", c.in, kt, vt, c.key, c.val)
+		}
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	cases := []struct {
+		a, b    Kind
+		want    Kind
+		wantErr bool
+	}{
+		{KInt, KInt, KInt, false},
+		{KVar, KString, KString, false},
+		{KFloat, KVar, KFloat, false},
+		{KNum, KInt, KInt, false},
+		{KFloat, KNum, KFloat, false},
+		{KSlice, KSlice, KSlice, false},
+		{KStruct, KStruct, KStruct, false},
+		{KChan, KChan, KChan, false},
+		{KMap, KMap, KMap, false},
+		{KFunc, KFunc, KFunc, false},
+		{KInt, KString, KVar, true},
+	}
+	for _, c := range cases {
+		got, err := reconcile(c.a, c.b)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("reconcile(%v, %v): expected error, got nil", c.a, c.b)
+			} else if !strings.Contains(err.Error(), "type mismatch") {
+				t.Errorf("reconcile(%v, %v): unexpected error message: %v", c.a, c.b, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("reconcile(%v, %v): unexpected error: %v", c.a, c.b, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("reconcile(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/types_helpers_test.go
+++ b/types_helpers_test.go
@@ -5,6 +5,52 @@ import (
 	"testing"
 )
 
+func TestKindString(t *testing.T) {
+	cases := []struct {
+		k    Kind
+		want string
+	}{
+		{KVar, "var"},
+		{KNum, "num"},
+		{KInt, "int"},
+		{KFloat, "float"},
+		{KBool, "bool"},
+		{KString, "string"},
+		{KVoid, "void"},
+		{KSlice, "slice"},
+		{KStruct, "struct"},
+		{KChan, "chan"},
+		{KMap, "map"},
+		{KFunc, "func"},
+		{KBytes, "bytes"},
+		{Kind(999), "?"},
+	}
+	for _, c := range cases {
+		if got := c.k.String(); got != c.want {
+			t.Errorf("Kind(%d).String() = %q, want %q", c.k, got, c.want)
+		}
+	}
+}
+
+func TestIsNumeric(t *testing.T) {
+	cases := []struct {
+		k    Kind
+		want bool
+	}{
+		{KInt, true},
+		{KFloat, true},
+		{KNum, true},
+		{KBool, false},
+		{KString, false},
+		{KVar, false},
+	}
+	for _, c := range cases {
+		if got := isNumeric(c.k); got != c.want {
+			t.Errorf("isNumeric(%v) = %v, want %v", c.k, got, c.want)
+		}
+	}
+}
+
 func TestSplitMapType(t *testing.T) {
 	cases := []struct {
 		in      string


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thosfg`

## Summary

Added unit tests for several previously-uncovered pure helper functions in types.go: splitMapType (nested map type parsing + malformed input), reconcile (Kind unification branches including the mismatch error path), returnArity/funcArity (return-count inference through if/while/range/arena nesting), and Kind.String()/isNumeric. These are small, low-risk, self-contained test-only additions that raise coverage on the type-checker's core inference helpers without touching any implementation code.

**Diff:**
```
funcarity_test.go     |  66 +++++++++++++++++++++++++++
 types_helpers_test.go | 120 ++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 186 insertions(+)
```
