### PR TITLE
test(lextest): cover cmdLexTest/cmdLexBench error paths

### DIFF
--- a/lextest_test.go
+++ b/lextest_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cmdLexTest had no direct test coverage; cover its error paths: missing argument, file not found,
+// and a successful lex of a simple source file.
+func TestCmdLexTestMissingArg(t *testing.T) {
+	if err := cmdLexTest(nil); err == nil {
+		t.Fatal("expected error for missing file arg, got nil")
+	}
+}
+
+func TestCmdLexTestFileNotFound(t *testing.T) {
+	if err := cmdLexTest([]string{"/nonexistent/path/file.mfl"}); err == nil {
+		t.Fatal("expected error for file not found, got nil")
+	}
+}
+
+func TestCmdLexTestSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.mfl")
+	src := "func main(){x:=1}"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdLexTest([]string{path}); err != nil {
+		t.Fatalf("cmdLexTest() error = %v", err)
+	}
+}
+
+// cmdLexBench had no direct test coverage; cover its error paths: missing arguments, file not found.
+func TestCmdLexBenchMissingArgs(t *testing.T) {
+	if err := cmdLexBench(nil); err == nil {
+		t.Fatal("expected error for missing args, got nil")
+	}
+	if err := cmdLexBench([]string{"file.mfl"}); err == nil {
+		t.Fatal("expected error for missing iters arg, got nil")
+	}
+}
+
+func TestCmdLexBenchFileNotFound(t *testing.T) {
+	if err := cmdLexBench([]string{"/nonexistent/path/file.mfl", "10"}); err == nil {
+		t.Fatal("expected error for file not found, got nil")
+	}
+}

--- a/parsetest_test.go
+++ b/parsetest_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // collectStructNames scans raw source lines for `type NAME` and `cstruct NAME`
 // declarations, feeding the set used to recognize `T{...}` composite literals
@@ -60,5 +64,66 @@ func TestSexprType(t *testing.T) {
 	want := "(type Point (fields (f x int) (f y int)))"
 	if got != want {
 		t.Fatalf("sexprType = %q, want %q", got, want)
+	}
+}
+
+// cmdParseTest had no direct test coverage; cover its subcommands and error paths.
+func TestCmdParseTestMissingSubcommand(t *testing.T) {
+	if err := cmdParseTest(nil); err == nil {
+		t.Fatal("expected error for missing subcommand, got nil")
+	}
+}
+
+func TestCmdParseTestExprMissingArg(t *testing.T) {
+	if err := cmdParseTest([]string{"--expr"}); err == nil {
+		t.Fatal("expected error for --expr missing source arg, got nil")
+	}
+}
+
+func TestCmdParseTestExprSuccess(t *testing.T) {
+	if err := cmdParseTest([]string{"--expr", "1"}); err != nil {
+		t.Fatalf("cmdParseTest --expr: %v", err)
+	}
+}
+
+func TestCmdParseTestExprTrailingTokens(t *testing.T) {
+	if err := cmdParseTest([]string{"--expr", "1 2"}); err == nil {
+		t.Fatal("expected error for trailing tokens after expression, got nil")
+	}
+}
+
+func TestCmdParseTestFuncMissingArg(t *testing.T) {
+	if err := cmdParseTest([]string{"--func"}); err == nil {
+		t.Fatal("expected error for --func missing source arg, got nil")
+	}
+}
+
+func TestCmdParseTestFuncSuccess(t *testing.T) {
+	if err := cmdParseTest([]string{"--func", "func main(){x:=1}"}); err != nil {
+		t.Fatalf("cmdParseTest --func: %v", err)
+	}
+}
+
+func TestCmdParseTestProgramMissingArg(t *testing.T) {
+	if err := cmdParseTest([]string{"--program"}); err == nil {
+		t.Fatal("expected error for --program missing file arg, got nil")
+	}
+}
+
+func TestCmdParseTestProgramFileNotFound(t *testing.T) {
+	if err := cmdParseTest([]string{"--program", "/nonexistent/path/file.mfl"}); err == nil {
+		t.Fatal("expected error for --program file not found, got nil")
+	}
+}
+
+func TestCmdParseTestProgramSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prog.mfl")
+	src := "func main(){x:=1}\n"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdParseTest([]string{"--program", path}); err != nil {
+		t.Fatalf("cmdParseTest --program: %v", err)
 	}
 }

--- a/racetest_test.go
+++ b/racetest_test.go
@@ -27,22 +27,8 @@ func TestCmdRaceTestFileNotFound(t *testing.T) {
 	}
 }
 
-func withCapturedStdout(t *testing.T, f func()) string {
-	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stdout = w
-	f()
-	w.Close()
-	os.Stdout = old
-
-	buf := make([]byte, 8192)
-	n, _ := r.Read(buf)
-	return string(buf[:n])
-}
+// withCapturedStdout is already defined in checktest_test.go (same package);
+// reuse it here instead of redeclaring it.
 
 func TestCmdRaceTestParseError(t *testing.T) {
 	dir := t.TempDir()

--- a/racetest_test.go
+++ b/racetest_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cmdRaceTest is the self-hosting race oracle; cover its error paths and happy cases:
+// missing args, missing --program flag, file not found, parse error, and successful detection.
+func TestCmdRaceTestMissingArgs(t *testing.T) {
+	if err := cmdRaceTest(nil); err == nil {
+		t.Fatal("expected error for missing args")
+	}
+}
+
+func TestCmdRaceTestMissingProgramFlag(t *testing.T) {
+	if err := cmdRaceTest([]string{"--bogus", "file.mfl"}); err == nil {
+		t.Fatal("expected error for missing --program flag")
+	}
+}
+
+func TestCmdRaceTestFileNotFound(t *testing.T) {
+	if err := cmdRaceTest([]string{"--program", "/nonexistent/path/file.mfl"}); err == nil {
+		t.Fatal("expected error for file not found")
+	}
+}
+
+func withCapturedStdout(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 8192)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestCmdRaceTestParseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.mfl")
+	if err := os.WriteFile(path, []byte("this is not valid mfl {{{\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	out := withCapturedStdout(t, func() {
+		callErr = cmdRaceTest([]string{"--program", path})
+	})
+	if callErr != nil {
+		t.Fatalf("cmdRaceTest returned error instead of printing: %v", callErr)
+	}
+	if strings.TrimSpace(out) != "(parse-error)" {
+		t.Fatalf("got %q, want (parse-error)", out)
+	}
+}
+
+func TestCmdRaceTestCleanProgram(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clean.mfl")
+	// A program with no races: single main function
+	src := "func main(){x:=1}\n"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	out := withCapturedStdout(t, func() {
+		callErr = cmdRaceTest([]string{"--program", path})
+	})
+	if callErr != nil {
+		t.Fatalf("cmdRaceTest: %v", callErr)
+	}
+	// Clean program should have no output (no findings)
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty output for clean program, got: %q", out)
+	}
+}
+
+func TestCmdRaceTestRaceFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "race.mfl")
+	// Two goroutines writing to the same global variable
+	src := "func worker(id){data:=100 println(id)} func main(){data:=0 go worker(1) go worker(2) println(data)}\n"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	out := withCapturedStdout(t, func() {
+		callErr = cmdRaceTest([]string{"--program", path})
+	})
+	if callErr != nil {
+		t.Fatalf("cmdRaceTest: %v", callErr)
+	}
+	// Should detect races (finding count depends on the race analysis)
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("expected race findings, got empty output")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp0ut`

## Summary

## Summary

Added 3 test improvements to close coverage gaps in oracle command functions:
1. **lextest_test.go**: Test coverage for cmdLexTest and cmdLexBench error paths (missing arguments, file not found)
2. **parsetest_test.go**: Test coverage for cmdParseTest subcommands (--expr, --func, --program) and their error paths
3. **racetest_test.go**: Test coverage for cmdRaceTest oracle function, covering parse errors and race detection

These tests ensure the oracle commands (which generate canonical output for byte-diffing the MFL self-hosted compiler against Go) properly handle error conditions and exercise all their subcommands.

**Diff:**
```
lextest_test.go   |  50 +++++++++++++++++++++++++
 parsetest_test.go |  67 ++++++++++++++++++++++++++++++++-
 racetest_test.go  | 108 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 224 insertions(+), 1 deletion(-)
```
