### PR TITLE
test(guide): cover cmdGuide --skill with missing name argument

### DIFF
--- a/guide_test.go
+++ b/guide_test.go
@@ -191,6 +191,9 @@ func TestCmdGuideSkillDispatch(t *testing.T) {
 	if err := cmdGuide([]string{"--skill", "bogus"}); err == nil {
 		t.Fatal("cmdGuide --skill bogus: expected error, got nil")
 	}
+	if err := cmdGuide([]string{"--skill"}); err == nil {
+		t.Fatal("cmdGuide --skill (no name): expected error, got nil")
+	}
 }
 
 func TestCmdGuideTextAndJSON(t *testing.T) {

--- a/lextest_test.go
+++ b/lextest_test.go
@@ -48,3 +48,16 @@ func TestCmdLexBenchFileNotFound(t *testing.T) {
 		t.Fatal("expected error for file not found, got nil")
 	}
 }
+
+func TestCmdLexBenchSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.mfl")
+	src := "func main(){x:=1}"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdLexBench([]string{path, "3"}); err != nil {
+		t.Fatalf("cmdLexBench() error = %v", err)
+	}
+}

--- a/parsetest_test.go
+++ b/parsetest_test.go
@@ -127,3 +127,27 @@ func TestCmdParseTestProgramSuccess(t *testing.T) {
 		t.Fatalf("cmdParseTest --program: %v", err)
 	}
 }
+
+func TestCmdParseTestFuncsMissingArg(t *testing.T) {
+	if err := cmdParseTest([]string{"--funcs"}); err == nil {
+		t.Fatal("expected error for --funcs missing file arg, got nil")
+	}
+}
+
+func TestCmdParseTestFuncsFileNotFound(t *testing.T) {
+	if err := cmdParseTest([]string{"--funcs", "/nonexistent/path/file.mfl"}); err == nil {
+		t.Fatal("expected error for --funcs file not found, got nil")
+	}
+}
+
+func TestCmdParseTestFuncsSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "funcs.mfl")
+	src := "func main(){x:=1}\nexport func broken(\nfunc add(a int, b int) int { return a + b }\n"
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdParseTest([]string{"--funcs", path}); err != nil {
+		t.Fatalf("cmdParseTest --funcs: %v", err)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #355 (am/am-7b5889-thol44): test(skillcmd): cover resolveSkill alias/canonical/unknown cases
    touches: build_test.go, check_test.go, lexer_extra_test.go, skillcmd_test.go


**Branch:** `am/am-7b5889-thrh6r`

## Summary

Added three small unit tests closing coverage gaps found via `go test -coverprofile`: cmdGuide's --skill flag with a missing name argument, cmdLexBench's success path (previously only error paths were tested), and cmdParseTest's --funcs mode (previously untested entirely, including its parse-error branch). No production code changed — test-only commits improving confidence in existing CLI subcommand behavior.

**Diff:**
```
guide_test.go     |  3 +++
 lextest_test.go   | 13 +++++++++++++
 parsetest_test.go | 24 ++++++++++++++++++++++++
 3 files changed, 40 insertions(+)
```
