### PR TITLE
test(types): cover tryRange channel range arity check

### DIFF
--- a/framework_test.go
+++ b/framework_test.go
@@ -61,6 +61,27 @@ func TestReadModulePrefersLocal(t *testing.T) {
 	}
 }
 
+// A path that isn't a real file and doesn't match the embedded tree by full
+// path (e.g. a nested alias) still resolves via the module's base name.
+func TestReadModuleBaseNameFallback(t *testing.T) {
+	got, err := readModule(filepath.Join("some", "other", "dir", "machweb.src"))
+	if err != nil {
+		t.Fatalf("expected base-name fallback to resolve, got: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected non-empty embedded module contents")
+	}
+}
+
+// A path with no matching real file, embedded full path, or embedded base
+// name surfaces the original os.ReadFile not-exist error.
+func TestReadModuleNotFound(t *testing.T) {
+	_, err := readModule(filepath.Join("some", "other", "dir", "does-not-exist.src"))
+	if err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected a not-exist error, got: %v", err)
+	}
+}
+
 // The embedded set covers the real modules an app composes against.
 func TestFrameworkModulesEmbedded(t *testing.T) {
 	mods := frameworkModules()

--- a/types_range_test.go
+++ b/types_range_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRangeOverChannelTwoVarsRejected exercises the tryRange KChan branch
+// (types.go) that rejects `for k, v := range ch` — a channel range yields a
+// single received element, not a key/value pair.
+func TestRangeOverChannelTwoVarsRejected(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { c := make(chan int) for k, v := range c { println(k) println(v) } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil || !strings.Contains(err.Error(), "range over a channel takes a single variable") {
+		t.Fatalf("expected channel range arity error, got %v", err)
+	}
+}
+
+// TestRangeOverChannelSingleVar exercises the tryRange KChan success branch
+// with a single loop variable bound to the channel's element type.
+func TestRangeOverChannelSingleVar(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { c := make(chan int) go send(c) for v := range c { println(v) } }`,
+		`func send(c) { c <- 1 close(c) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thoz04`

**Diff:**
```
framework_test.go   | 21 +++++++++++++++++++++
 types_range_test.go | 37 +++++++++++++++++++++++++++++++++++++
 2 files changed, 58 insertions(+)
```
