### PR TITLE
test(classify): cover classifyCheck empty-message fallthrough case

### DIFF
--- a/classify_test.go
+++ b/classify_test.go
@@ -41,6 +41,7 @@ func TestClassifyCheckBranches(t *testing.T) {
 		{`arity mismatch for "f"`, "arity-mismatch"},
 		{"unsupported construct in this context", "unsupported-construct"},
 		{"totally unrecognized checker message", "type-error"},
+		{"", "type-error"},
 	}
 	for _, c := range cases {
 		if got := classifyCheck(c.msg); got != c.want {

--- a/classify_test.go
+++ b/classify_test.go
@@ -14,6 +14,7 @@ func TestClassifyParseBranches(t *testing.T) {
 		{"unterminated string literal", "parse-unterminated-string"},
 		{"unbalanced braces near: func f(", "parse-unbalanced-braces"},
 		{"something else entirely", "parse-error"},
+		{"", "parse-error"},
 	}
 	for _, c := range cases {
 		if got := classifyParse(c.msg); got != c.want {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp725`

**Diff:**
```
classify_test.go | 2 ++
 1 file changed, 2 insertions(+)
```
