### PR TITLE
test(crypto): cover sha1_bytes empty input edge case

### DIFF
--- a/crypto_sha1_test.go
+++ b/crypto_sha1_test.go
@@ -27,3 +27,24 @@ func main() {
 		}
 	}
 }
+
+// Test empty input (edge case) and verify SHA-1 digest length for consistency.
+func TestSha1BytesEmpty(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    digest := sha1_bytes(bytes(""))
+    println("len=" + str(len(digest)))
+    println("hex=" + to_hex(digest))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"len=20", "hex=da39a3ee5e6b4b0d3255bfef95601890afd80709",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/mathstr2_builtins_test.go
+++ b/mathstr2_builtins_test.go
@@ -30,3 +30,31 @@ func main() {
 		}
 	}
 }
+
+// Test to_lower edge cases: empty string, numbers, symbols, and all-lowercase input.
+// These edge cases ensure the function doesn't regress on non-alphabetic content.
+func TestToLowerEdgeCases(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("empty=[" + to_lower("") + "]")
+    println("numbers=[" + to_lower("ABC123") + "]")
+    println("symbols=[" + to_lower("ABC!@#") + "]")
+    println("already_lower=[" + to_lower("hello") + "]")
+    println("mixed=[" + to_lower("TeSt_123!") + "]")
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"empty=[]",
+		"numbers=[abc123]",
+		"symbols=[abc!@#]",
+		"already_lower=[hello]",
+		"mixed=[test_123!]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/mathstr3_builtins_test.go
+++ b/mathstr3_builtins_test.go
@@ -32,3 +32,31 @@ func main() {
 		}
 	}
 }
+
+// Test to_upper edge cases: empty string, numbers, symbols, and all-uppercase input.
+// These edge cases ensure the function doesn't regress on non-alphabetic content.
+func TestToUpperEdgeCases(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("empty=[" + to_upper("") + "]")
+    println("numbers=[" + to_upper("abc123") + "]")
+    println("symbols=[" + to_upper("abc!@#") + "]")
+    println("already_upper=[" + to_upper("HELLO") + "]")
+    println("mixed=[" + to_upper("teSt_123!") + "]")
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"empty=[]",
+		"numbers=[ABC123]",
+		"symbols=[ABC!@#]",
+		"already_upper=[HELLO]",
+		"mixed=[TEST_123!]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #406 (am/am-7b5889-thp8th): test(mathstr): cover abs() and round() edge cases including negative values
    touches: abs_round_test.go, ceil_floor_sqrt_test.go, minmax_test.go
- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thp9gu`

## Summary

## Test Coverage Improvements

Added 3 targeted test improvements for uncovered edge cases across the codebase:

1. **SHA1 empty input edge case** (crypto_sha1_test.go) — Tests `sha1_bytes()` with empty input, ensuring the well-known SHA-1("") test vector is correctly computed.

2. **to_lower edge cases** (mathstr2_builtins_test.go) — Tests `to_lower()` with empty strings, numbers, symbols, and already-lowercase input to ensure non-alphabetic content is handled correctly.

3. **to_upper edge cases** (mathstr3_builtins_test.go) — Tests `to_upper()` with empty strings, numbers, symbols, and already-uppercase input to ensure non-alphabetic content is handled correctly.

All tests pass. These improvements fill gaps in edge case coverage without overlapping with the 7 open PRs.

**Diff:**
```
crypto_sha1_test.go       | 21 +++++++++++++++++++++
 mathstr2_builtins_test.go | 28 ++++++++++++++++++++++++++++
 mathstr3_builtins_test.go | 28 ++++++++++++++++++++++++++++
 3 files changed, 77 insertions(+)
```
