### PR TITLE
test(main): cover cmdPack arg validation, encoding, and repack tolerance

### DIFF
--- a/cmdpack_test.go
+++ b/cmdpack_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cmdPack had no direct test coverage; these cover its two error paths and the
+// happy path where each non-blank line becomes one base64-encoded declaration.
+func TestCmdPackWrongArgCount(t *testing.T) {
+	if err := cmdPack(nil); err == nil {
+		t.Fatal("expected error with zero args")
+	}
+	if err := cmdPack([]string{"a.mfl", "b.mfl"}); err == nil {
+		t.Fatal("expected error with two args")
+	}
+}
+
+func TestCmdPackMissingFile(t *testing.T) {
+	if err := cmdPack([]string{filepath.Join(t.TempDir(), "nope.mfl")}); err == nil {
+		t.Fatal("expected error for a missing file")
+	}
+}
+
+func TestCmdPackEncodesEachDecl(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.mfl")
+	decl := `func main() int { return 0 }`
+	src := "\n" + decl + "\n\n" // blank lines around the decl must be skipped
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = cmdPack([]string{path})
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("cmdPack: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	out := strings.TrimSpace(string(buf[:n]))
+	decoded, err := base64.StdEncoding.DecodeString(out)
+	if err != nil {
+		t.Fatalf("output is not valid base64: %v", err)
+	}
+	if string(decoded) != decl {
+		t.Fatalf("got decoded %q, want %q", decoded, decl)
+	}
+}
+
+// declFromLine must tolerate input that is already packed (base64), so pack
+// can safely be re-run on a file that mixes plain and packed lines.
+func TestCmdPackTolerantOfAlreadyPackedLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.mfl")
+	decl := `func f() int { return 1 }`
+	packed := base64.StdEncoding.EncodeToString([]byte(decl))
+	if err := os.WriteFile(path, []byte(packed+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := os.Stdout
+	devnull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	os.Stdout = devnull
+	err := cmdPack([]string{path})
+	os.Stdout = old
+	if devnull != nil {
+		devnull.Close()
+	}
+	if err != nil {
+		t.Fatalf("cmdPack should tolerate an already-packed line, got: %v", err)
+	}
+}

--- a/cmdskill_test.go
+++ b/cmdskill_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cmdSkill (the `machin skill` subcommand dispatcher) had no direct test
+// coverage: default-to-list, "show", "install", and the unknown-subcommand
+// error path.
+
+func withSilencedStdout(t *testing.T, fn func() error) error {
+	t.Helper()
+	old := os.Stdout
+	devnull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	defer func() {
+		os.Stdout = old
+		if devnull != nil {
+			devnull.Close()
+		}
+	}()
+	os.Stdout = devnull
+	return fn()
+}
+
+func TestCmdSkillDefaultsToList(t *testing.T) {
+	err := withSilencedStdout(t, func() error { return cmdSkill(nil) })
+	if err != nil {
+		t.Fatalf("cmdSkill with no args should list, got: %v", err)
+	}
+}
+
+func TestCmdSkillShowKnown(t *testing.T) {
+	err := withSilencedStdout(t, func() error { return cmdSkill([]string{"show", "machin-start"}) })
+	if err != nil {
+		t.Fatalf("cmdSkill show machin-start: %v", err)
+	}
+}
+
+func TestCmdSkillShowAlias(t *testing.T) {
+	err := withSilencedStdout(t, func() error { return cmdSkill([]string{"show", "web"}) })
+	if err != nil {
+		t.Fatalf("cmdSkill show web (alias): %v", err)
+	}
+}
+
+func TestCmdSkillShowUnknownErrors(t *testing.T) {
+	err := withSilencedStdout(t, func() error { return cmdSkill([]string{"show", "nope"}) })
+	if err == nil {
+		t.Fatal("expected an error for an unknown skill name")
+	}
+}
+
+func TestCmdSkillShowMissingNameErrors(t *testing.T) {
+	err := withSilencedStdout(t, func() error { return cmdSkill([]string{"show"}) })
+	if err == nil {
+		t.Fatal("expected an error when show is given no name")
+	}
+}
+
+func TestCmdSkillInstallDispatches(t *testing.T) {
+	dir := t.TempDir()
+	err := withSilencedStdout(t, func() error {
+		return cmdSkill([]string{"install", "--dir", dir, "machin-start"})
+	})
+	if err != nil {
+		t.Fatalf("cmdSkill install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "machin-start", "SKILL.md")); err != nil {
+		t.Fatalf("expected machin-start installed: %v", err)
+	}
+}
+
+func TestCmdSkillUnknownSubcommandErrors(t *testing.T) {
+	err := withSilencedStdout(t, func() error { return cmdSkill([]string{"bogus"}) })
+	if err == nil {
+		t.Fatal("expected an error for an unknown subcommand")
+	}
+}
+
+func TestEmbeddedSkillsHasAllOrderedNames(t *testing.T) {
+	skills := embeddedSkills()
+	for _, n := range skillOrder {
+		if skills[n] == "" {
+			t.Fatalf("embeddedSkills missing content for %q", n)
+		}
+	}
+}

--- a/racecheck_globalaccess_branches_test.go
+++ b/racecheck_globalaccess_branches_test.go
@@ -1,0 +1,196 @@
+package main
+
+import "testing"
+
+// racecheck_analysis_test.go already covers the common-case branches of
+// collectGlobalAccess/collectCallGraph (Ident/Binary/Call reads; AssignStmt/
+// ExprStmt/IfStmt/GoStmt/SendStmt walks). This file covers the remaining
+// expr/stmt kinds those functions switch on, plus blockOf's RangeStmt/ArenaStmt
+// cases and mainPostGlobals' pre-spawn nested-block descent.
+
+func TestCollectGlobalAccessRemainingExprKinds(t *testing.T) {
+	gset := map[string]bool{"g": true}
+	local := map[string]bool{}
+
+	var reads []string
+	sink := func(name string, read, write bool) {
+		if read {
+			reads = append(reads, name)
+		}
+	}
+
+	body := []Stmt{
+		&ExprStmt{X: &Index{X: &Ident{Name: "g"}, Idx: &IntLit{Val: 0}}},
+		&ExprStmt{X: &FieldAccess{X: &Ident{Name: "g"}, Name: "f"}},
+		&ExprStmt{X: &Unary{Op: "-", X: &Ident{Name: "g"}}},
+		&ExprStmt{X: &SliceLit{Elems: []Expr{&Ident{Name: "g"}}}},
+		&ExprStmt{X: &StructLit{Type: "P", Vals: []Expr{&Ident{Name: "g"}}}},
+		&IfStmt{Cond: nil, Then: nil}, // rd(nil) must not panic
+	}
+
+	collectGlobalAccess(body, gset, local, sink)
+
+	if len(reads) < 5 {
+		t.Fatalf("expected at least 5 reads of g (index/field/unary/slice/struct), got %v", reads)
+	}
+	for _, r := range reads {
+		if r != "g" {
+			t.Fatalf("unexpected read target %q, want only \"g\"", r)
+		}
+	}
+}
+
+func TestCollectGlobalAccessRemainingStmtKinds(t *testing.T) {
+	gset := map[string]bool{"g": true}
+	local := map[string]bool{}
+
+	var events []string
+	sink := func(name string, read, write bool) {
+		switch {
+		case write:
+			events = append(events, "write:"+name)
+		case read:
+			events = append(events, "read:"+name)
+		}
+	}
+
+	body := []Stmt{
+		&MultiAssign{Names: []string{"a", "b"}, Op: ":=", Rhs: []Expr{&Ident{Name: "g"}}},
+		&IndexAssign{Target: &Index{X: &Ident{Name: "g"}, Idx: &IntLit{Val: 0}}, Val: &IntLit{Val: 1}},
+		&FieldAssign{Target: &FieldAccess{X: &Ident{Name: "g"}, Name: "f"}, Val: &IntLit{Val: 1}},
+		&ReturnStmt{Vals: []Expr{&Ident{Name: "g"}}},
+		&WhileStmt{Cond: &Ident{Name: "g"}, Body: []Stmt{&ExprStmt{X: &Ident{Name: "g"}}}},
+		&RangeStmt{X: &Ident{Name: "g"}, Body: []Stmt{&ExprStmt{X: &Ident{Name: "g"}}}},
+		&ArenaStmt{Body: []Stmt{&ExprStmt{X: &Ident{Name: "g"}}}},
+	}
+
+	collectGlobalAccess(body, gset, local, sink)
+
+	wantWrite := map[string]bool{"write:g": false} // IndexAssign/FieldAssign on g are whole-cell paths, not plain idents
+	for _, e := range events {
+		if e == "write:g" {
+			wantWrite["write:g"] = true
+		}
+	}
+	// IndexAssign/FieldAssign target g via placeOf, so they DO report a write.
+	if !wantWrite["write:g"] {
+		t.Errorf("expected at least one write:g event from IndexAssign/FieldAssign, got %v", events)
+	}
+
+	readCount := 0
+	for _, e := range events {
+		if e == "read:g" {
+			readCount++
+		}
+	}
+	// MultiAssign rhs, ReturnStmt val, while cond+body, range X+body, arena body: >= 6
+	if readCount < 6 {
+		t.Errorf("expected >= 6 reads of g across MultiAssign/ReturnStmt/While/Range/Arena, got %d (%v)", readCount, events)
+	}
+}
+
+func TestCollectCallGraphRemainingExprKinds(t *testing.T) {
+	var normal []string
+	var gos []goSite
+
+	body := []Stmt{
+		&ExprStmt{X: &Unary{Op: "-", X: &Call{Callee: "unaryArg"}}},
+		&ExprStmt{X: &Index{X: &Call{Callee: "indexBase"}, Idx: &Call{Callee: "indexArg"}}},
+		&ExprStmt{X: &FieldAccess{X: &Call{Callee: "fieldBase"}, Name: "f"}},
+		&ExprStmt{X: &SliceLit{Elems: []Expr{&Call{Callee: "sliceElem"}}}},
+		&ExprStmt{X: &StructLit{Type: "P", Vals: []Expr{&Call{Callee: "structVal"}}}},
+	}
+
+	collectCallGraph(body, false, &normal, &gos)
+
+	want := []string{"unaryArg", "indexBase", "indexArg", "fieldBase", "sliceElem", "structVal"}
+	for _, w := range want {
+		found := false
+		for _, got := range normal {
+			if got == w {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("collectCallGraph: normal callees %v missing %q", normal, w)
+		}
+	}
+}
+
+func TestCollectCallGraphRemainingStmtKinds(t *testing.T) {
+	var normal []string
+	var gos []goSite
+
+	body := []Stmt{
+		&MultiAssign{Names: []string{"a", "b"}, Op: ":=", Rhs: []Expr{&Call{Callee: "multiAssignRhs"}}},
+		&IndexAssign{Target: &Index{X: &Ident{Name: "x"}, Idx: &IntLit{Val: 0}}, Val: &Call{Callee: "indexAssignVal"}},
+		&FieldAssign{Target: &FieldAccess{X: &Ident{Name: "x"}, Name: "f"}, Val: &Call{Callee: "fieldAssignVal"}},
+		&ReturnStmt{Vals: []Expr{&Call{Callee: "returnVal"}}},
+		&RangeStmt{X: &Ident{Name: "xs"}, Body: []Stmt{&GoStmt{Call: &Call{Callee: "rangedWorker"}}}},
+		&ArenaStmt{Body: []Stmt{&GoStmt{Call: &Call{Callee: "arenaWorker"}}}},
+	}
+
+	collectCallGraph(body, false, &normal, &gos)
+
+	want := []string{"multiAssignRhs", "indexAssignVal", "fieldAssignVal", "returnVal"}
+	for _, w := range want {
+		found := false
+		for _, got := range normal {
+			if got == w {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("collectCallGraph: normal callees %v missing %q", normal, w)
+		}
+	}
+
+	bySite := map[string]bool{}
+	for _, g := range gos {
+		bySite[g.callee] = g.inLoop
+	}
+	if inLoop, ok := bySite["rangedWorker"]; !ok || !inLoop {
+		t.Errorf("collectCallGraph: 'rangedWorker' inside a range must have inLoop=true, got %v (present=%v)", inLoop, ok)
+	}
+	if inLoop, ok := bySite["arenaWorker"]; !ok || inLoop {
+		t.Errorf("collectCallGraph: 'arenaWorker' inside an arena (not a loop) must inherit inLoop=false, got %v (present=%v)", inLoop, ok)
+	}
+}
+
+func TestBlockOfRangeAndArena(t *testing.T) {
+	rangeBody := []Stmt{&AssignStmt{Name: "a", Op: ":=", Val: &IntLit{Val: 1}}}
+	if body, ok := blockOf(&RangeStmt{Body: rangeBody}); !ok || len(body) != 1 {
+		t.Fatalf("blockOf(RangeStmt) = (%v, %v), want its body", body, ok)
+	}
+
+	arenaBody := []Stmt{&AssignStmt{Name: "b", Op: ":=", Val: &IntLit{Val: 2}}}
+	if body, ok := blockOf(&ArenaStmt{Body: arenaBody}); !ok || len(body) != 1 {
+		t.Fatalf("blockOf(ArenaStmt) = (%v, %v), want its body", body, ok)
+	}
+}
+
+// mainPostGlobals must descend into a block that precedes the first `go` spawn
+// (to find a spawn nested inside it) without collecting the accesses inside
+// that pre-spawn block itself.
+func TestMainPostGlobalsDescendsPreSpawnBlock(t *testing.T) {
+	gset := map[string]bool{"g": true}
+	local := map[string]bool{}
+
+	body := []Stmt{
+		&IfStmt{
+			Cond: &Ident{Name: "cond"},
+			Then: []Stmt{
+				&ExprStmt{X: &Ident{Name: "g"}}, // pre-spawn access inside the nested block: must NOT be collected
+				&GoStmt{Call: &Call{Callee: "worker"}},
+			},
+		},
+		&ExprStmt{X: &Ident{Name: "g"}}, // post-spawn (top-level, after the if): must be collected
+	}
+
+	got := mainPostGlobals(body, gset, local)
+
+	acc := got["g"]
+	if acc == nil || !acc.read {
+		t.Fatalf("mainPostGlobals: expected a post-spawn read of g, got %v", got)
+	}
+}

--- a/skilltargets_test.go
+++ b/skilltargets_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// skillTargets and skillInstall had no direct test coverage; cover the target
+// resolution rules (explicit --dir wins, env var, ~/.agents/skills, and the
+// conditional ~/.claude/skills) and the actual file-writing side of install.
+
+func TestSkillTargetsExplicitDirWins(t *testing.T) {
+	t.Setenv("AGENT_SKILLS_DIR", "/should/be/ignored")
+	got := skillTargets("/explicit/dir")
+	if len(got) != 1 || got[0] != "/explicit/dir" {
+		t.Fatalf("got %v, want [/explicit/dir]", got)
+	}
+}
+
+func TestSkillTargetsDetectsClaudeDirWhenPresent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_SKILLS_DIR", "")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := skillTargets("")
+	want := []string{
+		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".claude", "skills"),
+	}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestSkillTargetsOmitsClaudeDirWhenAbsent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_SKILLS_DIR", "")
+
+	got := skillTargets("")
+	want := []string{filepath.Join(home, ".agents", "skills")}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestSkillTargetsIncludesAgentSkillsDirEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_SKILLS_DIR", "/custom/agent/dir")
+
+	got := skillTargets("")
+	if len(got) == 0 || got[0] != "/custom/agent/dir" {
+		t.Fatalf("expected AGENT_SKILLS_DIR first, got %v", got)
+	}
+}
+
+func TestSkillInstallWritesAllSkillsToExplicitDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := skillInstall([]string{"--dir", dir}); err != nil {
+		t.Fatalf("skillInstall: %v", err)
+	}
+	for _, n := range skillOrder {
+		p := filepath.Join(dir, n, "SKILL.md")
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("expected %s to be written: %v", p, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("%s is empty", p)
+		}
+	}
+}
+
+func TestSkillInstallSingleNamedSkill(t *testing.T) {
+	dir := t.TempDir()
+	if err := skillInstall([]string{"--dir", dir, "machin-web"}); err != nil {
+		t.Fatalf("skillInstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "machin-web", "SKILL.md")); err != nil {
+		t.Fatalf("expected machin-web installed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "machin-deploy")); err == nil {
+		t.Fatal("machin-deploy should not have been installed")
+	}
+}
+
+func TestSkillInstallUnknownSkillErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := skillInstall([]string{"--dir", dir, "not-a-real-skill"}); err == nil {
+		t.Fatal("expected an error for an unknown skill name")
+	}
+}
+
+func TestSkillInstallNoTargetErrors(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("AGENT_SKILLS_DIR", "")
+	if err := skillInstall(nil); err == nil {
+		t.Fatal("expected an error when no install target can be resolved")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thoxis`

## Summary

Added Go unit tests for previously-uncovered code paths: `cmdPack` (the `machin pack` subcommand, including its already-packed-input tolerance), `skillTargets`/`skillInstall` (install-target resolution rules and actual file writes), `cmdSkill`/`embeddedSkills` (the `machin skill` subcommand dispatcher), and the remaining AST-kind branches of `racecheck.go`'s `collectGlobalAccess`/`collectCallGraph`/`blockOf`/`mainPostGlobals` (bringing those four from 48-56% to 100% statement coverage). No production code changed — pure test-coverage work following the same pattern as other recent test(...) commits in this repo, and avoids the files already claimed by in-flight PRs #381 and #355.

**Diff:**
```
cmdpack_test.go                         |  84 ++++++++++++++
 cmdskill_test.go                        |  89 +++++++++++++++
 racecheck_globalaccess_branches_test.go | 196 ++++++++++++++++++++++++++++++++
 skilltargets_test.go                    | 105 +++++++++++++++++
 4 files changed, 474 insertions(+)
```
