### PR TITLE
test(main): cover raceGate clean/type-error/race-found paths

### DIFF
--- a/callbacktype_test.go
+++ b/callbacktype_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// isCallbackType/parseCallbackType were only exercised indirectly through
+// callbackCType; these lock in the "cb(t1,t2)ret" encoding directly.
+func TestIsCallbackType(t *testing.T) {
+	if !isCallbackType("cb(int)") {
+		t.Error(`isCallbackType("cb(int)") = false, want true`)
+	}
+	if !isCallbackType("cb()") {
+		t.Error(`isCallbackType("cb()") = false, want true`)
+	}
+	if isCallbackType("int") {
+		t.Error(`isCallbackType("int") = true, want false`)
+	}
+	if isCallbackType("") {
+		t.Error(`isCallbackType("") = true, want false`)
+	}
+}
+
+func TestParseCallbackType(t *testing.T) {
+	cases := []struct {
+		enc        string
+		wantParams []string
+		wantRet    string
+	}{
+		{"cb()", nil, ""},
+		{"cb()int", nil, "int"},
+		{"cb(int)", []string{"int"}, ""},
+		{"cb(int,f32)i8", []string{"int", "f32"}, "i8"},
+	}
+	for _, c := range cases {
+		params, ret := parseCallbackType(c.enc)
+		if !reflect.DeepEqual(params, c.wantParams) || ret != c.wantRet {
+			t.Errorf("parseCallbackType(%q) = (%v, %q), want (%v, %q)",
+				c.enc, params, ret, c.wantParams, c.wantRet)
+		}
+	}
+}

--- a/loaddecls_test.go
+++ b/loaddecls_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// loadDecls had no direct test — only exercised indirectly through loadMFL.
+// Cover its three paths: plain source, packed (base64) source, and a bad
+// packed line.
+func TestLoadDecls_Plain(t *testing.T) {
+	decls, err := loadDecls("func main() { print(1) }\n")
+	if err != nil {
+		t.Fatalf("loadDecls: %v", err)
+	}
+	if len(decls) != 1 || !strings.Contains(decls[0], "print") {
+		t.Fatalf("got %+v, want one decl containing print", decls)
+	}
+}
+
+func TestLoadDecls_Packed(t *testing.T) {
+	line := base64.StdEncoding.EncodeToString([]byte("func main(){print(1)}"))
+	decls, err := loadDecls(line + "\n")
+	if err != nil {
+		t.Fatalf("loadDecls: %v", err)
+	}
+	if len(decls) != 1 || decls[0] != "func main(){print(1)}" {
+		t.Fatalf("got %+v, want decoded packed decl", decls)
+	}
+}
+
+func TestLoadDecls_BadPacked(t *testing.T) {
+	_, err := loadDecls("not-valid-base64-!!!\n")
+	if err == nil {
+		t.Fatal("loadDecls should error on an invalid packed line, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid packed") {
+		t.Fatalf("err = %v, want mention of invalid packed MFL", err)
+	}
+}

--- a/racegate_test.go
+++ b/racegate_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// raceGate had no direct test — only exercised indirectly through cmdRun/cmdBuild
+// via --race-safe. Cover its three outcomes: clean program, type error (defers to
+// the normal compile path), and a genuine race (formatted error).
+func TestRaceGate_Clean(t *testing.T) {
+	prog, err := ParseProgram([]string{"func main(){x:=1 print(x)}"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := raceGate(prog); err != nil {
+		t.Fatalf("raceGate on clean program: got %v, want nil", err)
+	}
+}
+
+func TestRaceGate_TypeError(t *testing.T) {
+	prog, err := ParseProgram([]string{"func main(){x:=undefined_fn()}"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := raceGate(prog); err != nil {
+		t.Fatalf("raceGate should defer type errors to the normal compile path, got %v", err)
+	}
+}
+
+func TestRaceGate_RaceFound(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		"func worker(xs, id){xs[id]=id*2}",
+		"func main(){data:=[]int{0,0,0,0} go worker(data,0) go worker(data,1)}",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	err = raceGate(prog)
+	if err == nil {
+		t.Fatal("raceGate should report the write/write race, got nil")
+	}
+	const want = "data race(s) detected (--race-safe): 1"
+	if got := err.Error(); !strings.Contains(got, want) {
+		t.Fatalf("raceGate error = %q, want to contain %q", got, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thot9g`

## Summary

Added direct unit test coverage for three previously untested helper functions in main.go and codegen.go: raceGate (clean/type-error/race-found paths), loadDecls (plain/packed/bad-packed-line paths), and isCallbackType/parseCallbackType. All were previously only exercised indirectly through higher-level commands or other functions. No production code was changed; full test suite (go test .) passes.

**Diff:**
```
callbacktype_test.go | 43 +++++++++++++++++++++++++++++++++++++++++++
 loaddecls_test.go    | 41 +++++++++++++++++++++++++++++++++++++++++
 racegate_test.go     | 47 +++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 131 insertions(+)
```
