### PR TITLE
test(guide): cover isBuiltinName catalog lookup and memoization

### DIFF
--- a/guide_test.go
+++ b/guide_test.go
@@ -201,3 +201,33 @@ func TestCmdGuideTextAndJSON(t *testing.T) {
 		t.Fatalf("cmdGuide (json default): %v", err)
 	}
 }
+
+// isBuiltinName must recognize every catalog builtin, reject arbitrary user
+// identifiers, and memoize builtinNames on first use rather than rebuilding it.
+func TestIsBuiltinName(t *testing.T) {
+	builtinNames = nil
+	g := machinGuide()
+	if len(g.Builtins) == 0 {
+		t.Fatal("catalog has no builtins to check against")
+	}
+	for _, b := range g.Builtins {
+		if !isBuiltinName(b.Name) {
+			t.Errorf("isBuiltinName(%q) = false, want true", b.Name)
+		}
+	}
+	for _, n := range []string{"", "notARealBuiltin", "my_custom_fn"} {
+		if isBuiltinName(n) {
+			t.Errorf("isBuiltinName(%q) = true, want false", n)
+		}
+	}
+	if builtinNames == nil || len(builtinNames) != len(g.Builtins) {
+		t.Fatalf("isBuiltinName did not memoize builtinNames correctly: got %d entries, want %d", len(builtinNames), len(g.Builtins))
+	}
+	// A stale/forged entry must survive a second call, proving the map is
+	// reused rather than rebuilt from the catalog every time.
+	builtinNames["__forged__"] = true
+	if !isBuiltinName("__forged__") {
+		t.Fatal("isBuiltinName rebuilt builtinNames instead of reusing the memoized map")
+	}
+	delete(builtinNames, "__forged__")
+}

--- a/racecheck_helpers_test.go
+++ b/racecheck_helpers_test.go
@@ -496,3 +496,32 @@ func TestRaceFindingToDiagnostic(t *testing.T) {
 		}
 	}
 }
+
+// accessSummary must record a function's direct param accesses plus, via its
+// call-graph fixed point, the accesses its callees perform transitively.
+func TestAccessSummary(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		"func poke(ys, k){ys[k]=1}",
+		"func worker(xs, id){poke(xs, id)}",
+		"func reader(zs){v:=zs[0] print(v)}",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	sum := accessSummary(prog)
+
+	poke := sum["poke"]
+	if len(poke) != 1 || poke[0].idx != 0 || !poke[0].write || len(poke[0].path) != 1 {
+		t.Fatalf("poke: direct write access = %+v, want one write on param 0 with an index step", poke)
+	}
+
+	worker := sum["worker"]
+	if len(worker) != 1 || worker[0].idx != 0 || !worker[0].write {
+		t.Fatalf("worker: transitive access via poke = %+v, want one write on param 0", worker)
+	}
+
+	reader := sum["reader"]
+	if len(reader) != 1 || reader[0].idx != 0 || reader[0].write {
+		t.Fatalf("reader: direct read access = %+v, want one read on param 0", reader)
+	}
+}

--- a/types_helpers_test.go
+++ b/types_helpers_test.go
@@ -118,3 +118,54 @@ func TestReconcile(t *testing.T) {
 		}
 	}
 }
+
+// The new*Slot constructors must set the Kind and cross-reference the fields
+// specific to their kind (fsig/mkey+mval/elem/sname) on the returned slot.
+func TestNewCompositeSlots(t *testing.T) {
+	c := &Checker{}
+
+	sig := &funcSig{params: []int{0, 1}, ret: 2}
+	fn := newFuncSlot(c, sig)
+	if c.kind[fn] != KFunc {
+		t.Errorf("newFuncSlot: kind = %v, want KFunc", c.kind[fn])
+	}
+	if c.fsig[fn] != sig {
+		t.Errorf("newFuncSlot: fsig = %v, want %v", c.fsig[fn], sig)
+	}
+
+	key := newSlot(c, KString)
+	val := newSlot(c, KInt)
+	m := newMapSlot(c, key, val)
+	if c.kind[m] != KMap {
+		t.Errorf("newMapSlot: kind = %v, want KMap", c.kind[m])
+	}
+	if c.mkey[m] != key || c.mval[m] != val {
+		t.Errorf("newMapSlot: mkey/mval = %d/%d, want %d/%d", c.mkey[m], c.mval[m], key, val)
+	}
+
+	elem := newSlot(c, KFloat)
+	sl := newSliceSlot(c, elem)
+	if c.kind[sl] != KSlice {
+		t.Errorf("newSliceSlot: kind = %v, want KSlice", c.kind[sl])
+	}
+	if c.elem[sl] != elem {
+		t.Errorf("newSliceSlot: elem = %d, want %d", c.elem[sl], elem)
+	}
+
+	st := newStructSlot(c, "Point")
+	if c.kind[st] != KStruct {
+		t.Errorf("newStructSlot: kind = %v, want KStruct", c.kind[st])
+	}
+	if c.sname[st] != "Point" {
+		t.Errorf("newStructSlot: sname = %q, want %q", c.sname[st], "Point")
+	}
+
+	chanElem := newSlot(c, KBool)
+	ch := newChanSlot(c, chanElem)
+	if c.kind[ch] != KChan {
+		t.Errorf("newChanSlot: kind = %v, want KChan", c.kind[ch])
+	}
+	if c.elem[ch] != chanElem {
+		t.Errorf("newChanSlot: elem = %d, want %d", c.elem[ch], chanElem)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thowos`

## Summary

Adds targeted unit tests for three previously-uncovered helpers: guide.go's isBuiltinName (catalog lookup + lazy memoization of builtinNames, which guards against user functions shadowing builtins), types.go's newFuncSlot/newMapSlot/newSliceSlot/newStructSlot/newChanSlot constructors (each sets the kind-specific cross-reference fields used by funcOf/mapKV/chanElem), and racecheck.go's accessSummary (the per-function param access fixed point that the whole race-detection pass is built on, tested here directly rather than only via the full detectRaces pipeline). All changes are test-only; `go build ./...` and `go test .` pass.

**Diff:**
```
guide_test.go             | 30 ++++++++++++++++++++++++++++
 racecheck_helpers_test.go | 29 +++++++++++++++++++++++++++
 types_helpers_test.go     | 51 +++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 110 insertions(+)
```
