### PR TITLE
test(guide): cover renderGuideText and cmdGuide --skill/--text/--json

### DIFF
--- a/guide_test.go
+++ b/guide_test.go
@@ -162,3 +162,42 @@ func argCount(sig string) int {
 	}
 	return strings.Count(inner, ",") + 1
 }
+
+// renderGuideText must weave every top-level catalog section into the dense
+// prose form, since --text is the human-facing (non-JSON) rendering.
+func TestRenderGuideText(t *testing.T) {
+	g := machinGuide()
+	out := renderGuideText(g)
+	for _, want := range []string{g.Version, g.Tagline, "COMMANDS", "DOMAINS", "PROOF", "TYPES"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderGuideText output missing %q", want)
+		}
+	}
+	for _, c := range g.Commands {
+		if !strings.Contains(out, c.Usage) {
+			t.Errorf("renderGuideText missing command usage %q", c.Usage)
+		}
+	}
+}
+
+// cmdGuide --skill dispatches to a canned skill doc for known names and
+// errors for unknown ones; --text/--json select the two guide renderings.
+func TestCmdGuideSkillDispatch(t *testing.T) {
+	for _, name := range []string{"start", "machin", "web", "gamedev", "game", "backend", "deploy"} {
+		if err := cmdGuide([]string{"--skill", name}); err != nil {
+			t.Errorf("cmdGuide --skill %q: unexpected error: %v", name, err)
+		}
+	}
+	if err := cmdGuide([]string{"--skill", "bogus"}); err == nil {
+		t.Fatal("cmdGuide --skill bogus: expected error, got nil")
+	}
+}
+
+func TestCmdGuideTextAndJSON(t *testing.T) {
+	if err := cmdGuide([]string{"--text"}); err != nil {
+		t.Fatalf("cmdGuide --text: %v", err)
+	}
+	if err := cmdGuide(nil); err != nil {
+		t.Fatalf("cmdGuide (json default): %v", err)
+	}
+}

--- a/parsetest_test.go
+++ b/parsetest_test.go
@@ -34,3 +34,31 @@ func TestCollectStructNamesEmpty(t *testing.T) {
 		t.Fatalf("collectStructNames(nil) = %v, want empty", got)
 	}
 }
+
+// sexprFields/sexprType are the leaf S-expression renderers the MFL
+// self-hosted parser (selfhost/parse.src) must match byte-for-byte.
+func TestSexprFields(t *testing.T) {
+	got := sexprFields([]string{"x", "y"}, []string{"int", "string"})
+	want := "(fields (f x int) (f y string))"
+	if got != want {
+		t.Fatalf("sexprFields = %q, want %q", got, want)
+	}
+	if got := sexprFields(nil, nil); got != "(fields)" {
+		t.Fatalf("sexprFields(nil, nil) = %q, want %q", got, "(fields)")
+	}
+}
+
+func TestSexprType(t *testing.T) {
+	td := &TypeDecl{
+		Name: "Point",
+		Fields: []Field{
+			{Name: "x", Type: "int"},
+			{Name: "y", Type: "int"},
+		},
+	}
+	got := sexprType(td)
+	want := "(type Point (fields (f x int) (f y int)))"
+	if got != want {
+		t.Fatalf("sexprType = %q, want %q", got, want)
+	}
+}

--- a/parsetest_test.go
+++ b/parsetest_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+// collectStructNames scans raw source lines for `type NAME` and `cstruct NAME`
+// declarations, feeding the set used to recognize `T{...}` composite literals
+// while parsing. It must find both forms, ignore unrelated lines, and not be
+// confused by a bare keyword with no following identifier.
+func TestCollectStructNames(t *testing.T) {
+	lines := []string{
+		"package main",
+		"type Point struct { x int y int }",
+		"extern \"c\" {",
+		"  cstruct CPoint { x int y int }",
+		"}",
+		"func main() { p := Point{x: 1, y: 2} }",
+		"type", // no following identifier — must not panic or add a bogus entry
+	}
+	got := collectStructNames(lines)
+	want := map[string]bool{"Point": true, "CPoint": true}
+	if len(got) != len(want) {
+		t.Fatalf("collectStructNames(%v) = %v, want %v", lines, got, want)
+	}
+	for name := range want {
+		if !got[name] {
+			t.Errorf("collectStructNames missing %q, got %v", name, got)
+		}
+	}
+}
+
+func TestCollectStructNamesEmpty(t *testing.T) {
+	got := collectStructNames(nil)
+	if len(got) != 0 {
+		t.Fatalf("collectStructNames(nil) = %v, want empty", got)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thovks`

## Summary

Added targeted unit tests for several previously-uncovered pure helper functions: guide.go's renderGuideText and cmdGuide's --skill/--text/--json dispatch, and parsetest.go's collectStructNames, sexprFields, and sexprType. These functions had 0% test coverage despite being self-contained and easy to exercise directly. No production code changed — test-only additions across 3 commits (guide_test.go, new parsetest_test.go x2).

**Diff:**
```
guide_test.go     | 39 +++++++++++++++++++++++++++++++++
 parsetest_test.go | 64 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 103 insertions(+)
```
