### PR TITLE
fix(codegen): give closure envs and captured-var boxes independent lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Fixed a use-after-free/segfault: a `func` literal passed directly as a
+  `go` call argument (e.g. `go f(func(){ return v })`) could dangle once the
+  spawning goroutine's arena was reclaimed.** The closure's captured-env
+  struct, and any boxed param/local shared with a nested closure, were
+  allocated with the arena-scoped `mfl_alloc`/`mfl_calloc` instead of plain
+  `malloc`/`calloc` — so the closure's captured state could be corrupted or
+  crash the process once read from the spawned goroutine, after the spawner
+  returned and freed its arena. Scalar (int/bool/float) captures are now
+  arena-independent, matching how channels and maps already manage their own
+  memory; string/slice/map captures reassigned through the box remain a
+  separate, still-open gap. See #314.
+
 ## v0.106.0
 
 - **Fixed a high-severity data-corruption bug: `parse()` silently mangled

--- a/codegen.go
+++ b/codegen.go
@@ -150,7 +150,10 @@ static void* mfl_alloc(size_t sz) {
     b->size = sz; b->next = mfl_arena_cur->head; mfl_arena_cur->head = b;
     return (void*)(b + 1);
 }
-static void* mfl_calloc(size_t n, size_t sz) { void* p = mfl_alloc(n * sz); memset(p, 0, n * sz); return p; }
+/* mfl_calloc is only ever used to box a local captured by a nested closure
+   (see function() in codegen.go); that box must outlive the arena of whoever
+   declares it, so it's plain calloc, not mfl_alloc (#314). */
+static void* mfl_calloc(size_t n, size_t sz) { return calloc(n, sz); }
 static void* mfl_realloc(void* old, size_t sz) {
     void* p = mfl_alloc(sz);
     if (old) { size_t o = ((mfl_blk*)old - 1)->size; memcpy(p, old, o < sz ? o : sz); }
@@ -3050,7 +3053,10 @@ func (g *cgen) function(inst string) error {
 		name := fn.Params[i]
 		if fn.Boxed[name] {
 			ct := g.c.ParamCType(inst, i)
-			fmt.Fprintf(&g.buf, "    %s* v_%s = mfl_alloc(sizeof(%s)); *v_%s = _arg_%s;\n", ct, name, ct, name, name)
+			// malloc, not mfl_alloc: this box must outlive the arena of
+			// whichever call frame declares it, since a closure sharing it
+			// may escape that frame (e.g. via `go`) (#314).
+			fmt.Fprintf(&g.buf, "    %s* v_%s = malloc(sizeof(%s)); *v_%s = _arg_%s;\n", ct, name, ct, name, name)
 		}
 	}
 	for _, name := range g.c.Locals(inst) {
@@ -3781,7 +3787,11 @@ func (g *cgen) expr(e Expr) (string, error) {
 		id := g.tmpID
 		g.tmpID++
 		var b strings.Builder
-		fmt.Fprintf(&b, "({ %s_env* _e%d = mfl_alloc(sizeof(%s_env));", name, id, name)
+		// malloc, not mfl_alloc: the env must outlive the arena of whichever
+		// goroutine constructs this closure (e.g. a `go f(func(){...})` call
+		// captures/allocates in the spawner, which may return and free its
+		// arena before the spawned goroutine invokes the closure) (#314).
+		fmt.Fprintf(&b, "({ %s_env* _e%d = malloc(sizeof(%s_env));", name, id, name)
 		for i, cap := range ex.Captures {
 			fmt.Fprintf(&b, " _e%d->f%d = v_%s;", id, i, cap)
 		}

--- a/goroutine_closure_capture_test.go
+++ b/goroutine_closure_capture_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A closure LITERAL passed as a `go` call argument (#314) must survive the
+// spawning goroutine's arena being reclaimed, same class of bug as #310's
+// string/slice-argument hazards (see TestGoArgStringSurvivesSpawnerArena in
+// mfl_test.go). MakeClosure previously allocated its captured-env struct with
+// mfl_alloc, which is scoped to the CALLING goroutine's arena; once that arena
+// is freed (the spawner returns) the closure's `env` pointer itself dangles,
+// so dereferencing it later from the spawned goroutine reads corrupted/reused
+// memory even though the captured value's own heap box (int/bool captures are
+// calloc'd independently of any arena, see codegen.go function()) is fine.
+// Fixed by allocating the env struct with plain malloc so its lifetime is
+// independent of any arena (mirrors how channels/maps already manage their
+// own memory). The capture here is a scalar (int) specifically to isolate
+// this env-struct-lifetime bug from the separate, still-open gap where a
+// STRING captured by a closure remains arena-owned bytes reachable through
+// the box (chanNeedsJSON/chanStrOffsets has no case for func-typed args to
+// freeze/thaw those) -- a separate follow-on fix, out of scope here.
+// Looped many times since the corruption is timing-dependent -- a single run
+// can pass by luck if the freed memory isn't reused in time.
+func TestGoClosureArgSurvivesSpawnerArena(t *testing.T) {
+	runLater := `func run_later(f, results) {
+	sleep(15)
+	results <- f()
+}`
+	spawnOne := `func spawn_one(n, results) {
+	v := n * 1000 + n
+	go run_later(func() { return v }, results)
+}`
+	churn := `func churn(n) {
+	i := 0
+	for i < 300 {
+		s := "garbage-" + str(n) + "-" + str(i) + "-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+		if len(s) < 0 { println(s) }
+		i = i + 1
+	}
+}`
+	main := `func main() {
+	results := make(chan int)
+	i := 0
+	for i < 25 {
+		go spawn_one(i, results)
+		go churn(i)
+		i = i + 1
+	}
+	acc := ""
+	j := 0
+	for j < 25 { acc = acc + str(<-results) + "\n"  j = j + 1 }
+	println(acc)
+}`
+	for round := 0; round < 2; round++ {
+		out := runProg(t, runLater, spawnOne, churn, main)
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != 25 {
+			t.Fatalf("round %d: expected 25 lines, got %d:\n%s", round, len(lines), out)
+		}
+		want := map[string]bool{}
+		for n := 0; n < 25; n++ {
+			want[strconv.Itoa(n*1000+n)] = true
+		}
+		seen := map[string]bool{}
+		for _, l := range lines {
+			if !want[l] {
+				t.Fatalf("round %d: corrupted closure capture (use-after-free, #314): %q", round, l)
+			}
+			if seen[l] {
+				t.Fatalf("round %d: duplicate value %q (aliased/corrupted env):\n%s", round, l, out)
+			}
+			seen[l] = true
+		}
+		if len(seen) != 25 {
+			t.Fatalf("round %d: expected 25 distinct values, got %d:\n%s", round, len(seen), out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thotq4`

## Summary

Fixes #314: `go f(func(){...})` with an inline closure literal segfaulted or silently corrupted captured values. Root cause: the closure's captured-env struct (codegen.go MakeClosure) and the heap "boxes" for params/locals captured by a nested closure (codegen.go function()) were allocated with the arena-scoped mfl_alloc/mfl_calloc, so they dangled once the spawning goroutine's arena was freed. Switched both allocation sites to plain malloc/calloc (matching how channels and maps already manage memory independently of any arena), and added a regression test (goroutine_closure_capture_test.go) that spawns many goroutines with closure-literal args under allocator churn — verified failing before the fix (segfault) and passing 10/10 runs after, plus the full `go test ./...` suite stays green. Scope: this covers scalar (int/bool/float) captures; string/slice/map captures escaping through a reassigned box remain a separate, narrower follow-up (flagged by the architect, out of scope here).

**Diff:**
```
CHANGELOG.md                      | 12 ++++++
 codegen.go                        | 16 ++++++--
 goroutine_closure_capture_test.go | 81 +++++++++++++++++++++++++++++++++++++++
 3 files changed, 106 insertions(+), 3 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when launching a goroutine with an inline function argument.
  * Improved handling of captured values so they remain valid even if the spawning context is freed or reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->