### PR TITLE
fix(codegen): short-circuit && / || instead of evaluating both operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Fixed `&&` / `||` not short-circuiting: the right operand was evaluated
+  even when the left already decided the result.** When either operand had a
+  side effect (a call or channel receive), codegen hoisted *both* operands
+  into temporaries via `seqExprs` before combining them, so the right operand
+  always ran. This broke guard idioms like `if p != nil && p.ok()` and, under
+  `--safe`, could turn a guarded expression into a crash (e.g.
+  `if j > 0 && boom(xs) == "a"` still called `boom` when `j == 0`). Logical
+  `&&`/`||` are now emitted directly as C's short-circuiting operators, which
+  guarantee left-to-right evaluation with a sequence point between operands.
+  See #437.
+
 ## v0.107.0
 
 - **Fixed a use-after-free/segfault: a `func` literal passed directly as a

--- a/codegen.go
+++ b/codegen.go
@@ -4059,6 +4059,23 @@ func (g *cgen) seqExprs(exprs []Expr, build func([]string) (string, error)) (str
 }
 
 func (g *cgen) binary(ex *Binary) (string, error) {
+	// Logical && / || must short-circuit: the right operand is evaluated only
+	// when the left does not already decide the result. seqExprs would hoist
+	// both operands into temporaries whenever either has a side effect, forcing
+	// the right operand to be evaluated unconditionally (#437). C's && / ||
+	// already guarantee left-to-right short-circuit evaluation with a sequence
+	// point between the operands, so emit them directly instead.
+	if ex.Op == "&&" || ex.Op == "||" {
+		l, err := g.expr(ex.L)
+		if err != nil {
+			return "", err
+		}
+		r, err := g.expr(ex.R)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("(%s %s %s)", l, ex.Op, r), nil
+	}
 	return g.seqExprs([]Expr{ex.L, ex.R}, func(n []string) (string, error) {
 		return g.binaryCombine(ex, n[0], n[1]), nil
 	})

--- a/shortcircuit_test.go
+++ b/shortcircuit_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// runNativeSafe compiles the given function sources with the --safe checks
+// enabled (bounds/overflow), runs the binary, and returns its combined stdout.
+// The bool result reports whether the process exited cleanly (no panic/abort).
+func runNativeSafe(t *testing.T, funcs ...string) (string, bool) {
+	t.Helper()
+	var fns []*FuncDecl
+	for _, f := range funcs {
+		fn, err := ParseFunc(normalize(f))
+		if err != nil {
+			t.Fatalf("parse %q: %v", f, err)
+		}
+		fns = append(fns, fn)
+	}
+	bin, err := os.CreateTemp("", "mfl-sc-*")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(&Program{Funcs: fns}, bin.Name(), true); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	out, err := exec.Command(bin.Name()).Output()
+	return string(out), err == nil
+}
+
+// TestShortCircuitAvoidsSideEffect verifies that && / || short-circuit: the
+// right operand is not evaluated when the left already decides the result.
+// Regression for #437, where seqExprs hoisted both operands into temporaries
+// whenever either had a side effect, evaluating the right operand always.
+func TestShortCircuitAvoidsSideEffect(t *testing.T) {
+	got := runNative(t,
+		`func touch() (b) { println("touched") b = true }`,
+		`func main() {
+			if false && touch() { println("A") } else { println("B") }
+			if true || touch() { println("C") }
+		}`)
+	const want = "B\nC\n"
+	if got != want {
+		t.Fatalf("got %q, want %q (right operand should not be evaluated)", got, want)
+	}
+}
+
+// TestShortCircuitInAssignment covers the same short-circuit guarantee in
+// value context (an assignment rather than an if-condition).
+func TestShortCircuitInAssignment(t *testing.T) {
+	got := runNative(t,
+		`func touch() (b) { println("touched") b = false }`,
+		`func main() {
+			x := true || touch()
+			y := false && touch()
+			println(x, y)
+		}`)
+	const want = "true false\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// TestShortCircuitSafeIndexGuard reproduces issue #437 directly: under --safe,
+// a guarding condition on the left of && must prevent the crashing call on the
+// right from running at all.
+func TestShortCircuitSafeIndexGuard(t *testing.T) {
+	out, ok := runNativeSafe(t,
+		`func boom(xs) (v) { v = xs[0 - 1] }`,
+		`func main() {
+			xs := []string{"a", "b"}
+			j := 0
+			if j > 0 && boom(xs) == "a" { println("entered") } else { println("skipped") }
+			println("survived")
+		}`)
+	if !ok {
+		t.Fatalf("program aborted (short-circuit did not guard boom); output=%q", out)
+	}
+	const want = "skipped\nsurvived\n"
+	if out != want {
+		t.Fatalf("got %q, want %q", out, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Pick a north-star domain; make one big move toward it each run.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #425 (am/am-7b5889-thrhng): test(parser): cover parseFuncLit/parseStructLit error branches
    touches: buildwasm_test.go, check_test.go


**Branch:** `am/am-7b5889-ti1g73`

**Diff:**
```
CHANGELOG.md         | 11 +++++++
 codegen.go           | 17 ++++++++++
 shortcircuit_test.go | 87 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 115 insertions(+)
```
