### PR TITLE
test(racecheck): cover typeShared heap-sharing cases

### DIFF
--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -187,6 +187,50 @@ func TestPlaceOf(t *testing.T) {
 	}
 }
 
+func TestTypeShared(t *testing.T) {
+	c := &Checker{
+		structs: map[string]*TypeDecl{
+			"Box":   {Name: "Box", Fields: []Field{{Name: "n", Type: "int"}, {Name: "items", Type: "[]int"}}},
+			"Outer": {Name: "Outer", Fields: []Field{{Name: "b", Type: "Box"}}},
+		},
+	}
+
+	// Empty path: never crosses an indirection.
+	if got := typeShared(c, "Box", accPath{}); got {
+		t.Fatalf("typeShared(Box, empty path) = %v, want false", got)
+	}
+
+	// Field navigation on a by-value struct stays private.
+	if got := typeShared(c, "Outer", accPath{{field: "b"}}); got {
+		t.Fatalf("typeShared(Outer.b) = %v, want false", got)
+	}
+
+	// Indexing a slice crosses into shared heap.
+	if got := typeShared(c, "[]int", accPath{{field: ""}}); !got {
+		t.Fatalf("typeShared([]int, index) = %v, want true", got)
+	}
+
+	// Indexing a map value crosses into shared heap.
+	if got := typeShared(c, "map[string]int", accPath{{field: ""}}); !got {
+		t.Fatalf("typeShared(map[string]int, index) = %v, want true", got)
+	}
+
+	// Field access after crossing a slice index stays "shared" (sticky).
+	if got := typeShared(c, "[]Box", accPath{{field: ""}, {field: "n"}}); !got {
+		t.Fatalf("typeShared([]Box, index then field) = %v, want true", got)
+	}
+
+	// Unknown field on a struct: stops early, reports whatever was accumulated.
+	if got := typeShared(c, "Box", accPath{{field: "missing"}}); got {
+		t.Fatalf("typeShared(Box.missing) = %v, want false", got)
+	}
+
+	// Indexing a string/bytes (no "[]" or "map[" prefix): no sharing, stops early.
+	if got := typeShared(c, "string", accPath{{field: ""}}); got {
+		t.Fatalf("typeShared(string, index) = %v, want false", got)
+	}
+}
+
 func TestMergeGAcc(t *testing.T) {
 	m := map[string]*gAccess{}
 

--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -190,6 +190,65 @@ func TestPlaceOf(t *testing.T) {
 	}
 }
 
+func TestSlotTypeName(t *testing.T) {
+	c := &Checker{}
+
+	scalars := []struct {
+		kind Kind
+		want string
+	}{
+		{KInt, "int"}, {KNum, "int"}, {KFloat, "float"}, {KBool, "bool"},
+		{KString, "string"}, {KBytes, "bytes"}, {KVoid, "?"},
+	}
+	for _, tt := range scalars {
+		s := newSlot(c, tt.kind)
+		if got := slotTypeName(c, s); got != tt.want {
+			t.Fatalf("slotTypeName(%v) = %q, want %q", tt.kind, got, tt.want)
+		}
+	}
+
+	elemSlot := newSlot(c, KInt)
+	sliceSlot := newSlot(c, KSlice)
+	c.elem[sliceSlot] = elemSlot
+	if got := slotTypeName(c, sliceSlot); got != "[]int" {
+		t.Fatalf("slotTypeName(slice of int) = %q, want []int", got)
+	}
+	emptySlice := newSlot(c, KSlice)
+	if got := slotTypeName(c, emptySlice); got != "[]?" {
+		t.Fatalf("slotTypeName(slice, no elem) = %q, want []?", got)
+	}
+
+	keySlot := newSlot(c, KString)
+	valSlot := newSlot(c, KInt)
+	mapSlot := newSlot(c, KMap)
+	c.mkey[mapSlot] = keySlot
+	c.mval[mapSlot] = valSlot
+	if got := slotTypeName(c, mapSlot); got != "map[string]int" {
+		t.Fatalf("slotTypeName(map) = %q, want map[string]int", got)
+	}
+	emptyMap := newSlot(c, KMap)
+	if got := slotTypeName(c, emptyMap); got != "map[?]?" {
+		t.Fatalf("slotTypeName(map, no key/val) = %q, want map[?]?", got)
+	}
+
+	chanElem := newSlot(c, KBool)
+	chanSlot := newSlot(c, KChan)
+	c.elem[chanSlot] = chanElem
+	if got := slotTypeName(c, chanSlot); got != "chan bool" {
+		t.Fatalf("slotTypeName(chan) = %q, want chan bool", got)
+	}
+	emptyChan := newSlot(c, KChan)
+	if got := slotTypeName(c, emptyChan); got != "chan ?" {
+		t.Fatalf("slotTypeName(chan, no elem) = %q, want chan ?", got)
+	}
+
+	structSlot := newSlot(c, KStruct)
+	c.sname[structSlot] = "Box"
+	if got := slotTypeName(c, structSlot); got != "Box" {
+		t.Fatalf("slotTypeName(struct) = %q, want Box", got)
+	}
+}
+
 func TestTypeShared(t *testing.T) {
 	c := &Checker{
 		structs: map[string]*TypeDecl{

--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestClonePath(t *testing.T) {
 	if got := clonePath(nil); got != nil {
@@ -228,6 +231,50 @@ func TestTypeShared(t *testing.T) {
 	// Indexing a string/bytes (no "[]" or "map[" prefix): no sharing, stops early.
 	if got := typeShared(c, "string", accPath{{field: ""}}); got {
 		t.Fatalf("typeShared(string, index) = %v, want false", got)
+	}
+}
+
+func TestGoAccessorsOf(t *testing.T) {
+	sum := map[string][]paramAcc{
+		"worker": {
+			{idx: 0, path: accPath{{field: "n"}}, write: true},
+			{idx: 1, path: nil, write: false},
+		},
+	}
+	st := &GoStmt{Call: &Call{Callee: "worker", Args: []Expr{
+		&Ident{Name: "box"},
+		&Ident{Name: "counter"},
+	}}}
+
+	got := goAccessorsOf(st, false, sum)
+	if len(got) != 2 {
+		t.Fatalf("goAccessorsOf(not in loop) = %d accesses, want 2: %+v", len(got), got)
+	}
+	if got[0].root != "box" || !got[0].write || got[0].mult != 1 {
+		t.Fatalf("goAccessorsOf[0] = %+v, want root=box write=true mult=1", got[0])
+	}
+	if got[1].root != "counter" || got[1].write || got[1].mult != 1 {
+		t.Fatalf("goAccessorsOf[1] = %+v, want root=counter write=false mult=1", got[1])
+	}
+
+	// Inside a loop, the multiplier doubles and the description labels it as such.
+	loopGot := goAccessorsOf(st, true, sum)
+	if len(loopGot) != 2 || loopGot[0].mult != 2 {
+		t.Fatalf("goAccessorsOf(in loop)[0].mult = %d, want 2", loopGot[0].mult)
+	}
+	if !strings.Contains(loopGot[0].desc, "loop-spawned goroutine") {
+		t.Fatalf("goAccessorsOf(in loop) desc = %q, want it to mention loop-spawned goroutine", loopGot[0].desc)
+	}
+
+	// An argument that isn't a place expression (e.g. a call result) is skipped.
+	nonPlace := &GoStmt{Call: &Call{Callee: "worker", Args: []Expr{&Call{Callee: "f"}, &Ident{Name: "counter"}}}}
+	if got := goAccessorsOf(nonPlace, false, sum); len(got) != 1 || got[0].root != "counter" {
+		t.Fatalf("goAccessorsOf(non-place arg) = %+v, want only the counter access", got)
+	}
+
+	// A callee with no recorded summary yields no accesses.
+	if got := goAccessorsOf(&GoStmt{Call: &Call{Callee: "unknown", Args: []Expr{&Ident{Name: "x"}}}}, false, sum); len(got) != 0 {
+		t.Fatalf("goAccessorsOf(unknown callee) = %+v, want none", got)
 	}
 }
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thounh`

## Summary

Added direct unit tests for three previously-untested racecheck.go helpers: typeShared (struct-vs-heap sharing decisions for the race detector), goAccessorsOf (re-rooting a spawned goroutine's parameter accesses onto caller args, including loop-spawn multiplier/label), and slotTypeName (rendering a checker type slot back to its MFL type-name string). These are small, self-contained additions with no production code changes — all existing tests (`go test .`) and `go build ./...` still pass.

**Diff:**
```
racecheck_helpers_test.go | 152 +++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 151 insertions(+), 1 deletion(-)
```
