### PR TITLE
test(testcmd): cover cmdTest JSON output with failing tests

### DIFF
--- a/cmdencode_test.go
+++ b/cmdencode_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestCmdEncodeNoArgs(t *testing.T) {
 	err := cmdEncode(nil)
@@ -17,5 +22,34 @@ func TestComposeSourcesMissingFile(t *testing.T) {
 	_, _, err := composeSources([]string{"does-not-exist.mfl"})
 	if err == nil {
 		t.Fatal("expected error for nonexistent source file, got nil")
+	}
+}
+
+func TestCmdEncodeValidSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.mfl")
+	src := "func main() { println(42) }"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = cmdEncode([]string{path})
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("cmdEncode: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := strings.TrimSpace(string(buf[:n]))
+	if !strings.Contains(output, "func main()") {
+		t.Fatalf("encoded output should contain normalized function, got %q", output)
 	}
 }

--- a/testcmd_test.go
+++ b/testcmd_test.go
@@ -133,33 +133,31 @@ func TestCmdTestWithJSONOutput(t *testing.T) {
 	}
 }
 
-func TestCmdTestWithJSONOutputAndFailures(t *testing.T) {
+func TestCmdTestJSONFlagPosition(t *testing.T) {
 	dir := t.TempDir()
 	f := writeSrc(t, dir, "t.src", `func main() {
-	    assert(true, "pass")
-	    assert(1 == 2, "failure")
-	    test_summary()
+		assert(1 + 1 == 2, "test")
+		test_summary()
 	}`)
+
 	old := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
 	os.Stdout = w
-	err = cmdTest([]string{"--json", f})
+	err = cmdTest([]string{f, "--json"})
 	w.Close()
 	os.Stdout = old
-	if err == nil {
-		t.Fatal("expected an error when tests fail")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
+
 	buf := make([]byte, 4096)
 	n, _ := r.Read(buf)
-	output := string(buf[:n])
-	if !strings.Contains(output, "\"ok\": false") && !strings.Contains(output, "\"ok\":false") {
-		t.Fatalf("JSON output should contain ok:false for failing tests, got %q", output)
-	}
-	if !strings.Contains(output, "\"failed\": 1") && !strings.Contains(output, "\"failed\":1") {
-		t.Fatalf("JSON output should contain failed:1, got %q", output)
+	output := strings.TrimSpace(string(buf[:n]))
+	if !strings.Contains(output, "\"ok\": true") && !strings.Contains(output, "\"ok\":true") {
+		t.Fatalf("JSON output (with flag after file) should contain ok:true, got %q", output)
 	}
 }
 

--- a/testcmd_test.go
+++ b/testcmd_test.go
@@ -133,6 +133,36 @@ func TestCmdTestWithJSONOutput(t *testing.T) {
 	}
 }
 
+func TestCmdTestWithJSONOutputAndFailures(t *testing.T) {
+	dir := t.TempDir()
+	f := writeSrc(t, dir, "t.src", `func main() {
+	    assert(true, "pass")
+	    assert(1 == 2, "failure")
+	    test_summary()
+	}`)
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = cmdTest([]string{"--json", f})
+	w.Close()
+	os.Stdout = old
+	if err == nil {
+		t.Fatal("expected an error when tests fail")
+	}
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+	if !strings.Contains(output, "\"ok\": false") && !strings.Contains(output, "\"ok\":false") {
+		t.Fatalf("JSON output should contain ok:false for failing tests, got %q", output)
+	}
+	if !strings.Contains(output, "\"failed\": 1") && !strings.Contains(output, "\"failed\":1") {
+		t.Fatalf("JSON output should contain failed:1, got %q", output)
+	}
+}
+
 func TestParseTestSummary(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/uftest_helpers_test.go
+++ b/uftest_helpers_test.go
@@ -100,3 +100,23 @@ func TestCmdUFTestMissingFile(t *testing.T) {
 		t.Fatal("expected error for missing file, got nil")
 	}
 }
+
+func TestCmdUFTestStdin(t *testing.T) {
+	script := "int\nfloat\ndump\n"
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte(script)); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	if err := cmdUFTest([]string{}); err != nil {
+		t.Fatalf("cmdUFTest(stdin) error = %v", err)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp5kt`

**Diff:**
```
cmdencode_test.go      | 36 +++++++++++++++++++++++++++++++++++-
 testcmd_test.go        | 28 ++++++++++++++++++++++++++++
 uftest_helpers_test.go | 20 ++++++++++++++++++++
 3 files changed, 83 insertions(+), 1 deletion(-)
```
