### PR TITLE
test(parser): cover parseTypeName/parseTypeDecl/parseMake branches

### DIFF
--- a/parser_typemake_test.go
+++ b/parser_typemake_test.go
@@ -1,0 +1,123 @@
+package main
+
+import "testing"
+
+func TestParseTypeSliceField(t *testing.T) {
+	td, err := ParseType(`type Box struct { items []int }`)
+	if err != nil {
+		t.Fatalf("ParseType: unexpected error: %v", err)
+	}
+	if len(td.Fields) != 1 || td.Fields[0].Type != "[]int" {
+		t.Errorf("Fields = %#v, want a single []int field", td.Fields)
+	}
+}
+
+func TestParseTypeMapField(t *testing.T) {
+	td, err := ParseType(`type Store struct { data map[string]int }`)
+	if err != nil {
+		t.Fatalf("ParseType: unexpected error: %v", err)
+	}
+	if len(td.Fields) != 1 || td.Fields[0].Type != "map[string]int" {
+		t.Errorf("Fields = %#v, want a single map[string]int field", td.Fields)
+	}
+}
+
+func TestParseTypeChanField(t *testing.T) {
+	td, err := ParseType(`type Pipe struct { c chan int }`)
+	if err != nil {
+		t.Fatalf("ParseType: unexpected error: %v", err)
+	}
+	if len(td.Fields) != 1 || td.Fields[0].Type != "chan int" {
+		t.Errorf("Fields = %#v, want a single chan int field", td.Fields)
+	}
+}
+
+func TestParseTypeFuncField(t *testing.T) {
+	td, err := ParseType(`type Handler struct { cb func }`)
+	if err != nil {
+		t.Fatalf("ParseType: unexpected error: %v", err)
+	}
+	if len(td.Fields) != 1 || td.Fields[0].Type != "func" {
+		t.Errorf("Fields = %#v, want a single func field", td.Fields)
+	}
+}
+
+func TestParseTypeNestedSliceOfMap(t *testing.T) {
+	td, err := ParseType(`type Grid struct { rows []map[string]int }`)
+	if err != nil {
+		t.Fatalf("ParseType: unexpected error: %v", err)
+	}
+	if len(td.Fields) != 1 || td.Fields[0].Type != "[]map[string]int" {
+		t.Errorf("Fields = %#v, want a single []map[string]int field", td.Fields)
+	}
+}
+
+func TestParseTypeBadFieldTypeToken(t *testing.T) {
+	if _, err := ParseType(`type Bad struct { n 123 }`); err == nil {
+		t.Fatal("ParseType: expected error for a non-identifier field type, got nil")
+	}
+}
+
+func TestParseTypeMissingTypeKeyword(t *testing.T) {
+	if _, err := ParseType(`Box struct { n int }`); err == nil {
+		t.Fatal("ParseType: expected error for missing 'type' keyword, got nil")
+	}
+}
+
+func TestParseTypeMissingStructKeyword(t *testing.T) {
+	if _, err := ParseType(`type Box { n int }`); err == nil {
+		t.Fatal("ParseType: expected error for missing 'struct' keyword, got nil")
+	}
+}
+
+func TestParseTypeMissingOpenBrace(t *testing.T) {
+	if _, err := ParseType(`type Box struct n int }`); err == nil {
+		t.Fatal("ParseType: expected error for missing '{', got nil")
+	}
+}
+
+func TestParseTypeFieldCommaSeparated(t *testing.T) {
+	td, err := ParseType(`type Point struct { x int, y int }`)
+	if err != nil {
+		t.Fatalf("ParseType: unexpected error: %v", err)
+	}
+	if len(td.Fields) != 2 {
+		t.Fatalf("Fields = %#v, want 2 fields", td.Fields)
+	}
+}
+
+func TestParseMakeChan(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { c := make(chan int) }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	as, ok := fn.Body[0].(*AssignStmt)
+	if !ok {
+		t.Fatalf("Body[0] = %T, want *AssignStmt", fn.Body[0])
+	}
+	mc, ok := as.Val.(*MakeChan)
+	if !ok || mc.Elem != "int" {
+		t.Errorf("Val = %#v, want *MakeChan{Elem: \"int\"}", as.Val)
+	}
+}
+
+func TestParseMakeMap(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { m := make(map[string]int) }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	as, ok := fn.Body[0].(*AssignStmt)
+	if !ok {
+		t.Fatalf("Body[0] = %T, want *AssignStmt", fn.Body[0])
+	}
+	mm, ok := as.Val.(*MakeMap)
+	if !ok || mm.Key != "string" || mm.Val != "int" {
+		t.Errorf("Val = %#v, want *MakeMap{Key: \"string\", Val: \"int\"}", as.Val)
+	}
+}
+
+func TestParseMakeUnsupportedKind(t *testing.T) {
+	if _, err := ParseFunc(normalize(`func main() { s := make(int) }`)); err == nil {
+		t.Fatal("ParseFunc: expected error for make(int), got nil")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thoy2s`

**Diff:**
```
parser_typemake_test.go | 123 ++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 123 insertions(+)
```
