### PR TITLE
test(parser): cover isExternDirective keyword checking

### DIFF
--- a/parser_extern_test.go
+++ b/parser_extern_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+// isExternDirective checks if a word is an extern directive keyword
+// (header, link, cflags, fn, cstruct); these cannot be used as return types.
+func TestIsExternDirective(t *testing.T) {
+	cases := []struct {
+		word string
+		want bool
+	}{
+		{"header", true},
+		{"link", true},
+		{"cflags", true},
+		{"fn", true},
+		{"cstruct", true},
+		{"int", false},
+		{"string", false},
+		{"myType", false},
+		{"", false},
+		{"FN", false},        // case-sensitive
+		{"Header", false},    // case-sensitive
+	}
+	for _, c := range cases {
+		if got := isExternDirective(c.word); got != c.want {
+			t.Errorf("isExternDirective(%q) = %v, want %v", c.word, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp4nh`

**Diff:**
```
parser_extern_test.go | 29 +++++++++++++++++++++++++++++
 1 file changed, 29 insertions(+)
```
