### PR TITLE
test(racecheck): cover placeOf and mergeGAcc helpers

### DIFF
--- a/check_helpers_test.go
+++ b/check_helpers_test.go
@@ -107,3 +107,45 @@ func TestLocateCheckError(t *testing.T) {
 		t.Errorf("locateCheckError with no matching decl: got (%q, %d), want (\"\", 0)", name, line)
 	}
 }
+
+// TestSplitFunctionsLoc covers splitting multiple decls with leading blank/comment
+// lines (skipped from the start-line count), a brace inside a string literal (must
+// not affect depth tracking), and the unbalanced-braces error path.
+func TestSplitFunctionsLoc(t *testing.T) {
+	src := "\n// leading comment\nfunc add(a int, b int) int {\n    return a + b\n}\nfunc greet() string {\n    return \"a { b\"\n}\n"
+	funcs, lines, err := splitFunctionsLoc(src)
+	if err != nil {
+		t.Fatalf("splitFunctionsLoc: unexpected error: %v", err)
+	}
+	if len(funcs) != 2 || len(lines) != 2 {
+		t.Fatalf("splitFunctionsLoc: got %d funcs / %d lines, want 2/2: %+v %+v", len(funcs), len(lines), funcs, lines)
+	}
+	if lines[0] != 3 {
+		t.Errorf("splitFunctionsLoc: first func start line = %d, want 3 (blank/comment lines skipped)", lines[0])
+	}
+	if lines[1] != 6 {
+		t.Errorf("splitFunctionsLoc: second func start line = %d, want 6", lines[1])
+	}
+
+	if _, _, err := splitFunctionsLoc("func add(a int, b int) int {\n    return a + b\n"); err == nil {
+		t.Error("splitFunctionsLoc on unbalanced braces: expected an error, got nil")
+	}
+}
+
+// TestParseOneDecl covers routing by leading keyword (type/extern/var/func) and
+// that a parse error on any branch is propagated.
+func TestParseOneDecl(t *testing.T) {
+	structs := map[string]bool{}
+	if err := parseOneDecl(`type Point struct { x int y int }`, structs); err != nil {
+		t.Errorf("parseOneDecl(type): unexpected error: %v", err)
+	}
+	if err := parseOneDecl(`var count = 0`, structs); err != nil {
+		t.Errorf("parseOneDecl(var): unexpected error: %v", err)
+	}
+	if err := parseOneDecl(`func add(a, b) { return a + b }`, structs); err != nil {
+		t.Errorf("parseOneDecl(func): unexpected error: %v", err)
+	}
+	if err := parseOneDecl(`func add(a, b) { return a + `, structs); err == nil {
+		t.Error("parseOneDecl on malformed func: expected an error, got nil")
+	}
+}

--- a/codegen_helpers_test.go
+++ b/codegen_helpers_test.go
@@ -1,0 +1,89 @@
+package main
+
+import "testing"
+
+func TestCTypeName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"int", "int64_t"},
+		{"float", "double"},
+		{"bool", "int"},
+		{"string", "char*"},
+		{"func", "mfl_closure"},
+		{"[]int", "mfl_slice"},
+		{"map[string]int", "mfl_map*"},
+		{"chan int", "mfl_chan*"},
+		{"Point", "mfl_Point"},
+	}
+	for _, tt := range tests {
+		if got := cTypeName(tt.in); got != tt.want {
+			t.Errorf("cTypeName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCZero(t *testing.T) {
+	tests := []struct {
+		k    Kind
+		want string
+	}{
+		{KInt, "0"},
+		{KBool, "0"},
+		{KFloat, "0.0"},
+		{KString, "\"\""},
+		{KSlice, "{0}"},
+		{KStruct, "{0}"},
+		{KFunc, "{0}"},
+		{KBytes, "{0}"},
+	}
+	for _, tt := range tests {
+		if got := cZero(tt.k); got != tt.want {
+			t.Errorf("cZero(%v) = %q, want %q", tt.k, got, tt.want)
+		}
+	}
+}
+
+func TestPrependEach(t *testing.T) {
+	if got := prependEach(", ", nil); got != "" {
+		t.Errorf("prependEach(sep, nil) = %q, want \"\"", got)
+	}
+	if got := prependEach(", ", []string{}); got != "" {
+		t.Errorf("prependEach(sep, empty) = %q, want \"\"", got)
+	}
+	if got := prependEach(", ", []string{"a"}); got != ", a" {
+		t.Errorf("prependEach(sep, [a]) = %q, want \", a\"", got)
+	}
+	if got := prependEach(", ", []string{"a", "b"}); got != ", a, b" {
+		t.Errorf("prependEach(sep, [a,b]) = %q, want \", a, b\"", got)
+	}
+}
+
+func TestExprHasSideEffect(t *testing.T) {
+	tests := []struct {
+		name string
+		e    Expr
+		want bool
+	}{
+		{"call", &Call{Callee: "f"}, true},
+		{"recv", &Recv{Ch: &Ident{Name: "ch"}}, true},
+		{"plain ident", &Ident{Name: "x"}, false},
+		{"unary of pure", &Unary{Op: "-", X: &Ident{Name: "x"}}, false},
+		{"unary of call", &Unary{Op: "-", X: &Call{Callee: "f"}}, true},
+		{"binary of pure operands", &Binary{Op: "+", L: &Ident{Name: "x"}, R: &Ident{Name: "y"}}, false},
+		{"binary with impure operand", &Binary{Op: "+", L: &Ident{Name: "x"}, R: &Call{Callee: "f"}}, true},
+		{"index pure", &Index{X: &Ident{Name: "a"}, Idx: &Ident{Name: "i"}}, false},
+		{"index with impure idx", &Index{X: &Ident{Name: "a"}, Idx: &Call{Callee: "f"}}, true},
+		{"field access pure", &FieldAccess{X: &Ident{Name: "p"}, Name: "x"}, false},
+		{"field access impure", &FieldAccess{X: &Call{Callee: "f"}, Name: "x"}, true},
+		{"slice lit pure", &SliceLit{Elems: []Expr{&Ident{Name: "a"}, &Ident{Name: "b"}}}, false},
+		{"slice lit impure element", &SliceLit{Elems: []Expr{&Ident{Name: "a"}, &Call{Callee: "f"}}}, true},
+		{"struct lit pure", &StructLit{Type: "P", Vals: []Expr{&Ident{Name: "a"}}}, false},
+		{"struct lit impure", &StructLit{Type: "P", Vals: []Expr{&Call{Callee: "f"}}}, true},
+	}
+	for _, tt := range tests {
+		if got := exprHasSideEffect(tt.e); got != tt.want {
+			t.Errorf("%s: exprHasSideEffect() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -156,3 +156,59 @@ func TestBlockOf(t *testing.T) {
 		t.Fatalf("blockOf(ReturnStmt) should return ok=false: not a block-bearing stmt")
 	}
 }
+
+func TestPlaceOf(t *testing.T) {
+	root, path, ok := placeOf(&Ident{Name: "x"})
+	if !ok || root != "x" || path != nil {
+		t.Fatalf("placeOf(Ident) = (%q, %v, %v), want (\"x\", nil, true)", root, path, ok)
+	}
+
+	root, path, ok = placeOf(&Index{X: &Ident{Name: "arr"}, Idx: &Ident{Name: "i"}})
+	if !ok || root != "arr" || !pathEq(path, accPath{{field: ""}}) {
+		t.Fatalf("placeOf(Index) = (%q, %v, %v), want (\"arr\", [index], true)", root, path, ok)
+	}
+
+	root, path, ok = placeOf(&FieldAccess{X: &Ident{Name: "p"}, Name: "y"})
+	if !ok || root != "p" || !pathEq(path, accPath{{field: "y"}}) {
+		t.Fatalf("placeOf(FieldAccess) = (%q, %v, %v), want (\"p\", [.y], true)", root, path, ok)
+	}
+
+	root, path, ok = placeOf(&FieldAccess{X: &Index{X: &Ident{Name: "s"}, Idx: &Ident{Name: "0"}}, Name: "z"})
+	if !ok || root != "s" || !pathEq(path, accPath{{field: ""}, {field: "z"}}) {
+		t.Fatalf("placeOf(nested Index.Field) = (%q, %v, %v), want (\"s\", [index,.z], true)", root, path, ok)
+	}
+
+	if _, _, ok := placeOf(&Call{Callee: "f"}); ok {
+		t.Fatalf("placeOf(Call) should return ok=false: not a place expression")
+	}
+
+	if _, _, ok := placeOf(&FieldAccess{X: &Call{Callee: "f"}, Name: "y"}); ok {
+		t.Fatalf("placeOf(FieldAccess on non-place) should return ok=false")
+	}
+}
+
+func TestMergeGAcc(t *testing.T) {
+	m := map[string]*gAccess{}
+
+	if changed := mergeGAcc(m, "g", &gAccess{read: true, write: false}); !changed {
+		t.Fatalf("mergeGAcc(new entry) should report changed=true")
+	}
+	if got := m["g"]; !got.read || got.write {
+		t.Fatalf("m[g] = %+v, want {read:true write:false}", got)
+	}
+
+	if changed := mergeGAcc(m, "g", &gAccess{read: true, write: false}); changed {
+		t.Fatalf("mergeGAcc(no new bits) should report changed=false")
+	}
+
+	if changed := mergeGAcc(m, "g", &gAccess{read: false, write: true}); !changed {
+		t.Fatalf("mergeGAcc(adding write) should report changed=true")
+	}
+	if got := m["g"]; !got.read || !got.write {
+		t.Fatalf("m[g] = %+v, want {read:true write:true}", got)
+	}
+
+	if changed := mergeGAcc(m, "g", &gAccess{read: true, write: true}); changed {
+		t.Fatalf("mergeGAcc(already set bits) should report changed=false")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thospg`

## Summary

Adds unit test coverage for several previously-untested pure helper functions: the data-race detector's `placeOf`/`mergeGAcc` (racecheck_helpers_test.go), the C codegen's `cTypeName`/`cZero`/`prependEach`/`exprHasSideEffect` (new codegen_helpers_test.go), and the type-checker's `splitFunctionsLoc`/`parseOneDecl` (check_helpers_test.go). These are small, isolated additions with no behavior changes — purely closing coverage gaps on internal helpers that other tests exercise only indirectly.

**Diff:**
```
check_helpers_test.go     | 42 ++++++++++++++++++++++
 codegen_helpers_test.go   | 89 +++++++++++++++++++++++++++++++++++++++++++++++
 racecheck_helpers_test.go | 56 +++++++++++++++++++++++++++++
 3 files changed, 187 insertions(+)
```
