### PR TITLE
[needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -70,6 +70,7 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `router_api`      | HTTP router — dispatch by method+path, extract path params |
 | `sqlite_crud`     | SQLite: `sqlite_open`/`sqlite_exec`/`sqlite_query`/`sqlite_close` — in-memory CRUD with parameterized queries, `parse()` row decode, and `json_get` single-field access |
 | `arena`           | scoped `arena{}` allocation |
+| `quant_matmul`    | Q8_0 quantized matrix-vector product (the LLM matmul kernel): `alloc`/`poke_u8`/`poke_f32` build int8 codes + per-group fp32 scales, `dot_q8` fuses the grouped, dual-scaled inner product; contiguous row-major weights addressed by pointer arithmetic |
 | `counter`         | closure/state counter |
 | `ffi_math`        | C FFI — calling external C functions (scalars) |
 | `ffi_ptr`         | C FFI — opaque `ptr` handles |

--- a/examples/complex/quant_matmul.mfl
+++ b/examples/complex/quant_matmul.mfl
@@ -1,0 +1,3 @@
+func poke4(p,off,a,b,c,d){poke_u8(p,off+0,a)poke_u8(p,off+1,b)poke_u8(p,off+2,c)poke_u8(p,off+3,d)}
+
+func main(){n:=4 gs:=2 rows:=3 groups:=n/gs xq:=alloc(n)xs:=alloc(groups*4)poke4(xq,0,2,3,1,254)poke_f32(xs,0,0.5)poke_f32(xs,4,0.25)wq:=alloc(rows*n)ws:=alloc(rows*groups*4)poke4(wq,0,4,5,3,1)poke_f32(ws,0,2.0)poke_f32(ws,4,4.0)poke4(wq,4,4,5,3,1)poke_f32(ws,8,4.0)poke_f32(ws,12,8.0)poke4(wq,8,1,0,0,0)poke_f32(ws,16,2.0)poke_f32(ws,20,2.0)total:=0.0 r:=0 for r<rows{y:=dot_q8(xq,xs,wq+r*n,ws+r*groups*4,n,gs)println("y["+str(r)+"] = "+str(y))total=total+y r=r+1}println("sum = "+str(total))}

--- a/quant_matmul_example_test.go
+++ b/quant_matmul_example_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+// The examples/complex/quant_matmul.mfl demo computes a Q8_0 quantized
+// matrix-vector product y = W . x with dot_q8: the activation vector and each
+// weight row are int8 codes with one fp32 scale per group of gs elements, laid
+// out contiguously and addressed by pointer arithmetic (as a real GGUF
+// checkpoint is memory-mapped). This pins the demo's numeric output so the
+// shipped example — and the dot_q8 kernel it exercises — cannot silently drift.
+//
+// Hand-check (gs=2 -> two groups per row; x codes [2,3,1,-2], scales [.5,.25]):
+//   row0 w=[4,5,3,1] s=[2,4]: (2*4+3*5)*.5*2 + (1*3-2*1)*.25*4 = 23 + 1  = 24
+//   row1 w=[4,5,3,1] s=[4,8]: (23)*.5*4       + (1)*.25*8              = 46 + 2  = 48
+//   row2 w=[1,0,0,0] s=[2,2]: (2*1)*.5*2      + 0                      = 2  + 0  = 2
+//   sum = 74
+func TestQuantMatmulExample(t *testing.T) {
+	prog, err := loadMFL("examples/complex/quant_matmul.mfl")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := "y[0] = 24\ny[1] = 48\ny[2] = 2\nsum = 74\n"
+	if out != want {
+		t.Fatalf("quant_matmul example output:\n got %q\nwant %q", out, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Pick a north-star domain; make one big move toward it each run.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #442 (am/am-7b5889-ti1ltg): test(kernels): Q8_0 GEMV/GEMM integration — dot_q8 fused == manual inner loop
    touches: SPEC.md, kernel_q8_gemv_test.go, lexer.go, lexer_underscore_test.go
- PR #441 (am/am-7b5889-ti1jvh): test(kernels): pin int8/Q8_0 dot & peek numeric contracts
    touches: assign_undefined_test.go, kernel_q8_edge_test.go, types.go
- PR #440 (am/am-7b5889-ti1i0s): fix(racecheck): propagate happens-before through pre-spawn callees
    touches: check.go, classify_test.go, racecheck.go, racecheck_test.go
- PR #438 (am/am-7b5889-ti1g73): fix(codegen): short-circuit && / || instead of evaluating both operands
    touches: CHANGELOG.md, codegen.go, shortcircuit_test.go
- PR #425 (am/am-7b5889-thrhng): test(parser): cover parseFuncLit/parseStructLit error branches
    touches: buildwasm_test.go, check_test.go


**Branch:** `am/am-7b5889-ti1pfj`

> ⚠️ **Verification failed** — this PR is a draft. Last output:
```
          want "e:=abs(yq-yref)"
    tighten_test.go:62: examples/complex/quantize_q8.mfl is not canonical:
          have "if e > maxerr { maxerr = e }"
          want "if e>maxerr{maxerr=e}"
    tighten_test.go:62: examples/complex/quantize_q8.mfl is not canonical:
          have "println(\"row\", r, \"q8:\", yq, \"ref:\", yref)"
          want "println(\"row\",r,\"q8:\",yq,\"ref:\",yref)"
    tighten_test.go:62: examples/complex/quantize_q8.mfl is not canonical:
          have "r = r + 1"
          want "r=r+1"
    tighten_test.go:62: examples/complex/quantize_q8.mfl is not canonical:
          have "// verdict is platform-stable: the error (~0.005) sits far under the bound."
          want "//verdict is platform-stable:the error(~0.005)sits far under the bound."
    tighten_test.go:62: examples/complex/quantize_q8.mfl is not canonical:
          have "println(\"quantized within tolerance:\", maxerr < 0.02)"
          want "println(\"quantized within tolerance:\",maxerr<0.02)"
0 root=0 kind=int
1 root=1 kind=func fsig=|0
err=0
0 root=0 kind=var
1 root=1 kind=num
2 root=2 kind=int
3 root=3 kind=float
4 root=4 kind=bool
5 root=5 kind=string
6 root=6 kind=void
7 root=7 kind=bytes
8 root=8 kind=slice elem=2
9 root=9 kind=chan elem=2
10 root=10 kind=struct sname=Bar
11 root=11 kind=map mkey=0 mval=1
12 root=12 kind=func fsig=0,1|2
err=1
0 root=0 kind=int
1 root=1 kind=string
err=1
err=0
FAIL
FAIL	machin	81.058s
FAIL
[verify environment problem — the command can't run in the worktree; not auto-fixable]
```

**Diff:**
```
examples/README.md                |  1 +
 examples/complex/quant_matmul.mfl |  3 +++
 quant_matmul_example_test.go      | 30 ++++++++++++++++++++++++++++++
 3 files changed, 34 insertions(+)
```
