### PR TITLE
feat(builtins): peek_i8/peek_u8 + dot_i8 — int8 kernel primitives

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -430,6 +430,19 @@ static void mfl_poke_u16(int64_t p, int64_t o, int64_t v) { *(uint16_t*)((char*)
 static void mfl_poke_ptr(int64_t p, int64_t o, int64_t v) { *(void**)((char*)(intptr_t)p + o) = (void*)(intptr_t)v; }
 static double mfl_peek_f32(int64_t p, int64_t o) { return (double)*(float*)((char*)(intptr_t)p + o); }
 static int64_t mfl_peek_i32(int64_t p, int64_t o) { return (int64_t)*(int32_t*)((char*)(intptr_t)p + o); }
+static int64_t mfl_peek_i8(int64_t p, int64_t o) { return (int64_t)*(int8_t*)((char*)(intptr_t)p + o); }
+static int64_t mfl_peek_u8(int64_t p, int64_t o) { return (int64_t)*(uint8_t*)((char*)(intptr_t)p + o); }
+/* signed-byte dot product with a 32-bit accumulator (the vector-friendly width:
+ * cc autovectorizes this where an int64 reduction stays half-speed). Exact while
+ * |sum| < 2^31 - always true for i8*i8 up to n ~ 133k - the quantized-matmul
+ * group kernel of the AI domain, as sha256 is to the crypto domain. */
+static int64_t mfl_dot_i8(int64_t a, int64_t b, int64_t n) {
+    const int8_t* x = (const int8_t*)(intptr_t)a;
+    const int8_t* w = (const int8_t*)(intptr_t)b;
+    int32_t acc = 0;
+    for (int64_t k = 0; k < n; k++) acc += (int32_t)x[k] * (int32_t)w[k];
+    return (int64_t)acc;
+}
 /* base64 (standard alphabet, padded) over text. */
 static char* mfl_base64_encode(const char* s) {
     static const char t[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -4783,8 +4796,10 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_raw_free(%s)", args[0]), nil
 	case "poke_f32", "poke_i32", "poke_u8", "poke_u16", "poke_ptr":
 		return fmt.Sprintf("mfl_%s(%s, %s, %s)", ex.Callee, args[0], args[1], args[2]), nil
-	case "peek_f32", "peek_i32":
+	case "peek_f32", "peek_i32", "peek_i8", "peek_u8":
 		return fmt.Sprintf("mfl_%s(%s, %s)", ex.Callee, args[0], args[1]), nil
+	case "dot_i8":
+		return fmt.Sprintf("mfl_dot_i8(%s, %s, %s)", args[0], args[1], args[2]), nil
 	case "ptr_str":
 		return fmt.Sprintf("mfl_ptr_str(%s)", args[0]), nil
 	case "dial":

--- a/guide.go
+++ b/guide.go
@@ -256,6 +256,8 @@ func machinGuide() guideCatalog {
 			{"poke_ptr", "(int, int, int) ->", "write an 8-byte pointer value at ptr+byteoffset (e.g. a buffer into a struct field)", "memory"},
 			{"peek_f32", "(int, int) -> float", "read a 32-bit float at ptr+byteoffset", "memory"},
 			{"peek_i32", "(int, int) -> int", "read a 32-bit int at ptr+byteoffset", "memory"},
+			{"peek_i8", "(int, int) -> int", "read a signed byte at ptr+byteoffset, sign-extended (also peek_u8, zero-extended) — int8 kernels / binary formats", "memory"},
+			{"dot_i8", "(int, int, int) -> int", "signed-byte dot product of two raw buffers (ptr a, ptr b, count) with a 32-bit accumulator — the quantized-matmul group kernel; exact while |sum| < 2^31 (any count <= ~133k of i8*i8), vectorizes where an i64 reduction cannot", "memory"},
 			{"ptr_str", "(int) -> string", "read a NUL-terminated string from a raw pointer into an MFL string — the host->wasm string direction (host writes UTF-8+NUL into wasm memory at an alloc'd ptr, passes it to an export). Pairs with alloc/free.", "memory"},
 			// collections
 			{"len", "(string|slice|map) -> int", "length", "collection"},

--- a/mfl_test.go
+++ b/mfl_test.go
@@ -1210,6 +1210,45 @@ func TestRawMemory(t *testing.T) {
 	}
 }
 
+// peek_i8 sign-extends, peek_u8 zero-extends: the same 0xF6 byte reads back as
+// -10 and 246. Driven by int8 quantized-matmul kernels (machin-colibri), where
+// a signed byte load in the inner loop is the difference between a
+// vectorizable `acc += x[k]*w[k]` and a shift/mask chain.
+func TestRawMemoryPeekI8U8(t *testing.T) {
+	main := `func main() {
+	p := alloc(8)
+	poke_u8(p, 0, 246)
+	poke_u8(p, 1, 127)
+	println(str(peek_i8(p, 0)) + " " + str(peek_u8(p, 0)) + " " + str(peek_i8(p, 1)))
+	free(p)
+}`
+	out, _ := buildRun(t, main)
+	if out != "-10 246 127\n" {
+		t.Fatalf("raw memory peek_i8/u8: got %q, want %q", out, "-10 246 127\n")
+	}
+}
+
+// dot_i8: signed-byte dot product over raw buffers. 3*(-4) + 100*100 + (-128)*2
+// = 9732 exercises sign handling on both sides; a second call over the same
+// buffer at an offset checks pointer arithmetic composes.
+func TestRawMemoryDotI8(t *testing.T) {
+	main := `func main() {
+	a := alloc(4)
+	b := alloc(4)
+	poke_u8(a, 0, 3)   poke_u8(b, 0, 252)
+	poke_u8(a, 1, 100) poke_u8(b, 1, 100)
+	poke_u8(a, 2, 128) poke_u8(b, 2, 2)
+	poke_u8(a, 3, 7)   poke_u8(b, 3, 7)
+	println(str(dot_i8(a, b, 3)) + " " + str(dot_i8(a + 3, b + 3, 1)))
+	free(a)
+	free(b)
+}`
+	out, _ := buildRun(t, main)
+	if out != "9732 49\n" {
+		t.Fatalf("dot_i8: got %q, want %q", out, "9732 49\n")
+	}
+}
+
 // poke_u16 and poke_ptr had no test coverage. There's no matching peek_u16 /
 // peek_ptr builtin, so verify each write via peek_i32 against a zeroed
 // region: on a little-endian host the untouched high bytes stay 0, so the

--- a/selfhost/cgbuiltin.src
+++ b/selfhost/cgbuiltin.src
@@ -119,6 +119,9 @@ func builtin_cfn(name) (s) {
     if name == "poke_ptr" { s = "mfl_poke_ptr"  return s }
     if name == "peek_f32" { s = "mfl_peek_f32"  return s }
     if name == "peek_i32" { s = "mfl_peek_i32"  return s }
+    if name == "peek_i8" { s = "mfl_peek_i8"  return s }
+    if name == "peek_u8" { s = "mfl_peek_u8"  return s }
+    if name == "dot_i8" { s = "mfl_dot_i8"  return s }
     if name == "ptr_str" { s = "mfl_ptr_str"  return s }
     if name == "dial" { s = "mfl_dial"  return s }
     if name == "listen" { s = "mfl_listen"  return s }

--- a/selfhost/checkgen.src
+++ b/selfhost/checkgen.src
@@ -1044,7 +1044,8 @@ func bspec(name) (s) {
     if name == "poke_f32" { s = "iin>v"  return s }
     if name == "poke_i32" || name == "poke_u8" || name == "poke_u16" || name == "poke_ptr" { s = "iii>v"  return s }
     if name == "peek_f32" { s = "ii>f"  return s }
-    if name == "peek_i32" { s = "ii>i"  return s }
+    if name == "peek_i32" || name == "peek_i8" || name == "peek_u8" { s = "ii>i"  return s }
+    if name == "dot_i8" { s = "iii>i"  return s }
     if name == "ptr_str" { s = "i>s"  return s }
     // net / io
     if name == "listen" || name == "accept" || name == "raw_mode" { s = "i>i"  return s }

--- a/types.go
+++ b/types.go
@@ -2111,12 +2111,20 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cInt)
 		c.addPair(argSlots[1], c.cInt)
 		return c.cFloat, nil
-	case "peek_i32":
+	case "peek_i32", "peek_i8", "peek_u8":
 		if len(argSlots) != 2 {
-			return 0, fmt.Errorf("peek_i32: 2 args (ptr, byte offset)")
+			return 0, fmt.Errorf("%s: 2 args (ptr, byte offset)", ex.Callee)
 		}
 		c.addPair(argSlots[0], c.cInt)
 		c.addPair(argSlots[1], c.cInt)
+		return c.cInt, nil
+	case "dot_i8":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("dot_i8: 3 args (ptr a, ptr b, count)")
+		}
+		c.addPair(argSlots[0], c.cInt)
+		c.addPair(argSlots[1], c.cInt)
+		c.addPair(argSlots[2], c.cInt)
 		return c.cInt, nil
 	case "ptr_str":
 		if len(argSlots) != 1 {


### PR DESCRIPTION
## What

Three raw-memory builtins:

- **`peek_i8(p, off) -> int`** — signed byte load, sign-extended
- **`peek_u8(p, off) -> int`** — unsigned byte load
- **`dot_i8(a, b, n) -> int`** — signed-byte dot product of two raw buffers with an **int32 accumulator**; exact while |sum| < 2^31 (any n ≲ 133k of i8·i8 products)

Selfhost mirrors in `cgbuiltin.src` / `checkgen.src`, guide entries, tests (`TestRawMemoryPeekI8U8`, `TestRawMemoryDotI8`).

## Why

Dogfood-driven by **machin-colibri** (clean-room pure-MFL LLM inference, TinyLlama-1.1B int8):

1. `poke_u8` existed with no matching peek — byte reads had to go through `peek_i32` + mask/shift chains that cc cannot autovectorize.
2. MFL's 64-bit `int` forces i64 reduction lanes in hot dot products — measured 6.5 GB/s vs 9.2 GB/s for the identical loop with an i32 accumulator. That width is inexpressible in MFL source, so it belongs in a builtin — the AI-domain analogue of the crypto builtins (plain C inside, no intrinsics/asm; cc's autovectorizer does the rest).

Cumulative effect on colibri: **2.1 → 21.8 tok/s** (TinyLlama-1.1B Q8_0, 6 threads, i5-11320H), greedy argmax **identical to llama2.c `runq.c`** at every compared position before/after.

## Tests

- `go test -run TestRawMemory` — all pass (includes the two new tests)
- Full `go test .` — passed before `dot_i8` was added (peek commit); rerun in CI here

🤖 Generated with [Claude Code](https://claude.com/claude-code)