### PR TITLE
test(testcmd): cover cmdTest no-files and JSON output paths

### DIFF
--- a/testcmd_test.go
+++ b/testcmd_test.go
@@ -100,6 +100,39 @@ func TestRunMFLTestsNoFiles(t *testing.T) {
 	}
 }
 
+func TestCmdTestNoFiles(t *testing.T) {
+	err := cmdTest(nil)
+	if err == nil {
+		t.Fatal("expected error with no files")
+	}
+}
+
+func TestCmdTestWithJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	f := writeSrc(t, dir, "t.src", `func main() {
+	    assert(1 + 1 == 2, "addition")
+	    test_summary()
+	}`)
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = cmdTest([]string{"--json", f})
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+	if !strings.Contains(output, "\"ok\": true") && !strings.Contains(output, "\"ok\":true") {
+		t.Fatalf("JSON output should contain ok:true, got %q", output)
+	}
+}
+
 func TestParseTestSummary(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp2c5`

**Diff:**
```
testcmd_test.go | 33 +++++++++++++++++++++++++++++++++
 1 file changed, 33 insertions(+)
```
