### PR TITLE
test(types): cover IsGlobal/GlobalKind/ParamKind/RetKindAt/ClosureInst

### DIFF
--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -362,3 +362,31 @@ func TestMergeGAcc(t *testing.T) {
 		t.Fatalf("mergeGAcc(already set bits) should report changed=false")
 	}
 }
+
+// TestRaceFindingToDiagnostic covers all three raceFinding.Kind branches:
+// write/write and use-after-move each pick a distinct code/message shape,
+// and anything else (e.g. read/write) falls through to the default RACE002.
+func TestRaceFindingToDiagnostic(t *testing.T) {
+	cases := []struct {
+		kind     string
+		wantCode string
+		wantMsg  string
+	}{
+		{"write/write", "RACE001", "data race on `x` (write/write): a; b"},
+		{"use-after-move", "RACE004", "use after move: a; b"},
+		{"read/write", "RACE002", "data race on `x` (read/write): a; b"},
+	}
+	for _, c := range cases {
+		rf := raceFinding{Root: "x", Decl: "f", Kind: c.kind, Writers: []string{"a", "b"}}
+		d := rf.toDiagnostic()
+		if d.Code != c.wantCode {
+			t.Errorf("Kind %q: Code = %q, want %q", c.kind, d.Code, c.wantCode)
+		}
+		if d.Message != c.wantMsg {
+			t.Errorf("Kind %q: Message = %q, want %q", c.kind, d.Message, c.wantMsg)
+		}
+		if d.Severity != "error" || d.Phase != "race" || d.Decl != "f" {
+			t.Errorf("Kind %q: unexpected Diagnostic shape: %+v", c.kind, d)
+		}
+	}
+}

--- a/types_query_test.go
+++ b/types_query_test.go
@@ -1,0 +1,103 @@
+package main
+
+import "testing"
+
+// TestGlobalQueries covers IsGlobal and GlobalKind: a declared package global
+// must be reported as global with its inferred kind, and an unrelated name
+// must not be mistaken for one.
+func TestGlobalQueries(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		"var total = 3",
+		"func main() { total = 4 }",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	if !c.IsGlobal("total") {
+		t.Error("IsGlobal(\"total\") = false, want true")
+	}
+	if c.IsGlobal("notAGlobal") {
+		t.Error("IsGlobal(\"notAGlobal\") = true, want false")
+	}
+	if got := c.GlobalKind("total"); got != KInt {
+		t.Errorf("GlobalKind(\"total\") = %v, want %v", got, KInt)
+	}
+}
+
+// TestParamAndRetKind covers ParamKind and RetKindAt against a function whose
+// param and named return have distinct kinds.
+func TestParamAndRetKind(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		"func square(x) (y) { y = x * x  return y }",
+		"func main() { println(square(2)) }",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	var inst string
+	for _, r := range c.Reps() {
+		if c.SrcFunc(r).Name == "square" {
+			inst = r
+			break
+		}
+	}
+	if inst == "" {
+		t.Fatal("no monomorphized instance found for square")
+	}
+
+	if got := c.ParamKind(inst, 0); got != KInt {
+		t.Errorf("ParamKind(square, 0) = %v, want %v", got, KInt)
+	}
+	if got := c.RetKindAt(inst, 0); got != KInt {
+		t.Errorf("RetKindAt(square, 0) = %v, want %v", got, KInt)
+	}
+}
+
+// TestClosureInst covers ClosureInst: a MakeClosure node produced by lambda-
+// lifting must resolve to the lifted lambda's instance, matching the C name
+// codegen would call.
+func TestClosureInst(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		"func main() { f := func() { return 7 }  println(f()) }",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	var encl string
+	var mc *MakeClosure
+	for _, r := range c.Reps() {
+		for _, stmt := range c.SrcFunc(r).Body {
+			if as, ok := stmt.(*AssignStmt); ok {
+				if m, ok := as.Val.(*MakeClosure); ok {
+					encl, mc = r, m
+				}
+			}
+		}
+	}
+	if mc == nil {
+		t.Fatal("no MakeClosure node found after lambda-lifting")
+	}
+
+	inst := c.ClosureInst(encl, mc)
+	if inst == "" {
+		t.Fatal("ClosureInst returned empty instance name")
+	}
+	if got, want := c.CName(inst), c.ClosureCName(encl, mc); got != want {
+		t.Errorf("CName(ClosureInst(...)) = %q, want %q (ClosureCName)", got, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thov45`

**Diff:**
```
racecheck_helpers_test.go |  28 +++++++++++++
 types_query_test.go       | 103 ++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 131 insertions(+)
```
