### PR TITLE
test(types): cover tryRange union-mismatch error branches

### DIFF
--- a/operators_net_test.go
+++ b/operators_net_test.go
@@ -96,6 +96,8 @@ func TestSafeChecks(t *testing.T) {
 		{"bounds", `func main() { xs := []int{1, 2, 3} println(xs[5]) }`, "index out of range"},
 		{"divzero", `func main() { a := 7 b := 0 println(a / b) }`, "divide by zero"},
 		{"overflow", `func main() { x := 9000000000000000000 println(x + x) }`, "overflow"},
+		{"mulOverflow", `func main() { x := 9000000000000000000 println(x * x) }`, "overflow"},
+		{"modzero", `func main() { a := 7 b := 0 println(a % b) }`, "modulo by zero"},
 	}
 	for _, c := range cases {
 		bin, err := os.CreateTemp("", "mfl-safe-*")

--- a/types.go
+++ b/types.go
@@ -406,21 +406,6 @@ func reconcile(a, b Kind) (Kind, error) {
 	if b == KNum && isNumeric(a) {
 		return a, nil
 	}
-	if a == KSlice && b == KSlice {
-		return KSlice, nil // element slots reconciled by union
-	}
-	if a == KStruct && b == KStruct {
-		return KStruct, nil // names reconciled by union
-	}
-	if a == KChan && b == KChan {
-		return KChan, nil // element slots reconciled by union
-	}
-	if a == KMap && b == KMap {
-		return KMap, nil // key/value slots reconciled by union
-	}
-	if a == KFunc && b == KFunc {
-		return KFunc, nil // signatures reconciled by union
-	}
 	return KVar, fmt.Errorf("type mismatch: %s vs %s", a, b)
 }
 

--- a/types_range_conflict_test.go
+++ b/types_range_conflict_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests exercise the union-failure error branches inside tryRange
+// (types.go) for each range-able kind: slice, string, and map. Each case
+// assigns a loop variable a value incompatible with the type tryRange
+// infers for it (e.g. slice index must be int, map value must match the
+// map's value type), forcing the union() call inside tryRange to fail.
+
+func TestRangeSliceKeyTypeConflict(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { s := []int{1, 2, 3} for i := range s { i = "oops" } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}
+
+func TestRangeSliceValueTypeConflict(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { s := []int{1, 2, 3} for i, v := range s { v = "oops" println(i) } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}
+
+func TestRangeStringKeyTypeConflict(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { s := "hi" for i := range s { i = "oops" } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}
+
+func TestRangeStringValueTypeConflict(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { s := "hi" for i, c := range s { c = 5 println(i) } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}
+
+func TestRangeMapKeyTypeConflict(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { m := make(map[string]int) m["a"] = 1 for k := range m { k = 5 } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}
+
+func TestRangeMapValueTypeConflict(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { m := make(map[string]int) m["a"] = 1 for k, v := range m { v = "oops" println(k) } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err == nil || !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("expected type mismatch error, got %v", err)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thrgjf`

## Summary

Three small, independent improvements to the type checker and codegen:
1. Added tests covering tryRange's previously-untested union-mismatch error branches (slice/string/map key and value type conflicts in for-range loops).
2. Removed five unreachable branches in reconcile() (types.go) — checks like `a == KSlice && b == KSlice` can never fire because the function's first line already returns early whenever `a == b`.
3. Extended TestSafeChecks (operators_net_test.go) with two missing --safe cases (integer multiply overflow, modulo by zero), covering binaryCombine's mfl_imul/mfl_imod panic paths.

All changes are test/coverage additions plus one dead-code removal; no behavior change to any reachable code path. Full test suite passes (one unrelated flaky wire_test.go case reproduced independently of these changes).

**Diff:**
```
operators_net_test.go        |  2 ++
 types.go                     | 15 --------
 types_range_conflict_test.go | 84 ++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 86 insertions(+), 15 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric type handling so expressions with mixed numeric values are checked more consistently.
  * Added safer error handling for arithmetic edge cases, including overflow and division-related failures.
  * Strengthened loop type checks to catch incompatible assignments in `for range` usage across slices, strings, and maps.

* **Tests**
  * Expanded test coverage for overflow, modulo-by-zero, and range-related type mismatch cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->