### PR TITLE
fix: complete #314 — closure-captured data now survives the go arena boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@
   arena-independent, matching how channels and maps already manage their own
   memory; string/slice/map captures reassigned through the box remain a
   separate, still-open gap. See #314.
+- **Completed the #314 fix: the DATA a captured variable holds now also
+  survives the arena boundary, not just the pointer chain.** The previous
+  entry made the env struct and capture boxes malloc-stable, but a captured
+  string's bytes, a captured struct's string fields, and a captured
+  slice/map's backing still lived in the spawning goroutine's arena — so
+  `go f(func(){ ...label... })` from a short-lived goroutine still read
+  corrupted memory once the spawner's arena was reclaimed (the original
+  repro was never actually fixed; verified before and after). `goStmt` now
+  classifies each capture of a closure literal passed to `go` and
+  freeze/thaws its box contents across the boundary — the same machinery
+  channel sends and plain `go` arguments already use (#310): string-offset
+  copy for strings and structs of strings, a JSON round-trip for anything
+  holding a slice or map; scalars need nothing. As with a channel send,
+  ownership moves: the spawner must not keep mutating a captured variable
+  after the `go` statement. A closure passed as a plain *variable* (not a
+  literal at the call site) keeps the documented shared-value caveat. See
+  #314.
 
 ## v0.106.0
 

--- a/codegen.go
+++ b/codegen.go
@@ -3616,6 +3616,60 @@ func (g *cgen) goStmt(st *GoStmt) error {
 		strOffs = append(strOffs, g.chanStrOffsets(argType, fmt.Sprintf("offsetof(struct mfl_go_%d, a%d) + ", id, i))...)
 	}
 
+	// #314: an argument that is a closure LITERAL (a *MakeClosure with
+	// captures) needs one more level of the same protection. Since #376 the
+	// env struct and each captured variable's box are plain malloc (stable
+	// across the arena boundary), but the DATA a box holds still lives in the
+	// spawning goroutine's arena: a captured string's bytes, a captured
+	// struct's string fields, a captured slice/map's backing. Freeze/thaw
+	// those through the env->box indirection, per capture. After the go
+	// statement the spawner must not keep mutating a captured variable (the
+	// same ownership-moves rule as a channel send); a closure passed as a
+	// plain VARIABLE has an unknowable env layout at this call site and keeps
+	// the documented shared-value caveat (SPEC.md 12).
+	type capStrOp struct {
+		ci   int
+		offs []string
+	}
+	type capJSONOp struct {
+		ci       int
+		ser, des string
+	}
+	type closureOps struct {
+		env  string
+		strs []capStrOp
+		js   []capJSONOp
+	}
+	closArgs := make(map[int]closureOps)
+	for i, a := range st.Call.Args {
+		mc, ok := a.(*MakeClosure)
+		if !ok || len(mc.Captures) == 0 {
+			continue
+		}
+		ops := closureOps{env: g.c.ClosureCName(g.curFn, mc) + "_env"}
+		for ci, cap := range mc.Captures {
+			capType := g.c.VarTypeString(g.curFn, cap)
+			if g.chanNeedsJSON(capType) {
+				ser, err := g.jsonSerializer(capType)
+				if err != nil {
+					return err
+				}
+				des, err := g.jsonParser(capType)
+				if err != nil {
+					return err
+				}
+				ops.js = append(ops.js, capJSONOp{ci, ser, des})
+				continue
+			}
+			if offs := g.chanStrOffsets(capType, ""); len(offs) > 0 {
+				ops.strs = append(ops.strs, capStrOp{ci, offs})
+			}
+		}
+		if len(ops.strs) > 0 || len(ops.js) > 0 {
+			closArgs[i] = ops
+		}
+	}
+
 	// arg struct + trampoline (a leading dummy field avoids an empty struct).
 	// A JSON-mode argument gets an extra _jN field carrying the malloc'd JSON
 	// blob across the arena boundary; its real aN field is populated inside
@@ -3625,6 +3679,11 @@ func (g *cgen) goStmt(st *GoStmt) error {
 		fmt.Fprintf(&g.tramp, " %s a%d;", g.c.ParamCType(inst, i), i)
 		if _, ok := jsonArgs[i]; ok {
 			fmt.Fprintf(&g.tramp, " char* _j%d;", i)
+		}
+		if ops, ok := closArgs[i]; ok {
+			for _, j := range ops.js {
+				fmt.Fprintf(&g.tramp, " char* _cb%d_%d;", i, j.ci)
+			}
 		}
 	}
 	g.tramp.WriteString(" };\n")
@@ -3637,6 +3696,20 @@ func (g *cgen) goStmt(st *GoStmt) error {
 	}
 	if len(strOffs) > 0 {
 		fmt.Fprintf(&g.tramp, "    mfl_thaw_strs(%d, (int[]){%s}, s);\n", len(strOffs), strings.Join(strOffs, ", "))
+	}
+	for i := 0; i < n; i++ {
+		ops, ok := closArgs[i]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&g.tramp, "    { %s* _ce = (%s*)s->a%d.env;\n", ops.env, ops.env, i)
+		for _, so := range ops.strs {
+			fmt.Fprintf(&g.tramp, "      mfl_thaw_strs(%d, (int[]){%s}, _ce->f%d);\n", len(so.offs), strings.Join(so.offs, ", "), so.ci)
+		}
+		for _, j := range ops.js {
+			fmt.Fprintf(&g.tramp, "      { const char* _p = s->_cb%d_%d; *_ce->f%d = %s(&_p); } free(s->_cb%d_%d);\n", i, j.ci, j.ci, j.des, i, j.ci)
+		}
+		g.tramp.WriteString("    }\n")
 	}
 	g.tramp.WriteString("    " + cname + "(")
 	for i := 0; i < n; i++ {
@@ -3665,6 +3738,20 @@ func (g *cgen) goStmt(st *GoStmt) error {
 	}
 	if len(strOffs) > 0 {
 		fmt.Fprintf(&g.buf, "        mfl_freeze_strs(%d, (int[]){%s}, s);\n", len(strOffs), strings.Join(strOffs, ", "))
+	}
+	for i := 0; i < n; i++ {
+		ops, ok := closArgs[i]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&g.buf, "        { %s* _ce = (%s*)s->a%d.env;\n", ops.env, ops.env, i)
+		for _, so := range ops.strs {
+			fmt.Fprintf(&g.buf, "          mfl_freeze_strs(%d, (int[]){%s}, _ce->f%d);\n", len(so.offs), strings.Join(so.offs, ", "), so.ci)
+		}
+		for _, j := range ops.js {
+			fmt.Fprintf(&g.buf, "          { char* _j = %s(*_ce->f%d); size_t _n = strlen(_j); s->_cb%d_%d = malloc(_n + 1); memcpy(s->_cb%d_%d, _j, _n + 1); }\n", j.ser, j.ci, i, j.ci, i, j.ci)
+		}
+		g.buf.WriteString("        }\n")
 	}
 	fmt.Fprintf(&g.buf, "        pthread_t t; pthread_create(&t, NULL, mfl_go_run_%d, s); pthread_detach(t);\n", id)
 	g.buf.WriteString("    }\n")

--- a/goroutine_closure_capture_test.go
+++ b/goroutine_closure_capture_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -18,10 +19,10 @@ import (
 // Fixed by allocating the env struct with plain malloc so its lifetime is
 // independent of any arena (mirrors how channels/maps already manage their
 // own memory). The capture here is a scalar (int) specifically to isolate
-// this env-struct-lifetime bug from the separate, still-open gap where a
-// STRING captured by a closure remains arena-owned bytes reachable through
-// the box (chanNeedsJSON/chanStrOffsets has no case for func-typed args to
-// freeze/thaw those) -- a separate follow-on fix, out of scope here.
+// this env-struct-lifetime bug from the second half of #314 -- a STRING
+// captured by a closure remaining arena-owned bytes reachable through the
+// box -- which is covered separately below by
+// TestGoClosureCapturedDataSurvivesSpawnerArena.
 // Looped many times since the corruption is timing-dependent -- a single run
 // can pass by luck if the freed memory isn't reused in time.
 func TestGoClosureArgSurvivesSpawnerArena(t *testing.T) {
@@ -77,5 +78,75 @@ func TestGoClosureArgSurvivesSpawnerArena(t *testing.T) {
 		if len(seen) != 25 {
 			t.Fatalf("round %d: expected 25 distinct values, got %d:\n%s", round, len(seen), out)
 		}
+	}
+}
+
+// The follow-on gap the scalar test above deliberately left out (#314, second
+// half): a STRING (or struct-of-strings, or slice) captured by a closure
+// literal passed directly to `go` had stable env+box pointers (the fix above)
+// but the box still pointed at DATA in the spawning goroutine's arena. The
+// spawner here is itself a short-lived goroutine -- the shape the original
+// repro needed -- and churn goroutines pressure the allocator so freed arena
+// memory is actually reused. goStmt now freeze/thaws the box contents through
+// the env->box indirection (strings/structs by offset, slices/maps via the
+// JSON round-trip), so every value must arrive intact and distinct.
+func TestGoClosureCapturedDataSurvivesSpawnerArena(t *testing.T) {
+	typ := `type Agent struct { name string  greeting string }`
+	runLater := `func run_later(f) { sleep(15) f() }`
+	spawnStr := `func spawn_str(n, results) {
+	label := "conv-id-0123456789-" + str(n)
+	go run_later(func() { results <- "s:" + label })
+}`
+	spawnStruct := `func spawn_struct(n, results) {
+	ag := Agent{name: "assistant-padding-xxxxxxxxxxxxxxxxxxxxxxxx", greeting: "greet-" + str(n)}
+	go run_later(func() { results <- "t:" + ag.greeting })
+}`
+	spawnSlice := `func spawn_slice(n, results) {
+	tags := []string{"alpha-" + str(n), "beta-" + str(n)}
+	go run_later(func() { results <- "l:" + tags[0] + "," + tags[1] })
+}`
+	churn := `func churn(n) {
+	i := 0
+	for i < 400 {
+		s := "garbage-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-" + str(n) + "-" + str(i)
+		if len(s) < 0 { println(s) }
+		i = i + 1
+	}
+}`
+	main := `func main() {
+	results := make(chan string)
+	i := 0
+	for i < 10 {
+		go spawn_str(i, results)
+		go spawn_struct(i, results)
+		go spawn_slice(i, results)
+		go churn(i)
+		i = i + 1
+	}
+	acc := ""
+	j := 0
+	for j < 30 { acc = acc + <-results + "\n" j = j + 1 }
+	println(acc)
+}`
+	out := runProg(t, typ, runLater, spawnStr, spawnStruct, spawnSlice, churn, main)
+	want := map[string]bool{}
+	for i := 0; i < 10; i++ {
+		want[fmt.Sprintf("s:conv-id-0123456789-%d", i)] = true
+		want[fmt.Sprintf("t:greet-%d", i)] = true
+		want[fmt.Sprintf("l:alpha-%d,beta-%d", i, i)] = true
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 30 {
+		t.Fatalf("expected 30 lines, got %d:\n%s", len(lines), out)
+	}
+	seen := map[string]bool{}
+	for _, l := range lines {
+		if !want[l] {
+			t.Fatalf("corrupted captured data (use-after-free, #314): %q", l)
+		}
+		if seen[l] {
+			t.Fatalf("duplicate value %q (aliased/corrupted capture):\n%s", l, out)
+		}
+		seen[l] = true
 	}
 }

--- a/types.go
+++ b/types.go
@@ -2659,6 +2659,11 @@ func (c *Checker) ctypeSlot(slot int) string {
 func (c *Checker) RetCTypeAt(fn string, i int) string   { return c.ctypeSlot(c.funcRets[fn][i]) }
 func (c *Checker) ParamCType(fn string, i int) string   { return c.ctypeSlot(c.funcParam[fn][i]) }
 func (c *Checker) VarCType(fn, name string) string      { return c.ctypeSlot(c.vars[fn][name]) }
+
+// VarTypeString is the MFL type string of a named variable in an instance —
+// used by goStmt to classify a closure's captured variables for the arena-
+// boundary deep copy (#314).
+func (c *Checker) VarTypeString(fn, name string) string { return c.typeStringSlot(c.vars[fn][name]) }
 func (c *Checker) NodeCType(inst string, n Node) string { return c.ctypeSlot(c.slotOf(inst, n)) }
 
 // ElemCType renders the C type of a slice- or channel-node's element.


### PR DESCRIPTION
## Summary

- Completes #314 (reopened after verifying PR #376 was a partial fix — its own test passes, but the original repro still corrupted deterministically on current main).
- #376 made the closure env struct and capture boxes malloc-stable; this PR fixes the remaining level: the **data a box points at** (string bytes, struct string fields, slice/map backings) still lived in the spawning goroutine's arena. When the spawner is itself a short-lived goroutine — the repro's exact shape — that arena is reclaimed while the spawned closure still reads through the box.
- `goStmt` now detects a `*MakeClosure` argument with captures and freeze/thaws each capture's box contents across the arena boundary, reusing #310's machinery one indirection level deeper: string-offset copy for strings/structs-of-strings, a JSON round-trip side-field for slice/map-bearing captures, nothing for scalars.
- Semantics follow the channel-send doctrine: ownership of a captured variable moves at the `go` statement. A closure passed as a plain *variable* keeps SPEC.md §12's documented shared-value caveat (env layout is unknowable at the call site).

## Verification

- Original repro: **3/3 corrupted pre-fix → 5/5 clean post-fix** (same binary-diff discipline as #310/#312).
- 30-way stress across all three capture classes (string, struct-of-strings, `[]string`) with allocation-churn goroutines pressuring arena reuse: all values intact and distinct.
- New regression test `TestGoClosureCapturedDataSurvivesSpawnerArena` fails reliably (3/3) on pre-fix codegen, passes (5/5) on the fix.
- Full `go test -count=1 .` green.
- Self-hosted parity: `verify-cgen.sh` **412 PASS / 0 FAIL** — no #313-style port needed, since closures are `(unsupported)` in the self-hosted codegen and never enter the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)