### PR TITLE
test(checktest): cover cmdCheckTest empty program case

### DIFF
--- a/checktest_test.go
+++ b/checktest_test.go
@@ -109,3 +109,23 @@ func TestCmdCheckTestProgram(t *testing.T) {
 		t.Fatalf("rows not sorted by key, got:\n%s", out)
 	}
 }
+
+// cmdCheckTest with empty program (no functions) returns empty output.
+func TestCmdCheckTestEmptyProgram(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.mfl")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	out := withCapturedStdout(t, func() {
+		callErr = cmdCheckTest([]string{"--program", path})
+	})
+	if callErr != nil {
+		t.Fatalf("cmdCheckTest: %v", callErr)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("empty program should produce no output, got: %q", out)
+	}
+}

--- a/checktest_test.go
+++ b/checktest_test.go
@@ -125,7 +125,10 @@ func TestCmdCheckTestEmptyProgram(t *testing.T) {
 	if callErr != nil {
 		t.Fatalf("cmdCheckTest: %v", callErr)
 	}
-	if strings.TrimSpace(out) != "" {
-		t.Fatalf("empty program should produce no output, got: %q", out)
+	// An empty program has no `main` function and no `export func`, so it has
+	// no entry point — Check() rejects it (see types.go: "no main function
+	// defined"), and cmdCheckTest correctly reports that as a checker error.
+	if strings.TrimSpace(out) != "(check-error)" {
+		t.Fatalf("empty program should produce a check error, got: %q", out)
 	}
 }

--- a/cmdskill_test.go
+++ b/cmdskill_test.go
@@ -72,6 +72,16 @@ func TestCmdSkillInstallDispatches(t *testing.T) {
 	}
 }
 
+func TestCmdSkillInstallUnknownErrors(t *testing.T) {
+	dir := t.TempDir()
+	err := withSilencedStdout(t, func() error {
+		return cmdSkill([]string{"install", "--dir", dir, "unknown-skill"})
+	})
+	if err == nil {
+		t.Fatal("expected error for install of unknown skill")
+	}
+}
+
 func TestCmdSkillUnknownSubcommandErrors(t *testing.T) {
 	err := withSilencedStdout(t, func() error { return cmdSkill([]string{"bogus"}) })
 	if err == nil {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp2ss`

**Diff:**
```
checktest_test.go | 20 ++++++++++++++++++++
 cmdskill_test.go  | 10 ++++++++++
 2 files changed, 30 insertions(+)
```
