### PR TITLE
test(main): cover cmdEncode missing-arg and composeSources file-error paths

### DIFF
--- a/cmdencode_test.go
+++ b/cmdencode_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestCmdEncodeNoArgs(t *testing.T) {
+	err := cmdEncode(nil)
+	if err == nil {
+		t.Fatal("expected error for missing source file, got nil")
+	}
+	want := "encode: need at least one source file"
+	if err.Error() != want {
+		t.Errorf("cmdEncode(nil) error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestComposeSourcesMissingFile(t *testing.T) {
+	_, _, err := composeSources([]string{"does-not-exist.mfl"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent source file, got nil")
+	}
+}

--- a/tryindex_test.go
+++ b/tryindex_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+// TestSliceIndexUseWrongIdxType exercises the tryIndex KSlice branch where
+// c.union(iu.idx, c.cInt) fails: indexing a slice with a non-int key.
+func TestSliceIndexUseWrongIdxType(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { xs := []int{1, 2, 3} k := "a" println(xs[k]) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil {
+		t.Fatal("expected type error indexing a slice with a string key")
+	}
+}
+
+// TestMapIndexUseWrongKeyType exercises the tryIndex KMap branch where
+// c.union(iu.idx, ks) fails: indexing a map[string]int with an int key.
+func TestMapIndexUseWrongKeyType(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { m := make(map[string]int) m["a"] = 1 x := m[1] println(x) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil {
+		t.Fatal("expected type error indexing map[string]int with an int key")
+	}
+}
+
+// TestSliceIndexResultTypeMismatch exercises the tryIndex KSlice branch where
+// c.union(iu.result, e) fails: the indexed element is later used as a string.
+func TestSliceIndexResultTypeMismatch(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { xs := []int{1, 2, 3} y := xs[0] y = "hi" println(y) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil {
+		t.Fatal("expected type error reassigning an []int element to a string")
+	}
+}
+
+// TestMapIndexResultTypeMismatch exercises the tryIndex KMap branch where
+// c.union(iu.result, vs) fails: the map value is later used as a string.
+func TestMapIndexResultTypeMismatch(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { m := make(map[string]int) m["a"] = 1 y := m["a"] y = "hi" println(y) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil {
+		t.Fatal("expected type error reassigning a map[string]int value to a string")
+	}
+}

--- a/types_branches_test.go
+++ b/types_branches_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func checkerFromProgram(t *testing.T, decls ...string) *Checker {
+	prog, err := ParseProgram(decls)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+	return c
+}
+
+// TestTypeSlotCompositeAndScalar exercises the typeSlot recursion through
+// []T, chan T, and map[K]V, plus its struct-name and scalar leaves.
+func TestTypeSlotCompositeAndScalar(t *testing.T) {
+	c := checkerFromProgram(t, `type P struct { x int  y int }`, `func main() { println(1) }`)
+
+	cases := []string{"int", "float", "bool", "string", "bytes", "[]int", "chan int", "map[string]int", "P"}
+	for _, tn := range cases {
+		if _, err := c.typeSlot(tn); err != nil {
+			t.Errorf("typeSlot(%q): unexpected error: %v", tn, err)
+		}
+	}
+}
+
+// TestTypeSlotUnknownType exercises the typeSlot error leaf for a type name
+// that is neither a builtin scalar nor a declared struct.
+func TestTypeSlotUnknownType(t *testing.T) {
+	c := checkerFromProgram(t, `func main() { println(1) }`)
+
+	if _, err := c.typeSlot("NoSuchType"); err == nil {
+		t.Fatal("typeSlot(\"NoSuchType\"): expected error, got nil")
+	}
+}
+
+// TestCheckTypeNameAccepts exercises the checkTypeName recursion through
+// []T, chan T, and map[K]V, plus its struct-name and scalar leaves.
+func TestCheckTypeNameAccepts(t *testing.T) {
+	c := checkerFromProgram(t, `type P struct { x int  y int }`, `func main() { println(1) }`)
+
+	cases := []string{"int", "float", "bool", "string", "bytes", "func", "[]int", "chan int", "map[string]int", "P"}
+	for _, tn := range cases {
+		if err := c.checkTypeName(tn); err != nil {
+			t.Errorf("checkTypeName(%q): unexpected error: %v", tn, err)
+		}
+	}
+}
+
+// TestCheckTypeNameRejectsUnknown exercises the checkTypeName error leaf,
+// including through a composite type whose element is unknown.
+func TestCheckTypeNameRejectsUnknown(t *testing.T) {
+	c := checkerFromProgram(t, `func main() { println(1) }`)
+
+	for _, tn := range []string{"NoSuchType", "[]NoSuchType", "map[string]NoSuchType"} {
+		err := c.checkTypeName(tn)
+		if err == nil {
+			t.Errorf("checkTypeName(%q): expected error, got nil", tn)
+			continue
+		}
+		if !strings.Contains(err.Error(), "unknown type") {
+			t.Errorf("checkTypeName(%q): error = %v, want mention of unknown type", tn, err)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp044`

## Summary

Added three small, focused test files that close real coverage gaps in main.go and types.go: cmdEncode/composeSources error paths, the tryIndex union-failure branches for slice/map index use (wrong index type, mismatched result type), and typeSlot/checkTypeName's composite-type recursion ([]T, chan T, map[K]V) plus their unknown-type error leaves. No source logic was changed — tests only, using the existing ParseProgram+Check(prog) harness pattern already used elsewhere in the suite. Avoided all files claimed by open PRs #381 and #355.

**Diff:**
```
cmdencode_test.go      | 21 +++++++++++++++
 tryindex_test.go       | 59 +++++++++++++++++++++++++++++++++++++++++
 types_branches_test.go | 71 ++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 151 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for command encoding when no source file is provided, including the expected error message.
  * Added a check that missing input files are reported as errors.
  * Expanded type-checking tests to validate invalid slice and map indexing cases.
  * Added broader type name validation tests for supported scalar and composite types, plus clear errors for unknown types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->