### PR TITLE
test(uftest): cover cmdUFTest script ops, dumpUF, and boolToInt

### DIFF
--- a/checktest_test.go
+++ b/checktest_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cmdCheckTest had no direct test coverage; cover its usage-error path plus
+// the --program happy path, parse-error path, and check-error path.
+func TestCmdCheckTestUsage(t *testing.T) {
+	if err := cmdCheckTest(nil); err == nil {
+		t.Fatal("expected usage error with no args")
+	}
+	if err := cmdCheckTest([]string{"--program"}); err == nil {
+		t.Fatal("expected usage error with missing file arg")
+	}
+	if err := cmdCheckTest([]string{"--bogus", "x"}); err == nil {
+		t.Fatal("expected usage error for unrecognized flag")
+	}
+}
+
+func TestCmdCheckTestMissingFile(t *testing.T) {
+	err := cmdCheckTest([]string{"--program", filepath.Join(t.TempDir(), "nope.mfl")})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func withCapturedStdout(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 8192)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestCmdCheckTestParseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.mfl")
+	if err := os.WriteFile(path, []byte("this is not valid mfl {{{\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	out := withCapturedStdout(t, func() {
+		callErr = cmdCheckTest([]string{"--program", path})
+	})
+	if callErr != nil {
+		t.Fatalf("cmdCheckTest returned error instead of printing: %v", callErr)
+	}
+	if strings.TrimSpace(out) != "(parse-error)" {
+		t.Fatalf("got %q, want (parse-error)", out)
+	}
+}
+
+func TestCmdCheckTestCheckError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unbound.mfl")
+	// parses fine but references an undefined function, so Check() fails.
+	if err := os.WriteFile(path, []byte("func main(){x:=undefinedFn(1)}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	out := withCapturedStdout(t, func() {
+		callErr = cmdCheckTest([]string{"--program", path})
+	})
+	if callErr != nil {
+		t.Fatalf("cmdCheckTest returned error instead of printing: %v", callErr)
+	}
+	if strings.TrimSpace(out) != "(check-error)" {
+		t.Fatalf("got %q, want (check-error)", out)
+	}
+}
+
+func TestCmdCheckTestProgram(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prog.mfl")
+	src := "func add(a,b){return a+b}\n\nfunc main(){x:=add(1,2)}\n"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	out := withCapturedStdout(t, func() {
+		callErr = cmdCheckTest([]string{"--program", path})
+	})
+	if callErr != nil {
+		t.Fatalf("cmdCheckTest: %v", callErr)
+	}
+	for _, want := range []string{"(func add", "(param a int)", "(param b int)", "(ret 0 int)", "(func main", "(local x int)"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q, got:\n%s", want, out)
+		}
+	}
+	// "add" sorts before "main", so its row must come first.
+	if strings.Index(out, "(func add") > strings.Index(out, "(func main") {
+		t.Fatalf("rows not sorted by key, got:\n%s", out)
+	}
+}

--- a/uftest_helpers_test.go
+++ b/uftest_helpers_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBoolToInt(t *testing.T) {
+	if got := boolToInt(true); got != 1 {
+		t.Fatalf("boolToInt(true) = %d, want 1", got)
+	}
+	if got := boolToInt(false); got != 0 {
+		t.Fatalf("boolToInt(false) = %d, want 0", got)
+	}
+}
+
+func TestDumpUF(t *testing.T) {
+	c := &Checker{}
+	newSlot(c, KVar)              // 0
+	s1 := newSlot(c, KSlice)      // 1
+	c.elem[s1] = newSlot(c, KInt) // 2
+	s2 := newSlot(c, KStruct)     // 3
+	c.sname[s2] = "Foo"
+	s3 := newSlot(c, KMap) // 4
+	c.mkey[s3] = newSlot(c, KString)
+	c.mval[s3] = newSlot(c, KBool)
+	newFuncSlot(c, &funcSig{params: []int{0}, ret: 2})
+
+	out := dumpUF(c, false)
+	for _, want := range []string{"kind=slice", "sname=Foo", "mkey=", "fsig=", "err=0"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dumpUF output missing %q, got:\n%s", want, out)
+		}
+	}
+
+	failedOut := dumpUF(c, true)
+	if !strings.Contains(failedOut, "err=1") {
+		t.Fatalf("dumpUF(failed) missing err=1, got:\n%s", failedOut)
+	}
+}
+
+func TestCmdUFTestScript(t *testing.T) {
+	script := `# comment line
+var
+num
+int
+float
+bool
+string
+void
+bytes
+slice 2
+chan 2
+struct Bar
+map 0 1
+func 0,1|2
+union 2 3
+dump
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.uf")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdUFTest([]string{path}); err != nil {
+		t.Fatalf("cmdUFTest() error = %v", err)
+	}
+}
+
+func TestCmdUFTestUnionMismatch(t *testing.T) {
+	script := "int\nstring\nunion 0 1\ndump\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.uf")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdUFTest([]string{path}); err != nil {
+		t.Fatalf("cmdUFTest() error = %v", err)
+	}
+}
+
+func TestCmdUFTestUnknownOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.uf")
+	if err := os.WriteFile(path, []byte("bogus\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdUFTest([]string{path}); err == nil {
+		t.Fatal("expected error for unknown op, got nil")
+	}
+}
+
+func TestCmdUFTestMissingFile(t *testing.T) {
+	if err := cmdUFTest([]string{filepath.Join(t.TempDir(), "does-not-exist.uf")}); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thozqs`

**Diff:**
```
checktest_test.go      | 111 +++++++++++++++++++++++++++++++++++++++++++++++++
 uftest_helpers_test.go | 102 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 213 insertions(+)
```
