### PR TITLE
docs(readme): add --race-safe flag to the CLI usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ bin/machin run    examples/demo.mfl      # compile to native + execute
 bin/machin build  app.mfl -o app         # standalone native binary
 bin/machin build  app.mfl --emit-c       # print the generated C
 bin/machin build  app.mfl --safe         # + bounds / div-zero / overflow checks
+bin/machin build|run app.mfl --race-safe # refuse to build if a data race is inferred
 bin/machin encode a.src b.src > app.mfl  # mint canonical .mfl from loose Go-like text
 bin/machin pack   app.mfl                # dense base64 form (distribution)
 bin/machin guide  --text                 # print the full feature catalog for agents


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Make exactly ONE small, focused documentation improvement to this repository. Pick a single existing feature, CLI flag, function, or module that is under-documented or has a doc gap, and add a clear, concise doc/README section (or fix an inaccuracy) for it. Do NOT modify any source/production code — documentation only (markdown, doc comments, or examples-in-docs). Keep the change small and focused (one doc improvement). Then commit and open a PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #425 (am/am-7b5889-thrhng): test(parser): cover parseFuncLit/parseStructLit error branches
    touches: buildwasm_test.go, check_test.go


**Branch:** `am/am-7b5889-thykoo`

## Summary

Added the missing --race-safe flag to the README usage examples. The README already documented --safe but not --race-safe, so this is a small doc-only fix that surfaces the data-race build gate alongside the other safety option.

**Diff:**
```
README.md | 1 +
 1 file changed, 1 insertion(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the `--race-safe` build/run option, which prevents builds when a potential data race is inferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->