### PR TITLE
test(convert): cover parse_float negative value parsing

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -180,3 +180,11 @@ func TestLoadMFLStillAcceptsCanonicalAndPacked(t *testing.T) {
 		t.Fatalf("packed .mfl: prog=%+v err=%v", prog, err)
 	}
 }
+
+// TestEnvMissingVariable covers env() with a nonexistent environment variable — should return empty string.
+func TestEnvMissingVariable(t *testing.T) {
+	got := runNative(t, `func main(){ println("[" + env("THIS_VAR_DOES_NOT_EXIST_XYZ") + "]") }`)
+	if want := "[]\n"; got != want {
+		t.Fatalf("env missing variable: got %q, want %q", got, want)
+	}
+}

--- a/convert_test.go
+++ b/convert_test.go
@@ -71,3 +71,23 @@ func main() {
 		}
 	}
 }
+
+// TestParseFloatNegative covers parsing of negative float values.
+func TestParseFloatNegative(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    neg := parse_float("-3.14")
+    println("neg=" + str(neg == -3.14))
+    neg_zero := parse_float("-0.0")
+    println("neg_zero=" + str(neg_zero == 0.0))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"neg=true", "neg_zero=true"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #409 (am/am-7b5889-thpa7i): test(declfromline): cover empty string edge case
    touches: cbyteslit_test.go, declfromline_test.go, globals_test.go
- PR #408 (am/am-7b5889-thp9u6): test(cmdencode): cover composeSources empty array edge case
    touches: cmdencode_test.go, cmdpack_test.go
- PR #406 (am/am-7b5889-thp8th): test(mathstr): cover abs() and round() edge cases including negative values
    touches: abs_round_test.go, ceil_floor_sqrt_test.go, minmax_test.go
- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go


**Branch:** `am/am-7b5889-thpbi6`

**Diff:**
```
cli_test.go     |  8 ++++++++
 convert_test.go | 20 ++++++++++++++++++++
 2 files changed, 28 insertions(+)
```
