### PR TITLE
test(build): cover ccPath/zigPath empty env var fallback cases

### DIFF
--- a/build_helpers_test.go
+++ b/build_helpers_test.go
@@ -78,3 +78,39 @@ func TestZigPath(t *testing.T) {
 		t.Fatalf("zigPath with ZIG=/opt/zig/zig: got %q, want %q", got, "/opt/zig/zig")
 	}
 }
+
+// TestCCPathEmpty covers the case where CC is set but empty, which should fall
+// back to the default "cc".
+func TestCCPathEmpty(t *testing.T) {
+	old, hadOld := os.LookupEnv("CC")
+	t.Cleanup(func() {
+		if hadOld {
+			os.Setenv("CC", old)
+		} else {
+			os.Unsetenv("CC")
+		}
+	})
+
+	os.Setenv("CC", "")
+	if got := ccPath(); got != "cc" {
+		t.Fatalf("ccPath with CC empty: got %q, want %q", got, "cc")
+	}
+}
+
+// TestZigPathEmpty covers the case where ZIG is set but empty, which should fall
+// back to the default "zig".
+func TestZigPathEmpty(t *testing.T) {
+	old, hadOld := os.LookupEnv("ZIG")
+	t.Cleanup(func() {
+		if hadOld {
+			os.Setenv("ZIG", old)
+		} else {
+			os.Unsetenv("ZIG")
+		}
+	})
+
+	os.Setenv("ZIG", "")
+	if got := zigPath(); got != "zig" {
+		t.Fatalf("zigPath with ZIG empty: got %q, want %q", got, "zig")
+	}
+}

--- a/callbacktype_test.go
+++ b/callbacktype_test.go
@@ -22,6 +22,30 @@ func TestIsCallbackType(t *testing.T) {
 	}
 }
 
+// TestIsCallbackTypeEdgeCases covers edge cases: strings that start with "cb("
+// pass validation even if malformed (no closing paren), while those that don't
+// start with "cb(" are rejected, and wrong prefix strings are rejected.
+func TestIsCallbackTypeEdgeCases(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"cb", false},           // missing opening paren
+		{"cb(", true},           // just the prefix (no closing paren needed)
+		{"cb(int", true},        // unclosed, but starts with "cb("
+		{"cb)", false},          // closing paren without opening
+		{"ycb(int)", false},     // wrong prefix
+		{"xcb(int)", false},     // wrong prefix
+		{"cb(int)string", true}, // valid with return type
+		{"cb(map,chan)", true},  // valid with multiple types
+	}
+	for _, c := range cases {
+		if got := isCallbackType(c.input); got != c.want {
+			t.Errorf("isCallbackType(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
 func TestParseCallbackType(t *testing.T) {
 	cases := []struct {
 		enc        string

--- a/convert_test.go
+++ b/convert_test.go
@@ -48,3 +48,26 @@ func main() {
 		}
 	}
 }
+
+// TestParseFloatEdgeCases covers empty string (parses to 0.0) and the literal
+// "0" (must parse to 0.0, not garbage).
+func TestParseFloatEdgeCases(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    empty := parse_float("")
+    println("empty=" + str(empty == 0.0))
+    zero := parse_float("0")
+    println("zero=" + str(zero == 0.0))
+    zero_dot := parse_float("0.0")
+    println("zero_dot=" + str(zero_dot == 0.0))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"empty=true", "zero=true", "zero_dot=true"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #409 (am/am-7b5889-thpa7i): test(declfromline): cover empty string edge case
    touches: cbyteslit_test.go, declfromline_test.go, globals_test.go
- PR #408 (am/am-7b5889-thp9u6): test(cmdencode): cover composeSources empty array edge case
    touches: cmdencode_test.go, cmdpack_test.go
- PR #406 (am/am-7b5889-thp8th): test(mathstr): cover abs() and round() edge cases including negative values
    touches: abs_round_test.go, ceil_floor_sqrt_test.go, minmax_test.go
- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go


**Branch:** `am/am-7b5889-thpari`

## Summary

## Summary

Landed 3 test improvements focusing on edge case coverage:

1. **ccPath/zigPath empty env var cases** (build_helpers_test.go) — Added tests for when CC/ZIG env vars are set but empty, ensuring proper fallback to defaults.

2. **isCallbackType prefix validation** (callbacktype_test.go) — Added edge case tests for malformed callback type strings, documenting that the function only validates the "cb(" prefix, not the full type structure.

3. **parse_float edge cases** (convert_test.go) — Added tests for empty string and literal "0"/"0.0" inputs to ensure they parse correctly to 0.0.

Each change follows the pattern of recent test commits by covering edge cases (empty, zero, special values) that are easy to miss but important for robustness.

**Diff:**
```
build_helpers_test.go | 36 ++++++++++++++++++++++++++++++++++++
 callbacktype_test.go  | 24 ++++++++++++++++++++++++
 convert_test.go       | 23 +++++++++++++++++++++++
 3 files changed, 83 insertions(+)
```
