### PR TITLE
test(lexer): cover isDigit/isAlpha/isAlnum character class helpers

### DIFF
--- a/cmdrun_test.go
+++ b/cmdrun_test.go
@@ -85,3 +85,30 @@ func TestCmdBuildMissingSource(t *testing.T) {
 		t.Fatalf("cmdBuild with missing source should error, got nil")
 	}
 }
+
+func TestCmdRunWithRaceSafeFlag(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "prog.src")
+	// Simple sequential code that passes race checking
+	if err := os.WriteFile(srcPath, []byte("func main() { x := 1; println(x) }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// cmdRun --race-safe should pass through raceGate and execute
+	if err := cmdRun([]string{"--race-safe", srcPath}); err != nil {
+		t.Fatalf("cmdRun --race-safe: %v", err)
+	}
+}
+
+func TestCmdBuildWithRaceSafeFlag(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "prog.src")
+	outPath := filepath.Join(dir, "out")
+	// Simple sequential code that passes race checking
+	if err := os.WriteFile(srcPath, []byte("func main() { x := 1; println(x) }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// cmdBuild --race-safe should pass through raceGate and build successfully
+	if err := cmdBuild([]string{"--race-safe", "-o", outPath, srcPath}); err != nil {
+		t.Fatalf("cmdBuild --race-safe: %v", err)
+	}
+}

--- a/cmdrun_test.go
+++ b/cmdrun_test.go
@@ -112,3 +112,19 @@ func TestCmdBuildWithRaceSafeFlag(t *testing.T) {
 		t.Fatalf("cmdBuild --race-safe: %v", err)
 	}
 }
+
+func TestCmdBuildMissingFlagArg(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "prog.src")
+	if err := os.WriteFile(srcPath, []byte("func main() { }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// cmdBuild -o with no path should error
+	if err := cmdBuild([]string{"-o", srcPath}); err == nil {
+		t.Fatal("cmdBuild -o with no path should error, got nil")
+	}
+	// cmdBuild --target with no value should error
+	if err := cmdBuild([]string{"--target", srcPath}); err == nil {
+		t.Fatal("cmdBuild --target with no value should error, got nil")
+	}
+}

--- a/lexer_helpers_test.go
+++ b/lexer_helpers_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+// isDigit/isAlpha/isAlnum are simple character class helpers used in the lexer
+// to classify bytes; they had no direct test coverage despite being foundational
+// to tokenization.
+func TestCharClassHelpers(t *testing.T) {
+	cases := []struct {
+		name  string
+		c     byte
+		digit bool
+		alpha bool
+		alnum bool
+	}{
+		{"digit 0", '0', true, false, true},
+		{"digit 5", '5', true, false, true},
+		{"digit 9", '9', true, false, true},
+		{"letter a", 'a', false, true, true},
+		{"letter Z", 'Z', false, true, true},
+		{"underscore", '_', false, true, true},
+		{"space", ' ', false, false, false},
+		{"punct !", '!', false, false, false},
+		{"punct .", '.', false, false, false},
+	}
+	for _, c := range cases {
+		if got := isDigit(c.c); got != c.digit {
+			t.Errorf("isDigit(%q) = %v, want %v", c.c, got, c.digit)
+		}
+		if got := isAlpha(c.c); got != c.alpha {
+			t.Errorf("isAlpha(%q) = %v, want %v", c.c, got, c.alpha)
+		}
+		if got := isAlnum(c.c); got != c.alnum {
+			t.Errorf("isAlnum(%q) = %v, want %v", c.c, got, c.alnum)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp3q5`

## Summary

## Summary: 3 Test Coverage Improvements

Landed 3 small, focused test coverage improvements to increase coverage toward 90%+:

1. **test(lexer)**: Added TestCharClassHelpers covering isDigit/isAlpha/isAlnum character classification helpers (TIER3-POLISH). Fixed syntax error in provided file.

2. **test(cmdrun)**: Added TestCmdRunWithRaceSafeFlag and TestCmdBuildWithRaceSafeFlag to cover the --race-safe flag path (TIER1-CRITICAL CLI coverage). Previously untested code path through raceGate.

3. **test(cmdrun)**: Added TestCmdBuildMissingFlagArg to cover missing argument error paths for -o and --target flags. Previously untested error handling.

All tests pass. Changes follow existing test patterns in cmdrun_test.go and maintain CI/verification gate requirements.

**Diff:**
```
cmdrun_test.go        | 43 +++++++++++++++++++++++++++++++++++++++++++
 lexer_helpers_test.go | 37 +++++++++++++++++++++++++++++++++++++
 2 files changed, 80 insertions(+)
```
