### PR TITLE
test(loaddecls): cover empty, whitespace-only, and multiple declaration cases

### DIFF
--- a/loaddecls_test.go
+++ b/loaddecls_test.go
@@ -39,3 +39,48 @@ func TestLoadDecls_BadPacked(t *testing.T) {
 		t.Fatalf("err = %v, want mention of invalid packed MFL", err)
 	}
 }
+
+func TestLoadDecls_Empty(t *testing.T) {
+	decls, err := loadDecls("")
+	if err != nil {
+		t.Fatalf("loadDecls empty: %v", err)
+	}
+	if len(decls) != 0 {
+		t.Fatalf("loadDecls empty: got %+v, want empty slice", decls)
+	}
+}
+
+func TestLoadDecls_WhitespaceOnly(t *testing.T) {
+	decls, err := loadDecls("  \n  \n\n")
+	if err != nil {
+		t.Fatalf("loadDecls whitespace only: %v", err)
+	}
+	if len(decls) != 0 {
+		t.Fatalf("loadDecls whitespace only: got %+v, want empty slice", decls)
+	}
+}
+
+func TestLoadDecls_MultiplePlain(t *testing.T) {
+	decls, err := loadDecls("func f1() {} func f2() {}")
+	if err != nil {
+		t.Fatalf("loadDecls multiple: %v", err)
+	}
+	if len(decls) != 2 {
+		t.Fatalf("loadDecls multiple: got %d decls, want 2", len(decls))
+	}
+}
+
+func TestLoadDecls_MultiplePacked(t *testing.T) {
+	line1 := base64.StdEncoding.EncodeToString([]byte("func f1(){}"))
+	line2 := base64.StdEncoding.EncodeToString([]byte("func f2(){}"))
+	decls, err := loadDecls(line1 + "\n" + line2 + "\n")
+	if err != nil {
+		t.Fatalf("loadDecls multiple packed: %v", err)
+	}
+	if len(decls) != 2 {
+		t.Fatalf("loadDecls multiple packed: got %d decls, want 2", len(decls))
+	}
+	if decls[0] != "func f1(){}" || decls[1] != "func f2(){}" {
+		t.Fatalf("loadDecls multiple packed: got %+v, want decoded decls", decls)
+	}
+}

--- a/loaddecls_test.go
+++ b/loaddecls_test.go
@@ -61,7 +61,12 @@ func TestLoadDecls_WhitespaceOnly(t *testing.T) {
 }
 
 func TestLoadDecls_MultiplePlain(t *testing.T) {
-	decls, err := loadDecls("func f1() {} func f2() {}")
+	// Each declaration must start on its own line: splitFunctionsLoc (the
+	// machinery loadDecls delegates to for plain text) only checks for a
+	// completed top-level block at line boundaries, so two decls packed onto
+	// a single physical line are never split — see TestSplitFunctionsLoc in
+	// check_helpers_test.go for the same one-decl-starts-a-line contract.
+	decls, err := loadDecls("func f1() {}\nfunc f2() {}\n")
 	if err != nil {
 		t.Fatalf("loadDecls multiple: %v", err)
 	}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #409 (am/am-7b5889-thpa7i): test(declfromline): cover empty string edge case
    touches: cbyteslit_test.go, declfromline_test.go, globals_test.go
- PR #408 (am/am-7b5889-thp9u6): test(cmdencode): cover composeSources empty array edge case
    touches: cmdencode_test.go, cmdpack_test.go
- PR #406 (am/am-7b5889-thp8th): test(mathstr): cover abs() and round() edge cases including negative values
    touches: abs_round_test.go, ceil_floor_sqrt_test.go, minmax_test.go
- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go


**Branch:** `am/am-7b5889-thpczi`

**Diff:**
```
loaddecls_test.go | 45 +++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 45 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for loading declarations from empty and whitespace-only input.
  * Added checks for handling multiple declarations across separate lines in both plain-text and encoded formats.
  * Verified the number, order, and content of decoded declarations for multi-item inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->