### PR TITLE
selfhost: slice/map (JSON) channel codegen (#293)

### DIFF
--- a/selfhost/cgagg.src
+++ b/selfhost/cgagg.src
@@ -72,6 +72,161 @@ func chan_str_offsets(tn, base) (offs) {
     }
 }
 
+// ---- #293: per-type JSON serializer/parser generators (for chan JSON-mode elements) ----
+// Port of codegen.go's jsonSerializer/jsonParser/chanJSONFns: a memoized, recursive,
+// type-string-keyed C-function-TEXT generator. The runtime helpers these generated
+// functions call (mfl_js_int/float/bool/str, mfl_json_str, mfl_map_get/keys/set,
+// mfl_make_map, ...) already live in the shared prelude (CG_PRELUDE_CORE, byte-identical
+// between both compilers) -- this only ports the CODE GENERATOR, no new runtime C.
+var g_jsonid = 0
+var g_jsonfns = []string{}   // accumulated generated function text -- spliced early in
+                              // cg_program (with the struct typedefs), same two-pass
+                              // idea as goroutine trampolines but at the reference's
+                              // exact position, for byte-identical output.
+func jsonfn_emit(s) { g_jsonfns = append(g_jsonfns, s) }
+
+var g_jsonmemo_k = []string{}
+var g_jsonmemo_v = []string{}
+func jsonmemo_get(t) (name, found) {
+    i := 0
+    for i < len(g_jsonmemo_k) { if g_jsonmemo_k[i] == t { name = g_jsonmemo_v[i]  found = 1  return name, found }  i = i + 1 }
+}
+func jsonmemo_set(t, name) { g_jsonmemo_k = append(g_jsonmemo_k, t)  g_jsonmemo_v = append(g_jsonmemo_v, name) }
+
+var g_parsememo_k = []string{}
+var g_parsememo_v = []string{}
+func parsememo_get(t) (name, found) {
+    i := 0
+    for i < len(g_parsememo_k) { if g_parsememo_k[i] == t { name = g_parsememo_v[i]  found = 1  return name, found }  i = i + 1 }
+}
+func parsememo_set(t, name) { g_parsememo_k = append(g_parsememo_k, t)  g_parsememo_v = append(g_parsememo_v, name) }
+
+var g_chanjson_k = []string{}
+var g_chanjson_ser = []string{}
+var g_chanjson_des = []string{}
+func chanjsonmemo_get(t) (ser, des, found) {
+    i := 0
+    for i < len(g_chanjson_k) { if g_chanjson_k[i] == t { ser = g_chanjson_ser[i]  des = g_chanjson_des[i]  found = 1  return ser, des, found }  i = i + 1 }
+}
+func chanjsonmemo_set(t, ser, des) { g_chanjson_k = append(g_chanjson_k, t)  g_chanjson_ser = append(g_chanjson_ser, ser)  g_chanjson_des = append(g_chanjson_des, des) }
+
+// json_serializer ensures a C function exists that serializes a value of MFL type `t`
+// to a JSON string, returning its name. Recurses into element/field/value types,
+// emitting children before parents (memo reserved BEFORE recursing, so a
+// self-referential struct type -- e.g. one with a []Self field -- terminates).
+func json_serializer(t) (name) {
+    memo, found := jsonmemo_get(t)
+    if found == 1 { name = memo  return name }
+    name = "mfl_json_v" + str(g_jsonid)
+    g_jsonid = g_jsonid + 1
+    jsonmemo_set(t, name)
+    ct := ctype_name(t)
+    body := ""
+    if t == "int" { body = "return mfl_str_i(v);" }
+    if t == "float" { body = "return mfl_str_d(v);" }
+    if t == "bool" { body = "return mfl_dup(v ? \"true\" : \"false\");" }
+    if t == "string" { body = "return mfl_json_str(v);" }
+    if body == "" && has_prefix(t, "[]") {
+        elem := substr(t, 2, len(t))
+        es := json_serializer(elem)
+        ect := ctype_name(elem)
+        body = "char* out = mfl_dup(\"[\");\n    for (int64_t i = 0; i < v.len; i++) {\n        if (i) out = mfl_cat(out, \",\");\n        out = mfl_cat(out, " + es + "(((" + ect + "*)v.data)[i]));\n    }\n    return mfl_cat(out, \"]\");"
+    }
+    if body == "" && has_prefix(t, "map[") {
+        kt, vt := split_map_type(t)
+        vs := json_serializer(vt)
+        kct := ctype_name(kt)
+        vct := ctype_name(vt)
+        keyjson := "mfl_json_str(mfl_str_i(_k))"
+        getcall := "mfl_map_get(v, _k, NULL, &_val);"
+        if kt == "string" { keyjson = "mfl_json_str(_k)"  getcall = "mfl_map_get(v, 0, _k, &_val);" }
+        body = "mfl_slice _ks = mfl_map_keys(v);\n    char* out = mfl_dup(\"{\");\n    for (int64_t i = 0; i < _ks.len; i++) {\n        if (i) out = mfl_cat(out, \",\");\n        " + kct + " _k = ((" + kct + "*)_ks.data)[i];\n        " + vct + " _val; " + getcall + "\n        out = mfl_cat(out, " + keyjson + ");\n        out = mfl_cat(out, \":\");\n        out = mfl_cat(out, " + vs + "(_val));\n    }\n    return mfl_cat(out, \"}\");"
+    }
+    if body == "" {
+        di := struct_def_idx(t)
+        d := g_structdefs[di]
+        b := "char* out = mfl_dup(\"{\");\n"
+        j := 0
+        for j < len(d.fnames) {
+            fs := json_serializer(d.ftypes[j])
+            prefix := "\"\\\"" + d.fnames[j] + "\\\":\""
+            if j > 0 { prefix = "\",\\\"" + d.fnames[j] + "\\\":\"" }
+            b = b + "    out = mfl_cat(out, " + prefix + ");\n"
+            b = b + "    out = mfl_cat(out, " + fs + "(v.f_" + d.fnames[j] + "));\n"
+            j = j + 1
+        }
+        b = b + "    return mfl_cat(out, \"}\");"
+        body = b
+    }
+    jsonfn_emit("static char* " + name + "(" + ct + " v) {\n    " + body + "\n}\n")
+}
+
+// json_parser ensures a C function exists that parses JSON (via a `const char**`
+// cursor) into a value of MFL type `t`, returning its name. Mirrors json_serializer.
+func json_parser(t) (name) {
+    memo, found := parsememo_get(t)
+    if found == 1 { name = memo  return name }
+    name = "mfl_jp_v" + str(g_jsonid)
+    g_jsonid = g_jsonid + 1
+    parsememo_set(t, name)
+    ct := ctype_name(t)
+    body := ""
+    if t == "int" { body = "return mfl_js_int(p);" }
+    if t == "float" { body = "return mfl_js_float(p);" }
+    if t == "bool" { body = "return mfl_js_bool(p);" }
+    if t == "string" { body = "return mfl_js_str(p);" }
+    if body == "" && has_prefix(t, "[]") {
+        elem := substr(t, 2, len(t))
+        ep := json_parser(elem)
+        ect := ctype_name(elem)
+        body = "mfl_slice s = {0};\n    mfl_js_ws(p);\n    if (**p == '[') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != ']') {\n            while (1) {\n                " + ect + " _e = " + ep + "(p);\n                s = mfl_append(s, &_e, sizeof(" + ect + "));\n                if (mfl_js_more(p)) continue;\n                break;\n            }\n        }\n        mfl_js_ws(p); if (**p == ']') (*p)++;\n    }\n    return s;"
+    }
+    if body == "" && has_prefix(t, "map[") {
+        kt, vt := split_map_type(t)
+        vp := json_parser(vt)
+        vct := ctype_name(vt)
+        keyisstr := 0
+        setcall := "mfl_map_set(m, strtoll(_k, 0, 10), 0, &_val);"
+        if kt == "string" { keyisstr = 1  setcall = "mfl_map_set(m, 0, _k, &_val);" }
+        body = "mfl_map* m = mfl_make_map(" + str(keyisstr) + ", sizeof(" + vct + "));\n    mfl_js_ws(p);\n    if (**p == '{') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != '}') {\n            while (1) {\n                char* _k = mfl_js_str(p); mfl_js_ws(p); if (**p == ':') (*p)++;\n                " + vct + " _val = " + vp + "(p);\n                " + setcall + "\n                if (mfl_js_more(p)) continue;\n                break;\n            }\n        }\n        mfl_js_ws(p); if (**p == '}') (*p)++;\n    }\n    return m;"
+    }
+    if body == "" {
+        di := struct_def_idx(t)
+        d := g_structdefs[di]
+        b := ct + " out = {0};\n"
+        b = b + "    mfl_js_ws(p);\n    if (**p == '{') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != '}') {\n            while (1) {\n                char* _k = mfl_js_str(p); mfl_js_ws(p); if (**p == ':') (*p)++;\n"
+        j := 0
+        for j < len(d.fnames) {
+            fp := json_parser(d.ftypes[j])
+            kw := "if"
+            if j > 0 { kw = "else if" }
+            b = b + "                " + kw + " (strcmp(_k, \"" + d.fnames[j] + "\") == 0) out.f_" + d.fnames[j] + " = " + fp + "(p);\n"
+            j = j + 1
+        }
+        b = b + "                else mfl_js_skip(p);\n                if (mfl_js_more(p)) continue;\n                break;\n            }\n        }\n        mfl_js_ws(p); if (**p == '}') (*p)++;\n    }\n    return out;"
+        body = b
+    }
+    jsonfn_emit("static " + ct + " " + name + "(const char** p) {\n    " + body + "\n}\n")
+}
+
+// chan_json_fns: (serName, desName) for a JSON-mode channel of element type-name `t` --
+// the wrapper functions mfl_make_chan's void*-based calling convention needs, adapting
+// the per-type serializer/parser above.
+func chan_json_fns(t) (ser, des) {
+    memoser, memodes, found := chanjsonmemo_get(t)
+    if found == 1 { ser = memoser  des = memodes  return ser, des }
+    sfn := json_serializer(t)
+    dfn := json_parser(t)
+    ct := ctype_name(t)
+    id := g_jsonid
+    g_jsonid = g_jsonid + 1
+    ser = "mfl_chanser_" + str(id)
+    des = "mfl_chandes_" + str(id)
+    jsonfn_emit("static char* " + ser + "(const void* _e) { return " + sfn + "(*(const " + ct + "*)_e); }\n")
+    jsonfn_emit("static void " + des + "(const char* _j, void* _o) { const char* _p = _j; *(" + ct + "*)_o = " + dfn + "(&_p); }\n")
+    chanjsonmemo_set(t, ser, des)
+}
+
 // element/map accessors from a node's slot
 func elem_kind_of(iid, idx) (k) {
     r := node_slot_of(iid, idx)

--- a/selfhost/cgen.src
+++ b/selfhost/cgen.src
@@ -142,8 +142,9 @@ func elem_ctype(iid, idx) (s) {
 }
 
 // chan_elem_typename: the MFL type-NAME of a channel node's element ("string", a
-// struct name, or a []/map[ form for slice/map elements; any scalar -> "int", which
-// carries no strings/structs so the string-offset walk is a no-op).
+// struct name, a full recursive "[]T" / "map[K]V" form for slice/map elements — via
+// type_string_slot, #293 — or "int" for any scalar, which carries no strings/structs
+// so the string-offset walk is a no-op).
 func chan_elem_typename(iid, idx) (tn) {
     tn = "int"
     r := node_slot_of(iid, idx)
@@ -153,8 +154,7 @@ func chan_elem_typename(iid, idx) (tn) {
     ek := g_kind[er]
     if ek == 5 { tn = "string"  return tn }
     if ek == 8 { tn = g_sname[er]  return tn }
-    if ek == 7 { tn = "[]x"  return tn }      // slice element -> chan_needs_json (defer)
-    if ek == 10 { tn = "map[x]x"  return tn }  // map element -> chan_needs_json (defer)
+    if ek == 7 || ek == 10 { tn = type_string_slot(g_elem[r])  return tn }  // #293: JSON path
 }
 // map_key_args: (ik, sk) for a map op — string keys pass ("0", key), else (key, "NULL").
 func map_key_args(iid, map_idx, keyexpr) (ik, sk) {
@@ -234,10 +234,14 @@ func cg_expr(iid, idx) (out) {
     if k == K_MAKECHAN {
         // scalar: mfl_make_chan(sizeof(T), 0, 0, 0). string / struct-with-strings: the
         // fast string-offset copy path (offsetof of each string field). slice/map (or a
-        // struct reaching one): a JSON round-trip -> deferred to a later slice.
+        // struct reaching one): a JSON round-trip (#293).
         ect := elem_ctype(iid, idx)
         tn := chan_elem_typename(iid, idx)
-        if chan_needs_json(tn) == 1 { g_cg_unsup = 1  out = "0"  return out }
+        if chan_needs_json(tn) == 1 {
+            ser, des := chan_json_fns(tn)
+            out = "mfl_make_chan(sizeof(" + ect + "), " + ser + ", " + des + ", 0)"
+            return out
+        }
         offs := chan_str_offsets(tn, "")
         if len(offs) == 0 {
             out = "mfl_make_chan(sizeof(" + ect + "), 0, 0, 0)"

--- a/selfhost/cgprog.src
+++ b/selfhost/cgprog.src
@@ -102,6 +102,24 @@ var g_glob_inits = []int{}   // global-init expr node indices (parallel to g_glo
 func cg_program() {
     compute_reps()
     cg_nslot_init()   // O(1) node->slot direct index (sized to the node count)
+
+    // -1. function bodies are generated FIRST, into a temp buffer, so everything they
+    //     lazily trigger as a side effect — goroutine trampolines (g_tramp) AND, #293,
+    //     per-type JSON serializers/parsers for chan JSON-mode elements (g_jsonfns) —
+    //     is fully known before the surrounding program structure gets emitted below,
+    //     in its normal declaration order. Matches the reference compiler's own
+    //     generate-then-assemble structure (this just widens the existing tramp/body
+    //     split to also cover g_jsonfns, which needs an EARLIER splice point than
+    //     trampolines — see step 3b).
+    g_goid = 0
+    g_tramp = []string{}
+    g_jsonfns = []string{}
+    saved := g_out
+    g_out = []string{}
+    for _, rid := range g_reps { cg_function(rid) }
+    bodies := g_out
+    g_out = saved
+
     // 0. extern (FFI) declarations: #include headers or raw cstruct typedefs + prototypes
     cg_extern_decls()
     // 1. struct typedefs — declared `type` structs and cstructs (mfl_ form), in
@@ -129,6 +147,13 @@ func cg_program() {
     }
     // 4. blank after typedefs when the program has any struct/cstruct types
     if len(g_structdefs) > 0 { cemit("\n") }
+    // 3b. #293: generated per-type JSON serializers/parsers (chan JSON-mode elements),
+    //     spliced here — the reference's exact position, right after typedefs and
+    //     before globals — for byte-identical output.
+    if len(g_jsonfns) > 0 {
+        for _, s := range g_jsonfns { cemit(s) }
+        cemit("\n")
+    }
     // 3. package globals: zero-initialized C statics
     gi := 0
     for gi < len(g_global_names) {
@@ -139,16 +164,8 @@ func cg_program() {
     // 4. function prototypes
     for _, rid := range g_reps { cemit(cg_signature(rid) + ";\n") }
     cemit("\n")
-    // 5. function bodies — generated into a temp buffer so goroutine trampolines
-    //    (populated during body codegen via g_tramp) can be spliced BEFORE the
-    //    bodies, matching the reference compiler's tramp/buf split.
-    g_goid = 0
-    g_tramp = []string{}
-    saved := g_out
-    g_out = []string{}
-    for _, rid := range g_reps { cg_function(rid) }
-    bodies := g_out
-    g_out = saved
+    // 5. function bodies (already generated above) — trampolines splice immediately
+    //    before them, matching the reference compiler's tramp/buf split.
     for _, t := range g_tramp { cemit(t) }
     for _, b := range bodies { cemit(b) }
     // 6. package-global initializers run in a C constructor (declaration order)

--- a/selfhost/verify-cgen.sh
+++ b/selfhost/verify-cgen.sh
@@ -232,6 +232,52 @@ func main() {
 EOF
 run "$T/h10.src"
 
+# #293: slice/map (JSON) channels — the element can't be deep-copied by the flat
+# string-offset path, so it round-trips through a generated per-type JSON
+# serializer/parser instead.
+cat > "$T/h11.src" <<'EOF'
+func sender(ch) {
+    ch <- []int{1, 2, 3}
+}
+func main() {
+    ch := make(chan []int)
+    go sender(ch)
+    xs := <-ch
+    println(str(len(xs)))
+}
+EOF
+run "$T/h11.src"
+
+cat > "$T/h12.src" <<'EOF'
+func sender(ch) {
+    m := make(map[string]int)
+    m["a"] = 1
+    ch <- m
+}
+func main() {
+    ch := make(chan map[string]int)
+    go sender(ch)
+    m := <-ch
+    println(str(len(keys(m))))
+}
+EOF
+run "$T/h12.src"
+
+cat > "$T/h13.src" <<'EOF'
+type Payload struct { name string  items []int }
+func sender(ch) {
+    p := Payload{name: "x", items: []int{1, 2}}
+    ch <- p
+}
+func main() {
+    ch := make(chan Payload)
+    go sender(ch)
+    p := <-ch
+    println(p.name + " " + str(len(p.items)))
+}
+EOF
+run "$T/h13.src"
+
 # SELF-APPLICATION: the MFL codegen emits byte-identical C for the compiler's OWN
 # source (checker + full codegen) — the fixpoint-adjacent milestone.
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \


### PR DESCRIPTION
Closes #293 — the last #280 self-hosted concurrency gap. Reuses proven existing machinery end to end: `type_string_slot` (already existed) for the type-string keying, and the shared runtime prelude (already has every JSON helper the generated functions call) — this is purely a codegen-generator port, no new runtime C.

## Summary
- `cgagg.src`: `json_serializer(t)` / `json_parser(t)` — a memoized, recursive, type-string-keyed C-function-text generator (mirrors `codegen.go`'s `jsonSerializer`/`jsonParser` exactly: int/float/bool/string base cases, `[]T`/`map[K]V`/struct recurse into element/field types, memo reserved before recursing for self-referential structs). `chan_json_fns(t)` wraps the pair to `mfl_make_chan`'s `void*` calling convention.
- `cgen.src`: `chan_elem_typename` now returns the real recursive type string for slice/map elements (via the already-existing `type_string_slot`) instead of a placeholder; `K_MAKECHAN`'s codegen calls `chan_json_fns` instead of bailing to `g_cg_unsup`.
- `cgprog.src`: widened the existing two-pass split (previously just goroutine trampolines) so the newly-generated JSON functions get captured before program assembly and spliced at the **reference compiler's exact position** — right after struct/multi-return typedefs, before globals — for byte-identical output. Function bodies now generate first; nothing before that in program order depends on their side effects, so this only changes *when* things are computed, not the final emission order.
- `verify-cgen.sh`: the issue's three "Done when" hand cases.

## Verification
- All three hand cases (`make(chan []int)`, `make(chan map[string]int)`, a struct-with-slice channel) **byte-match** `machin cgentest --program` exactly.
- All three additionally **compile and run correctly** end to end (goroutine sends, receiver gets the value back intact).
- `verify-fixpoint.sh`: stable PASS across repeated runs.
- `verify-parse/check/check2/check3/cgen/race.sh`: all clean — `verify-cgen.sh` now 415/0 (up from 412/0 by exactly the 3 new cases).
- The two pre-existing unrelated failures (`verify-check4.sh`: a missing crypto builtin; `verify-nogo.sh`: a cosmetic C-diff in the standalone `machin.src` reimplementation) are present on `main` before this branch too — confirmed during #308's work, unaffected by this change.

## Test plan
- [x] `verify-fixpoint.sh` (×2, stable)
- [x] `verify-parse.sh` / `verify-check.sh` / `verify-check2.sh` / `verify-check3.sh` / `verify-cgen.sh` (415/0) / `verify-race.sh`
- [x] Byte-diff + compile + run all three "Done when" hand cases against the Go oracle