### PR TITLE
test(callbacktype): cover single param with return type case

### DIFF
--- a/callbacktype_test.go
+++ b/callbacktype_test.go
@@ -55,6 +55,7 @@ func TestParseCallbackType(t *testing.T) {
 		{"cb()", nil, ""},
 		{"cb()int", nil, "int"},
 		{"cb(int)", []string{"int"}, ""},
+		{"cb(int)i8", []string{"int"}, "i8"},
 		{"cb(int,f32)i8", []string{"int", "f32"}, "i8"},
 	}
 	for _, c := range cases {

--- a/cgentest_test.go
+++ b/cgentest_test.go
@@ -117,6 +117,36 @@ func TestCmdCGenTestCodegenError(t *testing.T) {
 	t.Fatalf("expected output from valid program")
 }
 
+func TestCmdCGenTestEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.mfl")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var callErr error
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	callErr = cmdCGenTest([]string{"--program", path})
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	if callErr != nil {
+		t.Fatalf("cmdCGenTest with empty file: %v", callErr)
+	}
+	if strings.TrimSpace(out) != "(check-error)" {
+		t.Fatalf("empty file should produce check-error, got %q", strings.TrimSpace(out))
+	}
+}
+
 func TestCmdCGenTestProgram(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "prog.mfl")

--- a/flags_test.go
+++ b/flags_test.go
@@ -80,6 +80,28 @@ func TestTimeMake(t *testing.T) {
 	}
 }
 
+// time_format with an empty pattern returns an empty string.
+func TestTimeFormatEmpty(t *testing.T) {
+	fn := parseFuncs(t, `func main() { println("[" + time_format(1782172800, "") + "]") }`)
+	bin, err := os.CreateTemp("", "mfl-tfmt-empty-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fn}, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	cmd := exec.Command(bin.Name())
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "[]" {
+		t.Fatalf("time_format with empty pattern: got %q, want []", strings.TrimSpace(string(out)))
+	}
+}
+
 // time_format_utc renders in UTC regardless of $TZ: with TZ pinned to a +0530
 // zone, the iCalendar stamp for 1782172800 must still be the UTC wall clock.
 func TestTimeFormatUTC(t *testing.T) {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #409 (am/am-7b5889-thpa7i): test(declfromline): cover empty string edge case
    touches: cbyteslit_test.go, declfromline_test.go, globals_test.go
- PR #408 (am/am-7b5889-thp9u6): test(cmdencode): cover composeSources empty array edge case
    touches: cmdencode_test.go, cmdpack_test.go
- PR #406 (am/am-7b5889-thp8th): test(mathstr): cover abs() and round() edge cases including negative values
    touches: abs_round_test.go, ceil_floor_sqrt_test.go, minmax_test.go
- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go


**Branch:** `am/am-7b5889-thpbvi`

## Summary

## Summary

Added three small, focused test coverage improvements to increase edge case coverage across the codebase:

1. **callbacktype_test.go**: Added test for `parseCallbackType` with single parameter and return type (`cb(int)i8`), which was not explicitly covered.

2. **flags_test.go**: Added test for `time_format` with empty pattern string, validating that it returns an empty result.

3. **cgentest_test.go**: Added test for `cmdCGenTest` with an empty input file, ensuring it produces the expected check-error.

These changes improve edge case coverage without modifying any non-test code, following the established pattern of small, isolated test additions to the codebase.

**Diff:**
```
callbacktype_test.go |  1 +
 cgentest_test.go     | 30 ++++++++++++++++++++++++++++++
 flags_test.go        | 22 ++++++++++++++++++++++
 3 files changed, 53 insertions(+)
```
