### PR TITLE
test(math): cover atan/atan2 builtins incl. all four quadrants

### DIFF
--- a/atan_builtins_test.go
+++ b/atan_builtins_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// atan and atan2 are wired into codegen (mfl_math_atan / mfl_math_atan2) but
+// had no dedicated test coverage. atan is single-arg; atan2 is two-arg and
+// must respect the sign of BOTH operands to place the angle in the correct
+// quadrant — a swapped-argument or dropped-sign regression in codegen would
+// otherwise slip through silently. Expected strings match the C runtime's
+// "%g" formatting (6 significant digits).
+func TestAtanBuiltin(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("atan0=" + str(atan(0.0)))
+    println("atan1=" + str(atan(1.0)))
+    println("atanNeg1=" + str(atan(-1.0)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"atan0=0",
+		"atan1=0.785398",     // pi/4
+		"atanNeg1=-0.785398", // -pi/4, odd function
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestAtan2Quadrants pins atan2's quadrant resolution: all four (y,x) sign
+// combinations, plus the axis cases that distinguish atan2 from a plain
+// atan(y/x).
+func TestAtan2Quadrants(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("q1=" + str(atan2(1.0, 1.0)))
+    println("q2=" + str(atan2(1.0, -1.0)))
+    println("q3=" + str(atan2(-1.0, -1.0)))
+    println("q4=" + str(atan2(-1.0, 1.0)))
+    println("piY=" + str(atan2(0.0, -1.0)))
+    println("halfpi=" + str(atan2(1.0, 0.0)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"q1=0.785398",   //  pi/4  (+,+)
+		"q2=2.35619",    //  3pi/4 (+,-)
+		"q3=-2.35619",   // -3pi/4 (-,-)
+		"q4=-0.785398",  // -pi/4  (-,+)
+		"piY=3.14159",   //  pi    on the negative x-axis
+		"halfpi=1.5708", //  pi/2  on the positive y-axis
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Pick a north-star domain; make one big move toward it each run.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go
- PR #442 (am/am-7b5889-ti1ltg): test(kernels): Q8_0 GEMV/GEMM integration — dot_q8 fused == manual inner loop
    touches: SPEC.md, kernel_q8_gemv_test.go, lexer.go, lexer_underscore_test.go
- PR #441 (am/am-7b5889-ti1jvh): test(kernels): pin int8/Q8_0 dot & peek numeric contracts
    touches: assign_undefined_test.go, kernel_q8_edge_test.go, types.go
- PR #440 (am/am-7b5889-ti1i0s): fix(racecheck): propagate happens-before through pre-spawn callees
    touches: check.go, classify_test.go, racecheck.go, racecheck_test.go
- PR #438 (am/am-7b5889-ti1g73): fix(codegen): short-circuit && / || instead of evaluating both operands
    touches: CHANGELOG.md, codegen.go, shortcircuit_test.go
- PR #425 (am/am-7b5889-thrhng): test(parser): cover parseFuncLit/parseStructLit error branches
    touches: buildwasm_test.go, check_test.go


**Branch:** `am/am-7b5889-ti1rk5`

**Diff:**
```
atan_builtins_test.go | 65 +++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 65 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the `atan` and `atan2` built-in functions.
  * Verified expected results for positive, negative, zero, axis, and quadrant-specific inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->