### PR TITLE
test(cli): cover parse_int empty string edge case

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -42,6 +42,14 @@ func TestParseIntAndNowMs(t *testing.T) {
 	}
 }
 
+// TestParseIntEmptyString covers parse_int("") edge case — empty input should return 0.
+func TestParseIntEmptyString(t *testing.T) {
+	got := runNative(t, `func main(){ println(parse_int("")) }`)
+	if want := "0\n"; got != want {
+		t.Fatalf("parse_int empty string: got %q, want %q", got, want)
+	}
+}
+
 // TestStringLiteralPunct guards against a parser bug surfaced building the SSG:
 // a string literal whose value is a structural token (")", "}", ",") was
 // mistaken for that token, terminating an argument/element list early.

--- a/flags_test.go
+++ b/flags_test.go
@@ -128,6 +128,29 @@ func TestReadStdin(t *testing.T) {
 	}
 }
 
+// TestReadStdinEmpty tests read_stdin with empty input — must return an empty string.
+func TestReadStdinEmpty(t *testing.T) {
+	fn := parseFuncs(t, `func main() { s := read_stdin()  println("[" + s + "]") }`)
+	bin, err := os.CreateTemp("", "mfl-stdin-empty-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fn}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cmd := exec.Command(bin.Name())
+	cmd.Stdin = strings.NewReader("") // empty input
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "[]" {
+		t.Fatalf("read_stdin empty: got %q, want []", strings.TrimSpace(string(out)))
+	}
+}
+
 // framework/flags.src composed with an app must parse short/long flags, the
 // `=` and space value forms, bool flags, defaults, and positionals — exercised
 // by building the real binary and passing it argv (parse_flags reads args()).

--- a/mathstr_builtins_test.go
+++ b/mathstr_builtins_test.go
@@ -33,3 +33,28 @@ func main() {
 		}
 	}
 }
+
+// TestCharatEdgeCases covers charat boundary conditions: empty string, negative index, and out-of-bounds access.
+func TestCharatEdgeCases(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("empty=[" + charat("", 0) + "]")
+    println("negative=[" + charat("hello", -1) + "]")
+    println("outofbounds=[" + charat("hello", 10) + "]")
+    println("single=[" + charat("x", 0) + "]")
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"empty=[]",
+		"negative=[]",
+		"outofbounds=[]",
+		"single=[x]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #409 (am/am-7b5889-thpa7i): test(declfromline): cover empty string edge case
    touches: cbyteslit_test.go, declfromline_test.go, globals_test.go
- PR #408 (am/am-7b5889-thp9u6): test(cmdencode): cover composeSources empty array edge case
    touches: cmdencode_test.go, cmdpack_test.go
- PR #406 (am/am-7b5889-thp8th): test(mathstr): cover abs() and round() edge cases including negative values
    touches: abs_round_test.go, ceil_floor_sqrt_test.go, minmax_test.go
- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go


**Branch:** `am/am-7b5889-thpb4u`

## Summary

## Summary

Added 3 focused edge case tests across the builtin functions:

1. **test(cli): cover parse_int empty string edge case** — Verify parse_int("") returns 0, matching behavior for other invalid inputs.

2. **test(mathstr): cover charat boundary condition edge cases** — Test charat with empty strings, negative indices, and out-of-bounds access.

3. **test(flags): cover read_stdin empty input edge case** — Verify read_stdin returns empty string when stdin is empty.

Each test follows the established pattern of targeting a specific edge case that wasn't previously covered, ensuring robust error handling and boundary condition coverage.

**Diff:**
```
cli_test.go              |  8 ++++++++
 flags_test.go            | 23 +++++++++++++++++++++++
 mathstr_builtins_test.go | 25 +++++++++++++++++++++++++
 3 files changed, 56 insertions(+)
```
