### PR TITLE
fix(racecheck): propagate happens-before through pre-spawn callees

### DIFF
--- a/check.go
+++ b/check.go
@@ -11,8 +11,17 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 )
+
+// arityMsg matches the argument-count errors the type checker emits, whose wording
+// varies across call sites: "expected 2 args, got 3", "len: 1 arg", and the many
+// builtin forms like "substr: 3 args (string, start, end)". None of these contain
+// the literal "argument"/"expects"/"arity" that classifyCheck keyed on, so they were
+// silently bucketed as the generic "type-error" instead of the documented
+// "arity-mismatch" code. The `\d+ args?` shape is the common thread.
+var arityMsg = regexp.MustCompile(`\b\d+ args?\b`)
 
 // Diagnostic is one problem the checker found. `Code` is the stable contract an agent
 // branches on; `Message` is human detail (don't pattern-match it). `Decl` is the
@@ -360,7 +369,7 @@ func classifyCheck(msg string) string {
 		return "undefined-field"
 	case strings.Contains(msg, "undefined") || strings.Contains(msg, "unknown") || strings.Contains(msg, "not defined"):
 		return "undefined-name"
-	case strings.Contains(msg, "argument") || strings.Contains(msg, "expects") || strings.Contains(msg, "arity"):
+	case strings.Contains(msg, "argument") || strings.Contains(msg, "expects") || strings.Contains(msg, "arity") || arityMsg.MatchString(msg):
 		return "arity-mismatch"
 	case strings.Contains(msg, "unsupported"):
 		return "unsupported-construct"

--- a/classify_test.go
+++ b/classify_test.go
@@ -40,6 +40,16 @@ func TestClassifyCheckBranches(t *testing.T) {
 		{`function "f" expects 2 arguments`, "arity-mismatch"},
 		{`wrong number of argument for "f"`, "arity-mismatch"},
 		{`arity mismatch for "f"`, "arity-mismatch"},
+		// The wording the type checker actually emits (types.go): none of these
+		// contain "argument"/"expects"/"arity", so they used to leak as "type-error".
+		{"main: expected 2 args, got 3", "arity-mismatch"},
+		{"len: 1 arg", "arity-mismatch"},
+		{"append: 2 args", "arity-mismatch"},
+		{"substr: 3 args (string, start, end)", "arity-mismatch"},
+		{"ed25519_verify: 3 args (pub, msg, sig — all bytes)", "arity-mismatch"},
+		// A struct field-count message must still classify as undefined-field, not
+		// arity (the "field" case is intentionally checked before the arity case).
+		{`struct "P": expected 2 fields, got 3`, "undefined-field"},
 		{"unsupported construct in this context", "unsupported-construct"},
 		{"totally unrecognized checker message", "type-error"},
 		{"", "type-error"},

--- a/racecheck.go
+++ b/racecheck.go
@@ -949,6 +949,42 @@ func mainPostGlobals(body []Stmt, gset, local map[string]bool) map[string]*gAcce
 	return out
 }
 
+// mainPostCallees returns the set of functions main invokes as NORMAL (non-`go`)
+// calls at or after its first `go` spawn. A callee invoked strictly before the
+// first spawn runs entirely before goroutine creation — a happens-before edge — so
+// its global writes are ordered with respect to the spawned goroutines and must not
+// be treated as concurrent. Excluding those callees propagates the caller's program
+// order through the call, so the canonical "init globals in a helper, then spawn a
+// worker pool" pattern is race-free (issue #434: interprocedural happens-before).
+func mainPostCallees(body []Stmt) map[string]bool {
+	out := map[string]bool{}
+	spawned := false
+	var walk func(ss []Stmt)
+	walk = func(ss []Stmt) {
+		for _, s := range ss {
+			if _, ok := s.(*GoStmt); ok {
+				spawned = true
+				continue
+			}
+			if !spawned {
+				// descend to catch a spawn nested in an early block, but don't collect
+				if b, ok := blockOf(s); ok {
+					walk(b)
+				}
+				continue
+			}
+			var normal []string
+			var gos []goSite
+			collectCallGraph([]Stmt{s}, false, &normal, &gos)
+			for _, n := range normal {
+				out[n] = true
+			}
+		}
+	}
+	walk(body)
+	return out
+}
+
 func blockOf(s Stmt) ([]Stmt, bool) {
 	switch st := s.(type) {
 	case *IfStmt:
@@ -1023,7 +1059,13 @@ func globalRaces(prog *Program, c *Checker) []raceFinding {
 		for g, a := range mainPostGlobals(mainFn.Body, gset, local["main"]) {
 			mergeGAcc(mainConc, g, a)
 		}
+		// Only callees invoked at/after the first spawn are concurrent; a callee
+		// completed before the spawn happens-before the goroutines (issue #434).
+		postCallees := mainPostCallees(mainFn.Body)
 		for _, ce := range normalCallees["main"] {
+			if !postCallees[ce] {
+				continue
+			}
 			for g, a := range gall[ce] {
 				mergeGAcc(mainConc, g, a)
 			}

--- a/racecheck_test.go
+++ b/racecheck_test.go
@@ -178,6 +178,36 @@ func TestRace_GlobalInitThenSpawn(t *testing.T) {
 	}
 }
 
+func TestRace_GlobalInitInCalleeThenSpawn(t *testing.T) {
+	// interprocedural happens-before (issue #434): a global written in a helper
+	// CALLED before the first spawn is ordered-before the goroutines, exactly like
+	// writing it inline in main. The init-then-spawn worker-pool pattern is safe
+	// even when initialization lives in a callee.
+	fs := rcCheck(t,
+		"var cfg = 0",
+		"func setup(){cfg=7}",
+		"func worker(jc,dc){for j:=range jc {dc<-j*cfg}}",
+		"func main(){setup() jobs:=make(chan int) done:=make(chan int) go worker(jobs,done) jobs<-6 println(str(<-done))}")
+	rcReport(t, "global init-in-callee then spawn", fs)
+	if len(fs) != 0 {
+		t.Fatalf("want CLEAN (callee write ordered-before spawn), got %+v", fs)
+	}
+}
+
+func TestRace_GlobalWriteInCalleeAfterSpawn(t *testing.T) {
+	// the guard for the #434 fix: a helper CALLED after the spawn writes the global
+	// concurrently with the goroutine's read — still a genuine race.
+	fs := rcCheck(t,
+		"var cfg = 0",
+		"func bump(){cfg=7}",
+		"func worker(ch){ch<-cfg}",
+		"func main(){ch:=make(chan int) go worker(ch) bump() print(<-ch)}")
+	rcReport(t, "global write-in-callee after spawn", fs)
+	if len(fs) != 1 || fs[0].Root != "cfg" || fs[0].Kind != "read/write" {
+		t.Fatalf("want 1 read/write race on cfg, got %+v", fs)
+	}
+}
+
 func TestRace_GlobalReadOnly(t *testing.T) {
 	fs := rcCheck(t,
 		"var base = 100",


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Pick a north-star domain; make one big move toward it each run.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #438 (am/am-7b5889-ti1g73): fix(codegen): short-circuit && / || instead of evaluating both operands
    touches: CHANGELOG.md, codegen.go, shortcircuit_test.go
- PR #425 (am/am-7b5889-thrhng): test(parser): cover parseFuncLit/parseStructLit error branches
    touches: buildwasm_test.go, check_test.go


**Branch:** `am/am-7b5889-ti1i0s`

**Diff:**
```
check.go          | 11 ++++++++++-
 classify_test.go  | 10 ++++++++++
 racecheck.go      | 42 ++++++++++++++++++++++++++++++++++++++++++
 racecheck_test.go | 30 ++++++++++++++++++++++++++++++
 4 files changed, 92 insertions(+), 1 deletion(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostic classification for argument-count mismatches, including varied checker message wording.
  - Preserved correct classification for struct field-count mismatches.
  - Refined race detection for global variables across helper calls before and after goroutine creation.

- **Tests**
  - Added coverage for expanded argument-mismatch diagnostics.
  - Added race-detection scenarios validating ordering around goroutine creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->