### PR TITLE
test(parser): cover parseWhile invalid condition and unterminated body

### DIFF
--- a/parser_while_error_test.go
+++ b/parser_while_error_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestParseWhileInvalidCondition exercises parseWhile's error path when the
+// condition expression itself fails to parse.
+func TestParseWhileInvalidCondition(t *testing.T) {
+	_, err := ParseProgram([]string{
+		`func main() { while * { println("x") } }`,
+	})
+	if err == nil {
+		t.Fatal("expected parse error for invalid while condition, got nil")
+	}
+}
+
+// TestParseWhileInvalidBody exercises parseWhile's error path when the loop
+// body block fails to parse (missing closing brace).
+func TestParseWhileInvalidBody(t *testing.T) {
+	_, err := ParseProgram([]string{
+		`func main() { while true { println("x") }`,
+	})
+	if err == nil {
+		t.Fatal("expected parse error for unterminated while body, got nil")
+	}
+}

--- a/racecheck_maptype_test.go
+++ b/racecheck_maptype_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+// TestMapValTypeSimple covers the common "map[K]V" case with an unbracketed key.
+func TestMapValTypeSimple(t *testing.T) {
+	if got := mapValType("map[string]int"); got != "int" {
+		t.Fatalf("mapValType(map[string]int) = %q, want %q", got, "int")
+	}
+}
+
+// TestMapValTypeBracketedKey covers a key type that itself contains brackets
+// (e.g. a slice key), exercising the depth-tracking loop.
+func TestMapValTypeBracketedKey(t *testing.T) {
+	if got := mapValType("map[[]int]string"); got != "string" {
+		t.Fatalf("mapValType(map[[]int]string) = %q, want %q", got, "string")
+	}
+}
+
+// TestMapValTypeMalformed covers the fallback "?" return when the key bracket
+// is never closed.
+func TestMapValTypeMalformed(t *testing.T) {
+	if got := mapValType("map[string"); got != "?" {
+		t.Fatalf("mapValType(map[string) = %q, want %q", got, "?")
+	}
+}

--- a/types_structlit_test.go
+++ b/types_structlit_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStructLitUnknownNamedField exercises genStructLit's error path when a
+// named-field literal references a field the struct doesn't declare.
+func TestStructLitUnknownNamedField(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type Point struct { x int y int }`,
+		`func main() { p := Point{x: 1, z: 2} println(p) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil || !strings.Contains(err.Error(), "has no field") {
+		t.Fatalf("expected unknown field error, got %v", err)
+	}
+}
+
+// TestStructLitPositionalArityMismatch exercises genStructLit's error path
+// when a positional literal supplies the wrong number of values.
+func TestStructLitPositionalArityMismatch(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type Point struct { x int y int }`,
+		`func main() { p := Point{1} println(p) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil || !strings.Contains(err.Error(), "expected 2 fields, got 1") {
+		t.Fatalf("expected field-count mismatch error, got %v", err)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #409 (am/am-7b5889-thpa7i): test(declfromline): cover empty string edge case
    touches: cbyteslit_test.go, declfromline_test.go, globals_test.go
- PR #406 (am/am-7b5889-thp8th): test(mathstr): cover abs() and round() edge cases including negative values
    touches: abs_round_test.go, ceil_floor_sqrt_test.go
- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #401 (am/am-7b5889-thp6i5): test(transform): cover liftClosures with multiple captures and nested if statements
    touches: ffi_ctype_test.go, transform_test.go, types_query_test.go
- PR #393 (am/am-7b5889-thp2ss): test(checktest): cover cmdCheckTest empty program case
    touches: checktest_test.go, cmdskill_test.go
- PR #389 (am/am-7b5889-thp0ut): test(lextest): cover cmdLexTest/cmdLexBench error paths
    touches: lextest_test.go, parsetest_test.go, racetest_test.go
- PR #381 (am/am-7b5889-thowos): test(guide): cover isBuiltinName catalog lookup and memoization
    touches: guide_test.go, racecheck_helpers_test.go, types_helpers_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-threbj`

## Summary

Added three small, self-contained test files closing real coverage gaps found via `go tool cover -func`: parser_while_error_test.go covers parseWhile's invalid-condition and unterminated-body error paths; types_structlit_test.go covers genStructLit's unknown-field and positional-arity-mismatch errors (75.0% -> 82.1%); racecheck_maptype_test.go covers mapValType's bracketed-key and malformed-input branches. No production code changed, only new unclaimed test files (no overlap with in-flight PRs).

**Diff:**
```
parser_while_error_test.go | 27 +++++++++++++++++++++++++++
 racecheck_maptype_test.go  | 26 ++++++++++++++++++++++++++
 types_structlit_test.go    | 38 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 91 insertions(+)
```
