### PR TITLE
test(codegen): cover stringZeroInits for nested struct string field initialization

### DIFF
--- a/codegen_extra_test.go
+++ b/codegen_extra_test.go
@@ -1,0 +1,139 @@
+package main
+
+import "testing"
+
+func TestStringZeroInits(t *testing.T) {
+	// Test struct with string fields and other field types
+	prog := &Program{
+		Types: []*TypeDecl{
+			{
+				Name: "Point",
+				Fields: []Field{
+					{Name: "x", Type: "int"},
+					{Name: "y", Type: "int"},
+				},
+			},
+			{
+				Name: "Person",
+				Fields: []Field{
+					{Name: "name", Type: "string"},
+					{Name: "age", Type: "int"},
+					{Name: "email", Type: "string"},
+				},
+			},
+			{
+				Name: "Nested",
+				Fields: []Field{
+					{Name: "id", Type: "string"},
+					{Name: "data", Type: "Person"},
+				},
+			},
+			{
+				Name: "Mixed",
+				Fields: []Field{
+					{Name: "text", Type: "string"},
+					{Name: "count", Type: "int"},
+					{Name: "vals", Type: "[]string"},
+					{Name: "lookup", Type: "map[string]int"},
+					{Name: "ch", Type: "chan int"},
+					{Name: "fn", Type: "func"},
+				},
+			},
+		},
+		Funcs: []*FuncDecl{
+			{Name: "main", Params: []string{}, Returns: []string{}, Body: []Stmt{}},
+		},
+	}
+
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+
+	g := &cgen{c: c}
+
+	tests := []struct {
+		typeStr string
+		want    []string
+	}{
+		{"Point", nil},                    // no string fields
+		{"Person", []string{".f_name = \"\"", ".f_email = \"\""}},
+		{"Nested", []string{".f_id = \"\"", ".f_data = (mfl_Person){.f_name = \"\", .f_email = \"\"}"}},
+		{"Mixed", []string{".f_text = \"\""}},
+		{"Unknown", nil}, // struct doesn't exist
+	}
+
+	for _, tt := range tests {
+		got := g.stringZeroInits(tt.typeStr)
+		if len(got) != len(tt.want) {
+			t.Errorf("stringZeroInits(%q) got %d items, want %d", tt.typeStr, len(got), len(tt.want))
+			t.Logf("  got: %v", got)
+			t.Logf("  want: %v", tt.want)
+			continue
+		}
+		for i, w := range tt.want {
+			if i >= len(got) || got[i] != w {
+				t.Errorf("stringZeroInits(%q)[%d] = %q, want %q", tt.typeStr, i, got[i], w)
+			}
+		}
+	}
+}
+
+func TestStringZeroInitsEmpty(t *testing.T) {
+	// Test struct with no fields
+	prog := &Program{
+		Types: []*TypeDecl{
+			{Name: "Empty", Fields: []Field{}},
+		},
+		Funcs: []*FuncDecl{
+			{Name: "main", Params: []string{}, Returns: []string{}, Body: []Stmt{}},
+		},
+	}
+
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+
+	g := &cgen{c: c}
+	got := g.stringZeroInits("Empty")
+	if len(got) != 0 {
+		t.Errorf("stringZeroInits(Empty) = %v, want nil", got)
+	}
+}
+
+func TestStringZeroInitsOnlyStrings(t *testing.T) {
+	// Test struct with only string fields
+	prog := &Program{
+		Types: []*TypeDecl{
+			{
+				Name: "Strings",
+				Fields: []Field{
+					{Name: "a", Type: "string"},
+					{Name: "b", Type: "string"},
+					{Name: "c", Type: "string"},
+				},
+			},
+		},
+		Funcs: []*FuncDecl{
+			{Name: "main", Params: []string{}, Returns: []string{}, Body: []Stmt{}},
+		},
+	}
+
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+
+	g := &cgen{c: c}
+	got := g.stringZeroInits("Strings")
+	if len(got) != 3 {
+		t.Errorf("stringZeroInits(Strings) = %v, want 3 items", got)
+	}
+	want := []string{".f_a = \"\"", ".f_b = \"\"", ".f_c = \"\""}
+	for i, w := range want {
+		if i >= len(got) || got[i] != w {
+			t.Errorf("stringZeroInits(Strings)[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}

--- a/parser_make_test.go
+++ b/parser_make_test.go
@@ -1,0 +1,256 @@
+package main
+
+import "testing"
+
+func TestParseMakeMissingParen(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { ch := make chan int }`))
+	if err == nil {
+		t.Fatal("expected error for make without opening paren")
+	}
+}
+
+func TestParseMakeChanMissingType(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { ch := make(chan) }`))
+	if err == nil {
+		t.Fatal("expected error for chan without element type")
+	}
+}
+
+func TestParseMakeChanMissingCloseParen(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { ch := make(chan int }`))
+	if err == nil {
+		t.Fatal("expected error for make(chan) without closing paren")
+	}
+}
+
+func TestParseMakeMapMissingBracket(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { m := make(map string int) }`))
+	if err == nil {
+		t.Fatal("expected error for map without bracket")
+	}
+}
+
+func TestParseMakeMapMissingKeyType(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { m := make(map[int) }`))
+	if err == nil {
+		t.Fatal("expected error for map without key type")
+	}
+}
+
+func TestParseMakeMapMissingCloseBracket(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { m := make(map[string int) }`))
+	if err == nil {
+		t.Fatal("expected error for map without closing bracket")
+	}
+}
+
+func TestParseMakeMapMissingValType(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { m := make(map[string]) }`))
+	if err == nil {
+		t.Fatal("expected error for map without value type")
+	}
+}
+
+func TestParseRangeSingleKey(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { for i := range arr { } }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	rs, ok := fn.Body[0].(*RangeStmt)
+	if !ok {
+		t.Fatalf("Body[0] = %T, want *RangeStmt", fn.Body[0])
+	}
+	if rs.Key != "i" || rs.Val != "" {
+		t.Errorf("RangeStmt Key/Val = %q/%q, want i/empty", rs.Key, rs.Val)
+	}
+}
+
+func TestParseRangeDoubleKey(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { for i, v := range arr { } }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	rs, ok := fn.Body[0].(*RangeStmt)
+	if !ok {
+		t.Fatalf("Body[0] = %T, want *RangeStmt", fn.Body[0])
+	}
+	if rs.Key != "i" || rs.Val != "v" {
+		t.Errorf("RangeStmt Key/Val = %q/%q, want i/v", rs.Key, rs.Val)
+	}
+}
+
+func TestParseRangeMissingIdent(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { for := range arr { } }`))
+	if err == nil {
+		t.Fatal("expected error for range without key ident")
+	}
+}
+
+func TestParseRangeMissingAssign(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { for i range arr { } }`))
+	if err == nil {
+		t.Fatal("expected error for range without := operator")
+	}
+}
+
+func TestParseRangeMissingRangeKeyword(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { for i := arr { } }`))
+	if err == nil {
+		t.Fatal("expected error for range without range keyword")
+	}
+}
+
+func TestParseRangeMissingCommaIdent(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { for i, := range arr { } }`))
+	if err == nil {
+		t.Fatal("expected error for range double-key with missing second ident")
+	}
+}
+
+func TestParseSliceLitEmpty(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { s := []int{} }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	assign := fn.Body[0].(*AssignStmt)
+	sl, ok := assign.Val.(*SliceLit)
+	if !ok {
+		t.Fatalf("Val = %T, want *SliceLit", assign.Val)
+	}
+	if sl.Elem != "int" || len(sl.Elems) != 0 {
+		t.Errorf("SliceLit Elem/len = %q/%d, want int/0", sl.Elem, len(sl.Elems))
+	}
+}
+
+func TestParseSliceLitInt(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { s := []int{1, 2, 3} }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	assign := fn.Body[0].(*AssignStmt)
+	sl, ok := assign.Val.(*SliceLit)
+	if !ok {
+		t.Fatalf("Val = %T, want *SliceLit", assign.Val)
+	}
+	if sl.Elem != "int" || len(sl.Elems) != 3 {
+		t.Errorf("SliceLit Elem/len = %q/%d, want int/3", sl.Elem, len(sl.Elems))
+	}
+}
+
+func TestParseSliceLitString(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { s := []string{"a", "b"} }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	assign := fn.Body[0].(*AssignStmt)
+	sl, ok := assign.Val.(*SliceLit)
+	if !ok {
+		t.Fatalf("Val = %T, want *SliceLit", assign.Val)
+	}
+	if sl.Elem != "string" || len(sl.Elems) != 2 {
+		t.Errorf("SliceLit Elem/len = %q/%d, want string/2", sl.Elem, len(sl.Elems))
+	}
+}
+
+func TestParseSliceLitFunc(t *testing.T) {
+	fn, err := ParseFunc(normalize(`func main() { s := []func{} }`))
+	if err != nil {
+		t.Fatalf("ParseFunc: unexpected error: %v", err)
+	}
+	assign := fn.Body[0].(*AssignStmt)
+	sl, ok := assign.Val.(*SliceLit)
+	if !ok {
+		t.Fatalf("Val = %T, want *SliceLit", assign.Val)
+	}
+	if sl.Elem != "func" {
+		t.Errorf("SliceLit Elem = %q, want func", sl.Elem)
+	}
+}
+
+func TestParseSliceLitMissingBracket(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { s := int{} }`))
+	if err == nil {
+		t.Fatal("expected error for slice without opening bracket")
+	}
+}
+
+func TestParseSliceLitMissingCloseBracket(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { s := [int{} }`))
+	if err == nil {
+		t.Fatal("expected error for slice without closing bracket")
+	}
+}
+
+func TestParseSliceLitBadElemType(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { s := []123{} }`))
+	if err == nil {
+		t.Fatal("expected error for slice with invalid element type")
+	}
+}
+
+func TestParseSliceLitMissingBrace(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { s := []int 1, 2 }`))
+	if err == nil {
+		t.Fatal("expected error for slice without opening brace")
+	}
+}
+
+func TestParseSliceLitMissingCloseBrace(t *testing.T) {
+	_, err := ParseFunc(normalize(`func main() { s := []int{1, 2 }`))
+	if err == nil {
+		t.Fatal("expected error for slice without closing brace")
+	}
+}
+
+func TestParseExternSimple(t *testing.T) {
+	src := normalize(`extern "m" { fn sqrt(float) float }`)
+	ed, err := ParseExtern(src)
+	if err != nil {
+		t.Fatalf("ParseExtern: unexpected error: %v", err)
+	}
+	if ed.Lib != "m" {
+		t.Errorf("ExternDecl.Lib = %q, want m", ed.Lib)
+	}
+	if len(ed.Funcs) != 1 || ed.Funcs[0].Name != "sqrt" {
+		t.Errorf("ExternDecl.Funcs = %v, want one sqrt function", ed.Funcs)
+	}
+}
+
+func TestParseExternWithHeader(t *testing.T) {
+	src := normalize(`extern "m" { header "math.h" fn sqrt(float) float }`)
+	ed, err := ParseExtern(src)
+	if err != nil {
+		t.Fatalf("ParseExtern: unexpected error: %v", err)
+	}
+	if ed.Header != "math.h" {
+		t.Errorf("ExternDecl.Header = %q, want math.h", ed.Header)
+	}
+}
+
+func TestParseExternMissingKeyword(t *testing.T) {
+	_, err := ParseExtern(normalize(`"m" { fn sqrt(float) float }`))
+	if err == nil {
+		t.Fatal("expected error for missing extern keyword")
+	}
+}
+
+func TestParseExternMissingLib(t *testing.T) {
+	_, err := ParseExtern(normalize(`extern { fn sqrt(float) float }`))
+	if err == nil {
+		t.Fatal("expected error for missing library string")
+	}
+}
+
+func TestParseExternMissingBrace(t *testing.T) {
+	_, err := ParseExtern(normalize(`extern "m" fn sqrt(float) float`))
+	if err == nil {
+		t.Fatal("expected error for missing opening brace")
+	}
+}
+
+func TestParseExternTrailingTokens(t *testing.T) {
+	_, err := ParseExtern(normalize(`extern "m" { fn sqrt(float) float } extra`))
+	if err == nil {
+		t.Fatal("expected error for trailing tokens after extern")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp50t`

**Diff:**
```
codegen_extra_test.go | 139 +++++++++++++++++++++++++++
 parser_make_test.go   | 256 ++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 395 insertions(+)
```
