### PR TITLE
test(uftest): cover func-no-params form and post-failure op skipping

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -178,6 +179,38 @@ func TestLoadMFLStillAcceptsCanonicalAndPacked(t *testing.T) {
 	}
 	if prog, err := loadMFL(packed); err != nil || len(prog.Funcs) != 1 {
 		t.Fatalf("packed .mfl: prog=%+v err=%v", prog, err)
+	}
+}
+
+// loadMFL's three error-wrapping branches (bad packed data, a parse error,
+// and a file with no functions) were only ever exercised indirectly through
+// loadDecls/ParseProgram's own tests, never through loadMFL itself — so a
+// regression that dropped the `%s: %w` path prefix would have gone unnoticed.
+func TestLoadMFLErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	badPacked := dir + "/bad.mfl"
+	if err := os.WriteFile(badPacked, []byte("not-base64!!!\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadMFL(badPacked); err == nil || !strings.Contains(err.Error(), badPacked) {
+		t.Fatalf("loadMFL(bad packed) error = %v, want it to mention %q", err, badPacked)
+	}
+
+	badSyntax := dir + "/syntax.mfl"
+	if err := os.WriteFile(badSyntax, []byte("func main() { if }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadMFL(badSyntax); err == nil || !strings.Contains(err.Error(), badSyntax) {
+		t.Fatalf("loadMFL(bad syntax) error = %v, want it to mention %q", err, badSyntax)
+	}
+
+	empty := dir + "/empty.mfl"
+	if err := os.WriteFile(empty, []byte("   \n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadMFL(empty); err == nil || !strings.Contains(err.Error(), "no functions") {
+		t.Fatalf("loadMFL(empty) error = %v, want \"no functions\"", err)
 	}
 }
 

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -1629,6 +1629,7 @@ func TestStripLineComment(t *testing.T) {
 		{`x := 1 // trailing comment`, `x := 1 `},
 		{`s := "http://example.com"`, `s := "http://example.com"`}, // // inside a string is not a comment
 		{`s := "a // b" // real comment`, `s := "a // b" `},
+		{`s := "a\"//b" // real comment`, `s := "a\"//b" `}, // escaped quote keeps the string open past the //
 		{`no comment here`, `no comment here`},
 		{`// whole line is a comment`, ``},
 	}

--- a/uftest_extra_test.go
+++ b/uftest_extra_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCmdUFTestFuncNoParams covers the "func -|R" form (no params, just a
+// return slot), which the existing "func 0,1|2" test never exercises.
+func TestCmdUFTestFuncNoParams(t *testing.T) {
+	script := "int\nfunc -|0\ndump\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.uf")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdUFTest([]string{path}); err != nil {
+		t.Fatalf("cmdUFTest() error = %v", err)
+	}
+}
+
+// TestCmdUFTestSkipsAfterFailure covers the "once a union mismatch is hit,
+// every remaining line except dump is skipped" branch: the trailing "var"
+// and "int" ops here must not add new slots to the table.
+func TestCmdUFTestSkipsAfterFailure(t *testing.T) {
+	script := "int\nstring\nunion 0 1\nvar\nint\ndump\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.uf")
+	if err := os.WriteFile(path, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = cmdUFTest([]string{path})
+	w.Close()
+	os.Stdout = stdout
+	if err != nil {
+		t.Fatalf("cmdUFTest() error = %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	if !strings.Contains(out, "err=1") {
+		t.Fatalf("expected err=1 in output, got:\n%s", out)
+	}
+	// Only the two original slots (int, string) should appear; the "var"
+	// and "int" ops issued after the failure must have been skipped.
+	if strings.Count(out, "root=") != 2 {
+		t.Fatalf("expected exactly 2 slots after skipped post-failure ops, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #403 (am/am-7b5889-thp7c5): test(closures): cover multiple variable capture in closures
    touches: closures_test.go, testcmd_test.go
- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thres4`

## Summary

Adds targeted unit tests for three previously-uncovered branches found via `go tool cover`: cmdUFTest's no-param `func -|R` form and its skip-remaining-ops-after-failure behavior (uftest_extra_test.go), stripLineComment's escaped-quote-before-`//` case (mfl_test.go), and loadMFL's three error-wrapping paths — bad packed base64, a downstream parse error, and a zero-function file (cli_test.go). These close real gaps: a regression in any of these branches (e.g. dropping the `%s: %w` path prefix, or the failed-op skip) would previously have passed the suite silently. No production code changed; full test suite passes (`go build ./...`, `go test ./...`).

**Diff:**
```
cli_test.go          | 33 ++++++++++++++++++++++++++++
 mfl_test.go          |  1 +
 uftest_extra_test.go | 61 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 95 insertions(+)
```
