### PR TITLE
test(racecheck): cover collectLocals shadowing across all Stmt kinds

### DIFF
--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -366,6 +366,48 @@ func TestMergeGAcc(t *testing.T) {
 // TestRaceFindingToDiagnostic covers all three raceFinding.Kind branches:
 // write/write and use-after-move each pick a distinct code/message shape,
 // and anything else (e.g. read/write) falls through to the default RACE002.
+// TestCollectLocals covers every Stmt case collectLocals recurses through: a
+// top-level `:=`, a `:=` MultiAssign, a range's key/val vars (recursing into its
+// body), and nested If/While/Arena bodies. Plain `=` (not `:=`) must NOT bind a
+// local, since it targets an existing name rather than shadowing a global.
+func TestCollectLocals(t *testing.T) {
+	body := []Stmt{
+		&AssignStmt{Name: "a", Op: ":=", Val: &IntLit{}},
+		&AssignStmt{Name: "existing", Op: "=", Val: &IntLit{}},
+		&MultiAssign{Names: []string{"b", "c"}, Op: ":="},
+		&RangeStmt{
+			Key: "i", Val: "v",
+			Body: []Stmt{&AssignStmt{Name: "inner", Op: ":=", Val: &IntLit{}}},
+		},
+		&IfStmt{
+			Then: []Stmt{&AssignStmt{Name: "then_local", Op: ":=", Val: &IntLit{}}},
+			Else: []Stmt{&AssignStmt{Name: "else_local", Op: ":=", Val: &IntLit{}}},
+		},
+		&WhileStmt{
+			Body: []Stmt{&AssignStmt{Name: "while_local", Op: ":=", Val: &IntLit{}}},
+		},
+		&ArenaStmt{
+			Body: []Stmt{&AssignStmt{Name: "arena_local", Op: ":=", Val: &IntLit{}}},
+		},
+	}
+
+	into := map[string]bool{}
+	collectLocals(body, into)
+
+	want := []string{"a", "b", "c", "i", "v", "inner", "then_local", "else_local", "while_local", "arena_local"}
+	for _, name := range want {
+		if !into[name] {
+			t.Errorf("collectLocals: missing %q in %v", name, into)
+		}
+	}
+	if into["existing"] {
+		t.Errorf("collectLocals: plain `=` must not bind a local, got %v", into)
+	}
+	if len(into) != len(want) {
+		t.Errorf("collectLocals: got %d locals %v, want exactly %v", len(into), into, want)
+	}
+}
+
 func TestRaceFindingToDiagnostic(t *testing.T) {
 	cases := []struct {
 		kind     string

--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -293,6 +293,44 @@ func TestTypeShared(t *testing.T) {
 	}
 }
 
+// TestTypeSharesHeap covers typeSharesHeap (distinct from typeShared above): it
+// decides whether SENDING a value of this type on a channel aliases shared heap,
+// by name prefix or by recursing into struct fields, with a depth cutoff against
+// runaway/cyclic struct definitions.
+func TestTypeSharesHeap(t *testing.T) {
+	c := &Checker{
+		structs: map[string]*TypeDecl{
+			"Box":       {Name: "Box", Fields: []Field{{Name: "n", Type: "int"}, {Name: "items", Type: "[]int"}}},
+			"Plain":     {Name: "Plain", Fields: []Field{{Name: "n", Type: "int"}, {Name: "s", Type: "string"}}},
+			"Wraps":     {Name: "Wraps", Fields: []Field{{Name: "b", Type: "Box"}}},
+			"Recursive": {Name: "Recursive", Fields: []Field{{Name: "next", Type: "Recursive"}}},
+		},
+	}
+
+	if !typeSharesHeap(c, "[]int", 0) {
+		t.Fatalf("typeSharesHeap([]int) = false, want true")
+	}
+	if !typeSharesHeap(c, "map[string]int", 0) {
+		t.Fatalf("typeSharesHeap(map[string]int) = false, want true")
+	}
+	if !typeSharesHeap(c, "Box", 0) {
+		t.Fatalf("typeSharesHeap(Box) = false, want true (has a []int field)")
+	}
+	if typeSharesHeap(c, "Plain", 0) {
+		t.Fatalf("typeSharesHeap(Plain) = true, want false (no shared-heap fields)")
+	}
+	if !typeSharesHeap(c, "Wraps", 0) {
+		t.Fatalf("typeSharesHeap(Wraps) = false, want true (transitively wraps Box)")
+	}
+	if typeSharesHeap(c, "unknown", 0) {
+		t.Fatalf("typeSharesHeap(unknown type) = true, want false")
+	}
+	// Depth cutoff: guards against runaway recursion on a self-referential struct.
+	if typeSharesHeap(c, "Recursive", 9) {
+		t.Fatalf("typeSharesHeap(depth>8) = true, want false (cutoff hit)")
+	}
+}
+
 func TestGoAccessorsOf(t *testing.T) {
 	sum := map[string][]paramAcc{
 		"worker": {

--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -337,6 +337,32 @@ func TestGoAccessorsOf(t *testing.T) {
 	}
 }
 
+// TestMarkLoopSpawns covers every Stmt case it recurses through (If/While/Range/
+// Arena) plus the GoStmt leaf that actually bumps `live`, mirroring the shape of
+// TestCollectLocals above.
+func TestMarkLoopSpawns(t *testing.T) {
+	sum := map[string][]paramAcc{
+		"worker": {{idx: 0, path: nil, write: true}},
+	}
+	goCall := func() Stmt {
+		return &GoStmt{Call: &Call{Callee: "worker", Args: []Expr{&Ident{Name: "box"}}}}
+	}
+
+	body := []Stmt{
+		&IfStmt{Then: []Stmt{goCall()}, Else: []Stmt{goCall()}},
+		&WhileStmt{Body: []Stmt{goCall()}},
+		&RangeStmt{Body: []Stmt{goCall()}},
+		&ArenaStmt{Body: []Stmt{goCall()}},
+	}
+
+	live := map[string]int{}
+	markLoopSpawns(body, live, sum)
+
+	if live["box"] != 5 {
+		t.Fatalf("markLoopSpawns: live[box] = %d, want 5 (if-then + if-else + while + range + arena)", live["box"])
+	}
+}
+
 func TestMergeGAcc(t *testing.T) {
 	m := map[string]*gAccess{}
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thow84`

## Summary

Added unit tests for three low-coverage racecheck.go helpers that had no direct tests: collectLocals (25% -> full branch coverage across AssignStmt/MultiAssign/RangeStmt/If/While/Arena), markLoopSpawns (44.4% -> covers all recursive Stmt kinds plus the GoStmt leaf), and typeSharesHeap (33.3% -> slice/map prefixes, struct recursion, and the depth>8 cutoff). These are the internal helpers the data-race checker relies on for local-shadowing and move-on-send analysis; no production code changed. All changes are additive test-only commits in racecheck_helpers_test.go, avoiding files claimed by open PR #355.

**Diff:**
```
racecheck_helpers_test.go | 106 ++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 106 insertions(+)
```
