### PR TITLE
test(main): cover usage() output for subcommand listing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// usage() had no direct test coverage; verify it prints the command summary to
+// stderr rather than stdout, and lists every top-level subcommand a user can run.
+func TestUsage(t *testing.T) {
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	usage()
+	w.Close()
+	os.Stderr = old
+
+	buf := make([]byte, 8192)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	for _, want := range []string{
+		"machin run", "machin build", "machin encode", "machin check",
+		"machin test", "machin pack", "machin guide", "machin skill install",
+		"machin framework",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("usage() output missing %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/parser_extern_test.go
+++ b/parser_extern_test.go
@@ -27,3 +27,36 @@ func TestIsExternDirective(t *testing.T) {
 		}
 	}
 }
+
+// ParseExtern's own Lex error path, and parseExternDecl's directive-argument
+// error branches (header/link/cflags/cstruct each expect a specific token
+// after the keyword), had zero test coverage.
+func TestParseExternLexError(t *testing.T) {
+	if _, err := ParseExtern(`extern "m { fn sqrt(float) float }`); err == nil {
+		t.Fatal("ParseExtern: expected a lex error for an unterminated string, got nil")
+	}
+}
+
+func TestParseExternHeaderMissingString(t *testing.T) {
+	if _, err := ParseExtern(`extern "m" { header 123 fn sqrt(float) float }`); err == nil {
+		t.Fatal("ParseExtern: expected error for header directive missing a string, got nil")
+	}
+}
+
+func TestParseExternLinkMissingString(t *testing.T) {
+	if _, err := ParseExtern(`extern "m" { link 123 fn sqrt(float) float }`); err == nil {
+		t.Fatal("ParseExtern: expected error for link directive missing a string, got nil")
+	}
+}
+
+func TestParseExternCflagsMissingString(t *testing.T) {
+	if _, err := ParseExtern(`extern "m" { cflags 123 fn sqrt(float) float }`); err == nil {
+		t.Fatal("ParseExtern: expected error for cflags directive missing a string, got nil")
+	}
+}
+
+func TestParseExternCstructMissingName(t *testing.T) {
+	if _, err := ParseExtern(`extern "m" { cstruct 123 { } fn sqrt(float) float }`); err == nil {
+		t.Fatal("ParseExtern: expected error for cstruct directive missing a name, got nil")
+	}
+}

--- a/parser_typemake_test.go
+++ b/parser_typemake_test.go
@@ -121,3 +121,66 @@ func TestParseMakeUnsupportedKind(t *testing.T) {
 		t.Fatal("ParseFunc: expected error for make(int), got nil")
 	}
 }
+
+// #? ParseType's trailing-tokens check and parseTypeName's error branches
+// (slice/map/chan with a malformed or missing element type) had zero test
+// coverage; each of these exercises one specific error path.
+func TestParseTypeTrailingTokens(t *testing.T) {
+	if _, err := ParseType(`type Box struct { n int } extra`); err == nil {
+		t.Fatal("ParseType: expected error for trailing tokens, got nil")
+	}
+}
+
+func TestParseTypeMissingFieldName(t *testing.T) {
+	if _, err := ParseType(`type Box struct { 123 int }`); err == nil {
+		t.Fatal("ParseType: expected error for a non-identifier field name, got nil")
+	}
+}
+
+func TestParseTypeMissingCloseBrace(t *testing.T) {
+	if _, err := ParseType(`type Box struct { n int`); err == nil {
+		t.Fatal("ParseType: expected error for missing closing '}', got nil")
+	}
+}
+
+func TestParseTypeSliceMissingCloseBracket(t *testing.T) {
+	if _, err := ParseType(`type Box struct { items [int }`); err == nil {
+		t.Fatal("ParseType: expected error for slice type missing ']', got nil")
+	}
+}
+
+func TestParseTypeSliceMissingElemType(t *testing.T) {
+	if _, err := ParseType(`type Box struct { items [] }`); err == nil {
+		t.Fatal("ParseType: expected error for slice type missing element type, got nil")
+	}
+}
+
+func TestParseTypeMapMissingOpenBracket(t *testing.T) {
+	if _, err := ParseType(`type Store struct { data map string]int }`); err == nil {
+		t.Fatal("ParseType: expected error for map type missing '[', got nil")
+	}
+}
+
+func TestParseTypeMapMissingKeyType(t *testing.T) {
+	if _, err := ParseType(`type Store struct { data map[]int }`); err == nil {
+		t.Fatal("ParseType: expected error for map type missing key type, got nil")
+	}
+}
+
+func TestParseTypeMapMissingCloseBracket(t *testing.T) {
+	if _, err := ParseType(`type Store struct { data map[string int }`); err == nil {
+		t.Fatal("ParseType: expected error for map type missing ']', got nil")
+	}
+}
+
+func TestParseTypeMapMissingValType(t *testing.T) {
+	if _, err := ParseType(`type Store struct { data map[string] }`); err == nil {
+		t.Fatal("ParseType: expected error for map type missing value type, got nil")
+	}
+}
+
+func TestParseTypeChanMissingElemType(t *testing.T) {
+	if _, err := ParseType(`type Pipe struct { c chan }`); err == nil {
+		t.Fatal("ParseType: expected error for chan type missing element type, got nil")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thrfc3`

## Summary

Added targeted unit tests for previously-uncovered code paths in the machin compiler: usage() output, ParseType's error branches (trailing tokens, missing field name/braces, malformed slice/map/chan type syntax), and ParseExtern's lex-error and directive-argument error branches (header/link/cflags/cstruct). These close small coverage gaps in error handling that were unexercised by the existing test suite (86.4% -> higher), with no production code changes.

**Diff:**
```
main_test.go            | 35 +++++++++++++++++++++++++++
 parser_extern_test.go   | 33 ++++++++++++++++++++++++++
 parser_typemake_test.go | 63 +++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 131 insertions(+)
```
