### PR TITLE
docs(north-star): chart the LLM/quantized-inference domain

### DIFF
--- a/docs/NORTH-STAR-INFERENCE.md
+++ b/docs/NORTH-STAR-INFERENCE.md
@@ -1,0 +1,150 @@
+# Inference: a north star for the domain
+
+machin is a **backend-first, machine-first** language — its core target is
+servers, tools, and protocols. But the dogfood loop (build real things; let real
+use surface gaps) keeps pulling it toward a new frontier: running **quantized
+neural-network inference** as a single static native binary, no Python, no
+`libtorch`, no cgo. Dogfooding a small LLM engine (**machin-colibri**, the
+worker-pool-over-mmapped-weights engine that surfaced issues [#434](https://github.com/javimosch/machin/issues/434)
+and drove the kernel builtins below) has turned "AI inference" into one of
+machin's freshly detected domains. This document is the north star for it.
+
+> The overall machin north star is unchanged (backend, machine-first). Inference
+> is a **branch** of it — a domain machin is being extended toward, one verified
+> builtin at a time — exactly like the [game-dev](./NORTH-STAR-GAMEDEV.md),
+> [web](./NORTH-STAR-WEB.md), and [backend](./NORTH-STAR-BACKEND.md) branches.
+> Several tiers below are aspirations, not commitments.
+
+## Why machin, for this domain
+
+Inference at the edge is a *systems* problem before it is a math problem: mmap a
+multi-gigabyte checkpoint without copying it, keep peak RSS flat while streaming
+tokens, saturate the SIMD units on the int8 hot loop, and start cold in
+milliseconds. That is precisely the shape machin already optimizes for — one
+static musl binary, a per-goroutine arena that bounds memory, and a C backend
+whose autovectorizer machin can feed directly. The weights are the model; the
+*engine* around them is plumbing, and plumbing is what machin is for.
+
+The bet is narrow and honest: machin will not train models and will not chase the
+GPU datacenter path. It aims to be an excellent **host for already-quantized
+weights on CPU** — the `llama.cpp`-shaped niche — where a tiny, dependency-free,
+fast-cold-start binary is worth more than peak FLOPS.
+
+## Where it stands today (all shipping, all verified)
+
+The int8 quantized-matmul kernel is the `sha256` of this domain — the one hot
+primitive everything else composes around — and it now exists as a native
+builtin, built up in three dogfood-driven steps:
+
+| capability | builtin(s) | landed | what it proved |
+|---|---|---|---|
+| zero-copy weight load | `mmap_file` (+ map auto-grow) | [#436](https://github.com/javimosch/machin/pull/436) (2026-07-11) | mmap a checkpoint read-only → `(ptr, len)`; pages fault in lazily; ~700× faster large-file/tokenizer load vs `read_file_bytes` + copy |
+| raw int8 access | `peek_i8` / `peek_u8` | [#435](https://github.com/javimosch/machin/pull/435) (2026-07-11) | read a signed/unsigned byte at `ptr+offset` out of the mapped buffer, sign- or zero-extended |
+| the group kernel | `dot_i8` | [#435](https://github.com/javimosch/machin/pull/435) (2026-07-11) | signed-byte dot product of two raw buffers with a **32-bit accumulator** — the width the C autovectorizer turns into `vpmaddwd`/`vpdpbusd`, where an int64 reduction stays half-speed. Exact while `|sum| < 2^31` (always, for i8·i8 up to n ≈ 133k) |
+| the whole inner product | `dot_q8` | [#439](https://github.com/javimosch/machin/pull/439) (2026-07-12) | grouped, **dual-scaled** int8 dot: the entire Q8_0 quantized-matmul inner product in one vectorized call, one int32 reduction per group with the two per-group fp32 scales applied group-at-a-time |
+
+Supporting primitives already in the language carry the rest: `alloc`/`free`
+(raw C buffers, pointers as `int`), `poke_f32`/`poke_i32`/`poke_u8` (build the
+quantized buffers), `peek_f32`/`peek_i32` (read the scales), `f64_bits`/
+`f64_from_bits` (byte-level float (de)serialization), goroutines + channels (a
+worker pool over rows), and `arena { … }` (bound the per-token allocation).
+
+The how-to substrate for the surrounding engine is the backend/web skills; the
+kernel builtins are catalogued in `machin guide` (the `memory` group).
+
+### The Q8_0 layout, concretely
+
+`dot_q8(xq, xs, wq, ws, n, gs)` computes the dual-scaled grouped dot product used
+by Q8_0 weights (the format `llama.cpp` calls `Q8_0`):
+
+- `xq`, `wq` — two `int8` buffers of `n` bytes each (the quantized activation and
+  weight rows). Read with `peek_i8`; written with `poke_u8` today (see the gap
+  below).
+- `xs`, `ws` — two `fp32` buffers of `n/gs` floats each (the per-group scales).
+  Read/written with `peek_f32`/`poke_f32`.
+- `gs` — the group size (`n` must be a multiple of `gs`); Q8_0 uses 32.
+
+It returns, in one call (autovectorized, one int32 reduction per group):
+
+```
+sum over g in [0, n/gs) of:
+    ( sum over k in [0, gs) of xq[g*gs+k] * wq[g*gs+k] )   // int32 group dot
+  * xs[g] * ws[g]                                          // fp32 group scales
+```
+
+That is a full GEMV inner product. Wrapped in an MFL `for` over the weight rows
+(one `dot_q8` per output element), it is a quantized matrix–vector product — the
+per-token compute of a transformer's linear layers. `dot_q8` exists precisely
+because doing this as an MFL loop of `dot_i8` + two `peek_f32` per group made the
+per-group *call overhead* the bottleneck; folding the group loop into one builtin
+removed it.
+
+## The vision, in tiers (near → far)
+
+**Tier 1 — the quantized GEMV kernel (here).** mmap the weights, `dot_q8` the
+rows, stream the output. Everything needed for a single quantized linear layer
+ships today. This is the load-bearing tier and it is real.
+
+**Tier 2 — a whole transformer block (composition + a few kernels).** A block is
+GEMV (have it) plus a small set of elementwise/reduction ops: **RMSNorm**,
+**SiLU/GELU**, a **softmax** over the attention scores, **RoPE** position
+rotation, and an **argmax**/sampling step over the logits. Each is a tight loop
+over an fp32 buffer — expressible in MFL today over `peek_f32`/`poke_f32`, and a
+candidate to promote to a builtin *only where measurement says the call/loop
+overhead caps throughput* (the exact reason `dot_q8` was carved out). This tier is
+mostly plumbing over existing primitives.
+
+**Tier 3 — a running small model (aspirational).** End-to-end token generation
+for a small quantized model (a TinyLlama / Qwen-0.5B-class checkpoint), decode
+loop and KV cache included, at a usable tokens/sec on commodity CPU. The engine
+is `machin-colibri`; the language gaps it hits become this roadmap.
+
+**Tier 4 — the edge-inference niche (stretch, not a plan).** A dependency-free
+inference binary small and fast enough to embed anywhere machin already goes — a
+webhook that classifies, a CLI that summarizes, a game NPC that talks — reusing
+the same static-musl, FROM-scratch-image story as the rest of machin. Listed as a
+direction, not a commitment.
+
+## The feature roadmap (gaps, in rough dependency order)
+
+Each is a candidate to be *driven by the engine*, not built speculatively — the
+same method as every other machin domain.
+
+1. ~~**int8 group kernel**~~ — **done:** `dot_i8` ([#435](https://github.com/javimosch/machin/pull/435)),
+   then `dot_q8` ([#439](https://github.com/javimosch/machin/pull/439)) for the
+   dual-scaled grouped form.
+2. ~~**Zero-copy weight load**~~ — **done:** `mmap_file`
+   ([#436](https://github.com/javimosch/machin/pull/436)); pages fault in lazily,
+   so a multi-GB checkpoint costs no upfront copy and no resident bloat.
+3. **`poke_i8` — close the signed-byte asymmetry.** `peek_i8` reads a signed
+   byte, but there is **no `poke_i8`**: an MFL quantizer that produces the `int8`
+   weight/activation buffers must write them through `poke_u8` and rely on
+   two's-complement wrapping (`poke_u8(p, o, v & 0xff)`), which is correct but
+   asymmetric and easy to get subtly wrong. Adding `poke_i8` completes the pair
+   the way `peek_u8`/`poke_u8`, `peek_i32`/`poke_i32`, and `peek_f32`/`poke_f32`
+   already are, and makes the quantize→store side as clean as the load→dot side.
+   The smallest, most obviously-missing next step.
+4. **Elementwise / reduction kernels (measure first).** RMSNorm, SiLU/GELU,
+   softmax, RoPE, argmax. Start as MFL over `peek_f32`/`poke_f32`; promote the
+   ones that measurably cap throughput to builtins, exactly as `dot_q8` was.
+5. **More quantization formats.** Q4_0 / Q4_K-style 4-bit weights (a nibble-unpack
+   before the int8 dot) widen which off-the-shelf checkpoints load.
+6. **Parallel GEMV over the row range.** A goroutine worker pool already exists;
+   the open question ([#434](https://github.com/javimosch/machin/issues/434)) is
+   race-inference for globals set once at load and read by every worker — a
+   race-checker refinement, not a kernel.
+
+## Method
+
+Same loop as the rest of machin: build a real thing (the `machin-colibri`
+engine), hit the wall, fill it in the language, release, and record it. Be honest
+about **composition vs. new feature** — the Tier-2 elementwise ops are *mostly
+composition* over `peek_f32`/`poke_f32`, and a kernel is carved out only when a
+profile says the loop overhead, not the arithmetic, is the ceiling. `dot_q8` is
+the model: it earned its place by replacing a measurably slower MFL loop, not by
+speculation. The next op the engine genuinely *can't* express fast enough names
+the next builtin.
+
+To contribute: build something real on the inference primitives, put it in its own
+public repo with a `build.sh`, and add it to
+[awesome-machin](https://github.com/javimosch/awesome-machin).

--- a/examples/complex/inference_kernels.mfl
+++ b/examples/complex/inference_kernels.mfl
@@ -1,0 +1,25 @@
+func sigmoid(x){return 1.0/(1.0+exp(0.0-x))}
+
+func silu(x){return x*sigmoid(x)}
+
+func tanhf(x){e:=exp(2.0*x)return(e-1.0)/(e+1.0)}
+
+func gelu(x){c:=0.7978845608*(x+0.044715*x*x*x)return 0.5*x*(1.0+tanhf(c))}
+
+func getf(buf,i){return peek_f32(buf,i*4)}
+
+func setf(buf,i,v){poke_f32(buf,i*4,v)}
+
+func load(buf,vals){i:=0 while i<len(vals){setf(buf,i,vals[i])i=i+1}}
+
+func rmsnorm(x,w,out,n){ss:=0.0 i:=0 while i<n{v:=getf(x,i)ss=ss+v*v i=i+1}inv:=1.0/sqrt(ss/float(n)+0.00001)i=0 while i<n{setf(out,i,getf(x,i)*inv*getf(w,i))i=i+1}}
+
+func softmax(x,out,n){mx:=getf(x,0)i:=1 while i<n{v:=getf(x,i)if v>mx{mx=v}i=i+1}sum:=0.0 i=0 while i<n{e:=exp(getf(x,i)-mx)setf(out,i,e)sum=sum+e i=i+1}i=0 while i<n{setf(out,i,getf(out,i)/sum)i=i+1}}
+
+func argmax(x,n){best:=0 bv:=getf(x,0)i:=1 while i<n{v:=getf(x,i)if v>bv{bv=v best=i}i=i+1}return best}
+
+func mi(v){return int(round(v*1000.0))}
+
+func dump(name,buf,n){print(name)i:=0 while i<n{print(" ")print(str(mi(getf(buf,i))))i=i+1}println("")}
+
+func main(){println("silu",str(mi(silu(0.0-2.0))),str(mi(silu(0.0))),str(mi(silu(2.0))))println("gelu",str(mi(gelu(0.0-1.0))),str(mi(gelu(0.0))),str(mi(gelu(1.0))))n:=3 x:=alloc(n*4)w:=alloc(n*4)out:=alloc(n*4)load(x,[]float{1.0,2.0,3.0})load(w,[]float{1.0,1.0,1.0})rmsnorm(x,w,out,n)dump("rmsnorm",out,n)softmax(x,out,n)dump("softmax",out,n)println("argmax",str(argmax(x,n)))free(x)free(w)free(out)}

--- a/inference_kernels_example_test.go
+++ b/inference_kernels_example_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// examples/complex/inference_kernels.mfl is the Tier-2 half of the inference
+// north star (docs/NORTH-STAR-INFERENCE.md): the elementwise/reduction ops that
+// wrap the int8 GEMV kernel into a transformer block — RMSNorm, SiLU, GELU,
+// softmax, argmax — written in *pure MFL* over peek_f32/poke_f32 fp32 buffers,
+// no new builtin. This test builds the committed example end-to-end (parse ->
+// cc -> run) and pins its output, so the numeric contract of each kernel is
+// locked and the example is proven to still compile and run.
+//
+// The reference values (activations are printed as int(round(v*1000)), i.e. in
+// milli-units, to keep the pinned output free of float-formatting noise):
+//
+//	silu(x)    = x*sigmoid(x):    silu(-2)=-0.238, silu(0)=0, silu(2)=1.762
+//	gelu(x)    tanh approx:       gelu(-1)=-0.159, gelu(0)=0, gelu(1)=0.841
+//	rmsnorm([1,2,3], w=1):        ss=14/3=4.667, inv=1/sqrt(ss)=0.4629
+//	                              -> [0.463, 0.926, 1.389]
+//	softmax([1,2,3]):             [0.0900, 0.2447, 0.6652] (sums to 1.0)
+//	argmax([1,2,3])            = 2
+func TestInferenceKernelsExample(t *testing.T) {
+	src, err := os.ReadFile("examples/complex/inference_kernels.mfl")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	funcs, err := splitFunctions(string(src))
+	if err != nil {
+		t.Fatalf("split example into functions: %v", err)
+	}
+
+	out, _ := buildRun(t, funcs...)
+
+	want := strings.Join([]string{
+		"silu -238 0 1762",
+		"gelu -159 0 841",
+		"rmsnorm 463 926 1389",
+		"softmax 90 245 665",
+		"argmax 2",
+		"",
+	}, "\n")
+	if out != want {
+		t.Fatalf("inference_kernels.mfl output:\n got %q\nwant %q", out, want)
+	}
+}
+
+// TestInferenceKernelsSoftmaxIsNormalized independently pins the defining
+// property of softmax — the outputs form a probability distribution — rather
+// than only the rounded per-element values above. It runs the same softmax
+// kernel over a deliberately skewed logit vector (a large value that would
+// overflow exp() without the max-subtraction stabilization the kernel does) and
+// checks the milli-unit probabilities sum to 1000 and the argmax dominates.
+func TestInferenceKernelsSoftmaxIsNormalized(t *testing.T) {
+	// Reuse the library kernels verbatim from the example, with a fresh main
+	// that stresses numerical stability (logit 50 => exp(50) overflows f32; the
+	// kernel subtracts the row max first, so exp() sees <= 0 and stays finite).
+	src, err := os.ReadFile("examples/complex/inference_kernels.mfl")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	funcs, err := splitFunctions(string(src))
+	if err != nil {
+		t.Fatalf("split example into functions: %v", err)
+	}
+	// Drop the example's main(); supply our own driver over the same kernels.
+	var kernels []string
+	for _, f := range funcs {
+		if strings.HasPrefix(strings.TrimSpace(f), "func main(") {
+			continue
+		}
+		kernels = append(kernels, f)
+	}
+	driver := `func main(){n:=4 x:=alloc(n*4)out:=alloc(n*4)` +
+		`load(x,[]float{0.0-1.0,3.0,50.0,2.0})softmax(x,out,n)` +
+		`s:=0 i:=0 while i<n{s=s+mi(getf(out,i))i=i+1}` +
+		`println("sum",str(s))println("argmax",str(argmax(x,n)))` +
+		`println("p2",str(mi(getf(out,2))))free(x)free(out)}`
+	kernels = append(kernels, driver)
+
+	out, _ := buildRun(t, kernels...)
+
+	// exp(50-50)=1 dominates the row; the other three logits are >=47 below the
+	// max, so their probabilities round to 0 milli-units and index 2 gets ~1000.
+	want := "sum 1000\nargmax 2\np2 1000\n"
+	if out != want {
+		t.Fatalf("stabilized softmax output:\n got %q\nwant %q", out, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Pick a north-star domain; make one big move toward it each run.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #444 (am/am-7b5889-ti1rk5): test(math): cover atan/atan2 builtins incl. all four quadrants
    touches: atan_builtins_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go
- PR #442 (am/am-7b5889-ti1ltg): test(kernels): Q8_0 GEMV/GEMM integration — dot_q8 fused == manual inner loop
    touches: SPEC.md, kernel_q8_gemv_test.go, lexer.go, lexer_underscore_test.go
- PR #441 (am/am-7b5889-ti1jvh): test(kernels): pin int8/Q8_0 dot & peek numeric contracts
    touches: assign_undefined_test.go, kernel_q8_edge_test.go, types.go
- PR #440 (am/am-7b5889-ti1i0s): fix(racecheck): propagate happens-before through pre-spawn callees
    touches: check.go, classify_test.go, racecheck.go, racecheck_test.go
- PR #438 (am/am-7b5889-ti1g73): fix(codegen): short-circuit && / || instead of evaluating both operands
    touches: CHANGELOG.md, codegen.go, shortcircuit_test.go
- PR #425 (am/am-7b5889-thrhng): test(parser): cover parseFuncLit/parseStructLit error branches
    touches: buildwasm_test.go, check_test.go


**Branch:** `am/am-7b5889-ti1ti5`

> ℹ️ **Possible mislabel** — a `docs`-titled PR also edits source files: `inference_kernels_example_test.go`. Consider splitting so each PR is one concern with an accurate title.


**Diff:**
```
docs/NORTH-STAR-INFERENCE.md           | 150 +++++++++++++++++++++++++++++++++
 examples/complex/inference_kernels.mfl |  25 ++++++
 inference_kernels_example_test.go      |  92 ++++++++++++++++++++
 3 files changed, 267 insertions(+)
```
