### PR TITLE
test(closures): cover multiple variable capture in closures

### DIFF
--- a/closures_test.go
+++ b/closures_test.go
@@ -64,3 +64,17 @@ func main() { f := makeAdder(5)  println(f(3))  println(f(10)) }`)
 		t.Fatalf("simple closure capture = %q, want %q", got, "8 15")
 	}
 }
+
+// A closure can capture multiple variables and use them together.
+func TestClosureMultipleCaptures(t *testing.T) {
+	prog := progFromSrc(t, `
+func makeMult(a, b) (mul) { mul = func() { return a * b } }
+func main() { f := makeMult(3, 4)  println(f())  g := makeMult(5, 6)  println(g()) }`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.Join(strings.Fields(out), " "); got != "12 30" {
+		t.Fatalf("closure multiple captures = %q, want %q", got, "12 30")
+	}
+}

--- a/testcmd_test.go
+++ b/testcmd_test.go
@@ -161,6 +161,38 @@ func TestCmdTestJSONFlagPosition(t *testing.T) {
 	}
 }
 
+func TestCmdTestJSONWithFailures(t *testing.T) {
+	dir := t.TempDir()
+	f := writeSrc(t, dir, "t.src", `func main() {
+		assert(1 + 1 == 2, "pass")
+		assert(false, "deliberate failure")
+		test_summary()
+	}`)
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = cmdTest([]string{"--json", f})
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := strings.TrimSpace(string(buf[:n]))
+	if !strings.Contains(output, "\"ok\": false") && !strings.Contains(output, "\"ok\":false") {
+		t.Fatalf("JSON output should contain ok:false for failing tests, got %q", output)
+	}
+	if !strings.Contains(output, "\"failed\": 1") && !strings.Contains(output, "\"failed\":1") {
+		t.Fatalf("JSON output should contain failed:1, got %q", output)
+	}
+}
+
 func TestParseTestSummary(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/testcmd_test.go
+++ b/testcmd_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -161,6 +162,14 @@ func TestCmdTestJSONFlagPosition(t *testing.T) {
 	}
 }
 
+// cmdTest os.Exit(1)s when res.OK is false (so `machin test` reports failure
+// to the shell) — that path can't be driven through cmdTest itself in-process
+// without killing the whole `go test` binary (which is exactly what made this
+// test's earlier, cmdTest-calling form take down the package: the test
+// program's own "FAIL: deliberate failure" / TEST_SUMMARY output is real and
+// expected, but the os.Exit(1) right after it aborted the test process before
+// any assertion ran). Exercise the same res-to-JSON path cmdTest's --json
+// branch uses instead, via the pure/exit-free runMFLTests core.
 func TestCmdTestJSONWithFailures(t *testing.T) {
 	dir := t.TempDir()
 	f := writeSrc(t, dir, "t.src", `func main() {
@@ -169,22 +178,22 @@ func TestCmdTestJSONWithFailures(t *testing.T) {
 		test_summary()
 	}`)
 
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stdout = w
-	err = cmdTest([]string{"--json", f})
-	w.Close()
-	os.Stdout = old
+	res, _, err := runMFLTests([]string{f})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if res.OK || res.Passed != 1 || res.Failed != 1 {
+		t.Fatalf("expected 1 passed/1 failed/not-ok, got %+v", res)
+	}
 
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
-	output := strings.TrimSpace(string(buf[:n]))
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(res); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	output := buf.String()
 	if !strings.Contains(output, "\"ok\": false") && !strings.Contains(output, "\"ok\":false") {
 		t.Fatalf("JSON output should contain ok:false for failing tests, got %q", output)
 	}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp7c5`

**Diff:**
```
closures_test.go | 14 ++++++++++++++
 testcmd_test.go  | 32 ++++++++++++++++++++++++++++++++
 2 files changed, 46 insertions(+)
```
