### PR TITLE
test(transform): cover liftClosures capture-by-reference lifting

### DIFF
--- a/parser_global_test.go
+++ b/parser_global_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+func TestParseGlobalSimple(t *testing.T) {
+	gv, err := ParseGlobal(`var counter = 0`)
+	if err != nil {
+		t.Fatalf("ParseGlobal: unexpected error: %v", err)
+	}
+	if gv.Name != "counter" {
+		t.Errorf("gv.Name = %q, want %q", gv.Name, "counter")
+	}
+	lit, ok := gv.Init.(*IntLit)
+	if !ok || lit.Val != 0 {
+		t.Errorf("gv.Init = %#v, want *IntLit{Val: 0}", gv.Init)
+	}
+}
+
+func TestParseGlobalWithStructLiteral(t *testing.T) {
+	structs := map[string]bool{"Config": true}
+	gv, err := ParseGlobalWith(`var cfg = Config{name: "x"}`, structs)
+	if err != nil {
+		t.Fatalf("ParseGlobalWith: unexpected error: %v", err)
+	}
+	if gv.Name != "cfg" {
+		t.Errorf("gv.Name = %q, want %q", gv.Name, "cfg")
+	}
+	sl, ok := gv.Init.(*StructLit)
+	if !ok {
+		t.Fatalf("gv.Init = %T, want *StructLit", gv.Init)
+	}
+	if sl.Type != "Config" {
+		t.Errorf("sl.Type = %q, want %q", sl.Type, "Config")
+	}
+}
+
+func TestParseGlobalWithoutStructsUnknownTypeNotLiteral(t *testing.T) {
+	// Without "Config" registered as a known struct name, `Config{...}` cannot be
+	// parsed as a composite literal, so this must fail rather than silently
+	// misparse.
+	if _, err := ParseGlobalWith(`var cfg = Config{name: "x"}`, nil); err == nil {
+		t.Errorf("ParseGlobalWith: want error when struct type is unregistered, got nil")
+	}
+}
+
+func TestParseGlobalMissingInitializer(t *testing.T) {
+	if _, err := ParseGlobal(`var counter`); err == nil {
+		t.Errorf("ParseGlobal: want error for missing `= <expr>`, got nil")
+	}
+}
+
+func TestParseGlobalTrailingTokens(t *testing.T) {
+	if _, err := ParseGlobal(`var counter = 0 extra`); err == nil {
+		t.Errorf("ParseGlobal: want error for trailing tokens after the initializer, got nil")
+	}
+}
+
+func TestParseGlobalMissingVarKeyword(t *testing.T) {
+	if _, err := ParseGlobal(`counter = 0`); err == nil {
+		t.Errorf("ParseGlobal: want error when leading `var` keyword is missing, got nil")
+	}
+}
+
+func TestParseGlobalMissingName(t *testing.T) {
+	if _, err := ParseGlobal(`var = 0`); err == nil {
+		t.Errorf("ParseGlobal: want error when the global has no name, got nil")
+	}
+}

--- a/racecheck_analysis_test.go
+++ b/racecheck_analysis_test.go
@@ -1,0 +1,132 @@
+package main
+
+import "testing"
+
+func TestCollectClosureVars(t *testing.T) {
+	innerMC := &MakeClosure{FuncName: "lambda_0", Captures: []string{"x"}}
+	shadowedMC := &MakeClosure{FuncName: "lambda_1", Captures: []string{"y"}}
+	body := []Stmt{
+		&AssignStmt{Name: "f", Op: ":=", Val: innerMC},
+		&IfStmt{
+			Then: []Stmt{&AssignStmt{Name: "g", Op: ":=", Val: shadowedMC}},
+		},
+		&WhileStmt{
+			Body: []Stmt{&AssignStmt{Name: "h", Op: ":=", Val: &MakeClosure{FuncName: "lambda_2"}}},
+		},
+		&RangeStmt{
+			Body: []Stmt{&AssignStmt{Name: "k", Op: ":=", Val: &MakeClosure{FuncName: "lambda_3"}}},
+		},
+		&ArenaStmt{
+			Body: []Stmt{&AssignStmt{Name: "m", Op: ":=", Val: &MakeClosure{FuncName: "lambda_4"}}},
+		},
+		&AssignStmt{Name: "notClosure", Op: ":=", Val: &IntLit{Val: 1}},
+	}
+
+	into := map[string]*MakeClosure{}
+	collectClosureVars(body, into)
+
+	want := []string{"f", "g", "h", "k", "m"}
+	for _, name := range want {
+		if into[name] == nil {
+			t.Errorf("collectClosureVars: missing MakeClosure for %q, got %v", name, into)
+		}
+	}
+	if into["f"] != innerMC {
+		t.Errorf("collectClosureVars: %q maps to %v, want the original MakeClosure pointer", "f", into["f"])
+	}
+	if _, ok := into["notClosure"]; ok {
+		t.Errorf("collectClosureVars: non-closure assignment must not be recorded, got %v", into)
+	}
+}
+
+func TestCollectGlobalAccess(t *testing.T) {
+	gset := map[string]bool{"g": true, "shadowed": true}
+	local := map[string]bool{"shadowed": true}
+
+	var events []string
+	sink := func(name string, read, write bool) {
+		switch {
+		case read:
+			events = append(events, "read:"+name)
+		case write:
+			events = append(events, "write:"+name)
+		}
+	}
+
+	body := []Stmt{
+		&AssignStmt{Name: "g", Op: "=", Val: &IntLit{Val: 1}},          // whole-cell write
+		&AssignStmt{Name: "shadowed", Op: "=", Val: &Ident{Name: "g"}}, // shadowed by local: no write event, but rhs reads g
+		&ExprStmt{X: &Ident{Name: "g"}},
+		&IfStmt{
+			Cond: &Ident{Name: "g"},
+			Then: []Stmt{&ExprStmt{X: &Ident{Name: "g"}}},
+		},
+	}
+
+	collectGlobalAccess(body, gset, local, sink)
+
+	wantReads := 0
+	wantWrites := 0
+	for _, e := range events {
+		switch e {
+		case "read:g":
+			wantReads++
+		case "write:g":
+			wantWrites++
+		case "write:shadowed", "read:shadowed":
+			t.Errorf("collectGlobalAccess: shadowed local %q must not be reported, got event %q", "shadowed", e)
+		}
+	}
+	if wantWrites != 1 {
+		t.Errorf("collectGlobalAccess: want 1 write of g, got %d (%v)", wantWrites, events)
+	}
+	if wantReads != 4 {
+		t.Errorf("collectGlobalAccess: want 4 reads of g (rhs of shadowed=, bare ExprStmt, if-cond, if-then), got %d (%v)", wantReads, events)
+	}
+}
+
+func TestCollectCallGraph(t *testing.T) {
+	var normal []string
+	var gos []goSite
+
+	body := []Stmt{
+		&ExprStmt{X: &Call{Callee: "topLevel"}},
+		&GoStmt{Call: &Call{Callee: "worker", Args: []Expr{&Call{Callee: "argCall"}}}},
+		&IfStmt{
+			Then: []Stmt{&GoStmt{Call: &Call{Callee: "thenWorker"}}},
+			Else: []Stmt{&ExprStmt{X: &Call{Callee: "elseCallee"}}},
+		},
+		&WhileStmt{
+			Body: []Stmt{&GoStmt{Call: &Call{Callee: "loopedWorker"}}},
+		},
+	}
+
+	collectCallGraph(body, false, &normal, &gos)
+
+	wantNormal := map[string]bool{"topLevel": true, "argCall": true, "elseCallee": true}
+	for n := range wantNormal {
+		found := false
+		for _, got := range normal {
+			if got == n {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("collectCallGraph: normal callees %v missing %q", normal, n)
+		}
+	}
+
+	bySite := map[string]bool{}
+	for _, g := range gos {
+		bySite[g.callee] = g.inLoop
+	}
+	if inLoop, ok := bySite["worker"]; !ok || inLoop {
+		t.Errorf("collectCallGraph: top-level go site 'worker' should have inLoop=false, got %v (present=%v)", inLoop, ok)
+	}
+	if inLoop, ok := bySite["thenWorker"]; !ok || inLoop {
+		t.Errorf("collectCallGraph: 'thenWorker' inherits inLoop=false from an if-branch, got %v (present=%v)", inLoop, ok)
+	}
+	if inLoop, ok := bySite["loopedWorker"]; !ok || !inLoop {
+		t.Errorf("collectCallGraph: 'loopedWorker' inside a while must have inLoop=true, got %v (present=%v)", inLoop, ok)
+	}
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -26,6 +26,55 @@ func TestLocalNames(t *testing.T) {
 	}
 }
 
+func TestLiftClosuresCapturesEnclosingLocal(t *testing.T) {
+	// func main() { x := 1; f := func() int { return x }; return f }
+	main := &FuncDecl{
+		Name: "main",
+		Body: []Stmt{
+			&AssignStmt{Name: "x", Op: ":=", Val: &IntLit{Val: 1}},
+			&AssignStmt{Name: "f", Op: ":=", Val: &FuncLit{
+				Body: []Stmt{&ReturnStmt{Vals: []Expr{&Ident{Name: "x"}}}},
+			}},
+			&ReturnStmt{Vals: []Expr{&Ident{Name: "f"}}},
+		},
+	}
+	prog := &Program{Funcs: []*FuncDecl{main}}
+
+	liftClosures(prog)
+
+	if len(prog.Funcs) != 2 {
+		t.Fatalf("want main + 1 lifted func, got %d funcs", len(prog.Funcs))
+	}
+	lifted := prog.Funcs[1]
+	if !lifted.IsLambda || lifted.NumCaptures != 1 {
+		t.Fatalf("lifted func: IsLambda=%v NumCaptures=%d, want true/1", lifted.IsLambda, lifted.NumCaptures)
+	}
+	if len(lifted.Params) != 1 || lifted.Params[0] != "x" {
+		t.Fatalf("lifted func params = %v, want [x] (capture as leading param)", lifted.Params)
+	}
+	if !lifted.Boxed["x"] {
+		t.Errorf("lifted func must mark captured param %q boxed", "x")
+	}
+	if !main.Boxed["x"] {
+		t.Errorf("enclosing func must box captured local %q so it's shared by reference", "x")
+	}
+
+	assign, ok := main.Body[1].(*AssignStmt)
+	if !ok {
+		t.Fatalf("main.Body[1] = %T, want *AssignStmt", main.Body[1])
+	}
+	mc, ok := assign.Val.(*MakeClosure)
+	if !ok {
+		t.Fatalf("f's initializer = %T, want *MakeClosure (FuncLit must be replaced in place)", assign.Val)
+	}
+	if mc.FuncName != lifted.Name {
+		t.Errorf("MakeClosure.FuncName = %q, want %q", mc.FuncName, lifted.Name)
+	}
+	if len(mc.Captures) != 1 || mc.Captures[0] != "x" {
+		t.Errorf("MakeClosure.Captures = %v, want [x]", mc.Captures)
+	}
+}
+
 func TestCollectDeclaredNestedFuncLitNotRecursed(t *testing.T) {
 	// collectDeclared must not descend into a nested FuncLit's own body — it has
 	// no case for *FuncLit, so a := inside it must not leak into the outer set.


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thox24`

## Summary

Added three focused unit test files covering previously-thin analysis code paths, none overlapping in-flight PRs #381/#355:
1. transform_test.go: TestLiftClosuresCapturesEnclosingLocal — direct coverage of liftClosures (closure lifting to top-level funcs, capture-by-reference boxing, MakeClosure rewrite).
2. racecheck_analysis_test.go (new file): collectClosureVars, collectGlobalAccess, and collectCallGraph — the data-race detector's closure/global/call-graph analysis helpers, previously at 42-56% coverage.
3. parser_global_test.go (new file): ParseGlobal/ParseGlobalWith — the standalone package-global parser entrypoint, previously at 0%/64.7% coverage, including struct-literal initializers and parse-error paths.
All tests pass; go build/vet/test are clean.

**Diff:**
```
parser_global_test.go      |  68 +++++++++++++++++++++++
 racecheck_analysis_test.go | 132 +++++++++++++++++++++++++++++++++++++++++++++
 transform_test.go          |  49 +++++++++++++++++
 3 files changed, 249 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test coverage for parsing global declarations, including valid initializers, struct-like literals, and several invalid input cases.
  * Added analysis tests for tracking closure captures, global reads/writes, and call relationships across control flow.
  * Added a test verifying closure lifting behavior when a nested function captures an outer local variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->