### PR TITLE
test(transform): cover freeIdents Unary/CallValue/SliceLit/FieldAccess/Range/GoStmt/ArenaStmt branches

### DIFF
--- a/transform_freeidents_extra_test.go
+++ b/transform_freeidents_extra_test.go
@@ -1,0 +1,98 @@
+package main
+
+import "testing"
+
+// These cover freeIdents expression/statement cases not exercised by
+// TestFreeIdents* in transform_test.go: Unary, CallValue, SliceLit,
+// FieldAccess expressions, and RangeStmt, FieldAssign, GoStmt, ArenaStmt
+// statements.
+
+func TestFreeIdentsUnaryExpr(t *testing.T) {
+	body := []Stmt{
+		&ReturnStmt{Vals: []Expr{&Unary{Op: "-", X: &Ident{Name: "outer"}}}},
+	}
+	free := freeIdents(body, []string{})
+	if !free["outer"] {
+		t.Errorf("expected Unary operand to be free: %v", free)
+	}
+}
+
+func TestFreeIdentsCallValueExpr(t *testing.T) {
+	body := []Stmt{
+		&ExprStmt{X: &CallValue{Fn: &Ident{Name: "fn"}, Args: []Expr{&Ident{Name: "arg"}}}},
+	}
+	free := freeIdents(body, []string{})
+	if !free["fn"] || !free["arg"] {
+		t.Errorf("expected CallValue's Fn and Args to be free: %v", free)
+	}
+}
+
+func TestFreeIdentsSliceLitExpr(t *testing.T) {
+	body := []Stmt{
+		&ReturnStmt{Vals: []Expr{&SliceLit{Elem: "int", Elems: []Expr{&Ident{Name: "elem"}}}}},
+	}
+	free := freeIdents(body, []string{})
+	if !free["elem"] {
+		t.Errorf("expected SliceLit element to be free: %v", free)
+	}
+}
+
+func TestFreeIdentsFieldAccessExpr(t *testing.T) {
+	body := []Stmt{
+		&ReturnStmt{Vals: []Expr{&FieldAccess{X: &Ident{Name: "obj"}, Name: "field"}}},
+	}
+	free := freeIdents(body, []string{})
+	if !free["obj"] {
+		t.Errorf("expected FieldAccess base to be free: %v", free)
+	}
+}
+
+func TestFreeIdentsRangeStmt(t *testing.T) {
+	body := []Stmt{
+		&RangeStmt{Key: "i", Val: "v", X: &Ident{Name: "xs"}, Body: []Stmt{
+			&ExprStmt{X: &Ident{Name: "captured"}},
+		}},
+	}
+	free := freeIdents(body, []string{})
+	if !free["xs"] {
+		t.Errorf("expected RangeStmt's iterated expr to be free: %v", free)
+	}
+	if !free["captured"] {
+		t.Errorf("expected RangeStmt body reference to be free: %v", free)
+	}
+}
+
+func TestFreeIdentsFieldAssignStmt(t *testing.T) {
+	body := []Stmt{
+		&FieldAssign{
+			Target: &FieldAccess{X: &Ident{Name: "obj"}, Name: "field"},
+			Val:    &Ident{Name: "val"},
+		},
+	}
+	free := freeIdents(body, []string{})
+	if !free["obj"] || !free["val"] {
+		t.Errorf("expected FieldAssign target and value to be free: %v", free)
+	}
+}
+
+func TestFreeIdentsGoStmt(t *testing.T) {
+	body := []Stmt{
+		&GoStmt{Call: &Call{Callee: "worker", Args: []Expr{&Ident{Name: "arg"}}}},
+	}
+	free := freeIdents(body, []string{})
+	if !free["arg"] {
+		t.Errorf("expected GoStmt call argument to be free: %v", free)
+	}
+}
+
+func TestFreeIdentsArenaStmt(t *testing.T) {
+	body := []Stmt{
+		&ArenaStmt{Body: []Stmt{
+			&ExprStmt{X: &Ident{Name: "captured"}},
+		}},
+	}
+	free := freeIdents(body, []string{})
+	if !free["captured"] {
+		t.Errorf("expected ArenaStmt body reference to be free: %v", free)
+	}
+}

--- a/types_elemquery_test.go
+++ b/types_elemquery_test.go
@@ -1,0 +1,126 @@
+package main
+
+import "testing"
+
+// TestElemQueriesOnSlice covers ElemKindOf, ElemCType, and ElemTypeString
+// against a slice-typed node's element (the KSlice/KChan branch of each).
+func TestElemQueriesOnSlice(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { xs := []int{1, 2, 3} for _, v := range xs { println(v) } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	var inst string
+	var xs Expr
+	for _, r := range c.Reps() {
+		if c.SrcFunc(r).Name != "main" {
+			continue
+		}
+		inst = r
+		for _, stmt := range c.SrcFunc(r).Body {
+			if rs, ok := stmt.(*RangeStmt); ok {
+				xs = rs.X
+			}
+		}
+	}
+	if inst == "" || xs == nil {
+		t.Fatal("no main instance / range base node found")
+	}
+
+	if got := c.ElemKindOf(inst, xs); got != KInt {
+		t.Errorf("ElemKindOf(xs) = %v, want %v", got, KInt)
+	}
+	if got := c.ElemCType(inst, xs); got != "int64_t" {
+		t.Errorf("ElemCType(xs) = %q, want %q", got, "int64_t")
+	}
+	if got := c.ElemTypeString(inst, xs); got != "int" {
+		t.Errorf("ElemTypeString(xs) = %q, want %q", got, "int")
+	}
+}
+
+// TestElemQueriesFallbackOnNonSlice covers the default-value fallback branch
+// of ElemKindOf/ElemCType/ElemTypeString when the node isn't a slice or chan.
+func TestElemQueriesFallbackOnNonSlice(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { n := 5 println(n) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	var inst string
+	var n Expr
+	for _, r := range c.Reps() {
+		if c.SrcFunc(r).Name != "main" {
+			continue
+		}
+		inst = r
+		for _, stmt := range c.SrcFunc(r).Body {
+			if as, ok := stmt.(*AssignStmt); ok && as.Name == "n" {
+				n = as.Val
+			}
+		}
+	}
+	if inst == "" || n == nil {
+		t.Fatal("no main instance / assign node found")
+	}
+
+	if got := c.ElemKindOf(inst, n); got != KInt {
+		t.Errorf("ElemKindOf(n) fallback = %v, want %v", got, KInt)
+	}
+	if got := c.ElemCType(inst, n); got != "int64_t" {
+		t.Errorf("ElemCType(n) fallback = %q, want %q", got, "int64_t")
+	}
+	if got := c.ElemTypeString(inst, n); got != "int" {
+		t.Errorf("ElemTypeString(n) fallback = %q, want %q", got, "int")
+	}
+}
+
+// TestParamElemCType covers ParamElemCType's slice-param branch and its
+// int64_t fallback for a non-slice param, on the same function's two
+// monomorphized instances.
+func TestParamElemCType(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func identity(xs) { return xs }`,
+		`func main() { s := []int{1, 2, 3} a := identity(s) b := identity(7) println(len(a)) println(b) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	var sliceInst, intInst string
+	for _, r := range c.Reps() {
+		if c.SrcFunc(r).Name != "identity" {
+			continue
+		}
+		if c.ParamKind(r, 0) == KSlice {
+			sliceInst = r
+		} else {
+			intInst = r
+		}
+	}
+	if sliceInst == "" || intInst == "" {
+		t.Fatal("expected two monomorphized instances of identity (slice and int)")
+	}
+
+	if got := c.ParamElemCType(sliceInst, 0); got != "int64_t" {
+		t.Errorf("ParamElemCType(slice param) = %q, want %q", got, "int64_t")
+	}
+	if got := c.ParamElemCType(intInst, 0); got != "int64_t" {
+		t.Errorf("ParamElemCType(int param) fallback = %q, want %q", got, "int64_t")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thrg2s`

**Diff:**
```
transform_freeidents_extra_test.go |  98 +++++++++++++++++++++++++++++
 types_elemquery_test.go            | 126 +++++++++++++++++++++++++++++++++++++
 2 files changed, 224 insertions(+)
```
