### PR TITLE
release: v0.107.0 — complete the #314 closure-capture arena fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.107.0
+
 - **Fixed a use-after-free/segfault: a `func` literal passed directly as a
   `go` call argument (e.g. `go f(func(){ return v })`) could dangle once the
   spawning goroutine's arena was reclaimed.** The closure's captured-env

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.106.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.107.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.106.0
+Version 0.107.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.106.0"
+const machinVersion = "0.107.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Version-marker bump (README badge, SPEC.md, guide.go machinVersion, CHANGELOG) for v0.107.0.

Routed through a PR because main's branch protection (required \`test\` check, enforce_admins) correctly rejects direct pushes now — first release since the gate went in. Tag gets cut on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)