### PR TITLE
[needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@
   verified byte-for-byte against the Go reference via `machin falsifytest`, so the
   machin-in-machin compiler both compiles *and* falsifies *and* proves, provably
   identically.
+- **Fixed a segfault when `parse()` filled a struct whose string fields were
+  absent from the JSON.** The generated JSON parser initialized the result with
+  `{0}`, so any string field not present in the payload stayed a NULL `char*`
+  instead of `""`. Touching such a field — `len()`, concatenation, printing —
+  dereferenced NULL and crashed (e.g. `strlen(NULL)`), which surfaced as an
+  exit-255/segfault when the unset field flowed through a helper back into a
+  range loop. The parser now seeds omitted string fields (recursively, through
+  nested structs) to `""` via the same `stringZeroInits` path the struct-literal
+  codegen already uses. See #449.
+
 - **Fixed `&&` / `||` not short-circuiting: the right operand was evaluated
   even when the left already decided the result.** When either operand had a
   side effect (a call or channel receive), codegen hoisted *both* operands

--- a/codegen.go
+++ b/codegen.go
@@ -5077,7 +5077,14 @@ func (g *cgen) jsonParser(typeStr string) (string, error) {
 			return "", fmt.Errorf("parse: cannot parse into type %q", typeStr)
 		}
 		var b strings.Builder
-		fmt.Fprintf(&b, "%s out = {0};\n", ct)
+		// Omitted string fields must default to "" not NULL — an absent JSON key
+		// leaves the field C-zeroed (NULL char*), which crashes len()/concat. Seed
+		// them (recursively) exactly like a struct literal does. See stringZeroInits.
+		if inits := g.stringZeroInits(typeStr); len(inits) > 0 {
+			fmt.Fprintf(&b, "%s out = {%s};\n", ct, strings.Join(inits, ", "))
+		} else {
+			fmt.Fprintf(&b, "%s out = {0};\n", ct)
+		}
 		b.WriteString(`    mfl_js_ws(p);
     if (**p == '{') {
         (*p)++; mfl_js_ws(p);

--- a/parse_null_string_field_test.go
+++ b/parse_null_string_field_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+// Regression for #449: parse() into a struct must default any JSON-absent string
+// field to "" (not a NULL char*). A NULL field crashes the moment it reaches
+// len()/concat — e.g. strlen(NULL) — which surfaced as a segfault when an unset
+// field flowed through a helper and back into a range loop. The struct-literal
+// path already seeds "" via stringZeroInits; the JSON parser must do the same.
+
+func TestParseUnsetStringFieldIsEmpty(t *testing.T) {
+	got := runProg(t,
+		`type T2 struct { a string  b string  c string }`,
+		`func getv(t, name) (v) { if name == "a" { v = t.a } if name == "b" { v = t.b } if name == "c" { v = t.c } }`,
+		`func main() {
+			t := parse("{\"b\":\"hello\"}", T2{})
+			for _, name := range []string{"a", "b", "c"} {
+				v := getv(t, name)
+				println("tok " + name + "='" + v + "'")
+				if len(v) == 0 { continue }
+				println("use " + name)
+			}
+			println("done")
+		}`)
+	want := "tok a=''\ntok b='hello'\nuse b\ntok c=''\ndone\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+// The same "" default must hold recursively for nested struct fields left unset
+// by the JSON payload — accessing inner.x on an absent inner must not deref NULL.
+func TestParseUnsetNestedStructStringFieldIsEmpty(t *testing.T) {
+	got := runProg(t,
+		`type Inner struct { x string  y string }`,
+		`type Outer struct { name string  in Inner  n int }`,
+		`func main() {
+			o := parse("{\"n\":5}", Outer{})
+			println("name.len=" + str(len(o.name)))
+			println("in.x.len=" + str(len(o.in.x)))
+			println("n=" + str(o.n))
+		}`)
+	want := "name.len=0\nin.x.len=0\nn=5\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}

--- a/parse_unset_field_paths_test.go
+++ b/parse_unset_field_paths_test.go
@@ -1,0 +1,65 @@
+package main
+
+import "testing"
+
+// Companion regression coverage for #449. The core fix (parse() seeds absent
+// struct string fields with "" instead of a NULL char*, recursively) lives in
+// codegen's jsonParser via stringZeroInits, and parse_null_string_field_test.go
+// pins the original repro plus one level of nesting. These cases lock in the
+// OTHER codegen paths the same NULL char* could have slipped through: struct
+// elements produced by the slice parser, recursion deeper than one level, and
+// an absent field consumed as a map key. Each would have dereferenced NULL
+// (strlen / hash) the moment the unset field met a string builtin.
+
+// Slice parser path: each element struct is produced by the element parser, so
+// its absent string fields must be "" too — not just top-level parse-into-struct.
+func TestParseSliceElementUnsetStringFieldIsEmpty(t *testing.T) {
+	got := runProg(t,
+		`type E struct { a string  b string }`,
+		`func main() {
+			xs := parse("[{\"a\":\"one\"},{\"b\":\"two\"}]", []E{})
+			for _, e := range xs { println("a='" + e.a + "' b='" + e.b + "'") }
+			println("ok")
+		}`)
+	want := "a='one' b=''\na='' b='two'\nok\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+// Recursion must hold beyond a single nesting level: a 3-deep chain where every
+// intermediate struct is absent from the payload must leave the innermost string
+// as "" rather than reaching a NULL through two zeroed parents.
+func TestParseDeeplyNestedUnsetStringFieldIsEmpty(t *testing.T) {
+	got := runProg(t,
+		`type A struct { x string }`,
+		`type B struct { a A  y string }`,
+		`type C struct { b B  z string }`,
+		`func main() {
+			c := parse("{\"z\":\"zz\"}", C{})
+			println("x.len=" + str(len(c.b.a.x)))
+			println("y.len=" + str(len(c.b.y)))
+			println("z=" + c.z)
+		}`)
+	want := "x.len=0\ny.len=0\nz=zz\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+// An absent field used as a map key must hash an empty string, not deref NULL.
+func TestParseUnsetStringFieldUsableAsMapKey(t *testing.T) {
+	got := runProg(t,
+		`type K struct { key string }`,
+		`func main() {
+			k := parse("{}", K{})
+			m := make(map[string]int)
+			m[k.key] = 7
+			println("v=" + str(m[k.key]))
+			println("keylen=" + str(len(k.key)))
+		}`)
+	want := "v=7\nkeylen=0\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}

--- a/selfhost/cgagg.src
+++ b/selfhost/cgagg.src
@@ -193,7 +193,11 @@ func json_parser(t) (name) {
     if body == "" {
         di := struct_def_idx(t)
         d := g_structdefs[di]
+        // Omitted string fields must default to "" not NULL (a NULL char* crashes
+        // len()/concat) — seed them recursively, like the struct-literal codegen. #449.
         b := ct + " out = {0};\n"
+        szi := string_zero_inits(t)
+        if len(szi) > 0 { b = ct + " out = {" + join(szi, ", ") + "};\n" }
         b = b + "    mfl_js_ws(p);\n    if (**p == '{') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != '}') {\n            while (1) {\n                char* _k = mfl_js_str(p); mfl_js_ws(p); if (**p == ':') (*p)++;\n"
         j := 0
         for j < len(d.fnames) {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go


**Branch:** `am/am-7b5889-ti3t65`

> ⚠️ **Verification failed** — this PR is a draft. Last output:
```
tokens/iter: 10
iters=3 total_tokens=30 elapsed_ms=0
sexpr: unhandled *main.MakeClosure
sexpr: unhandled stmt <nil>
(int 1)
(func main (params) (returns) (body (assign := x (int 1))))
(func main (params) (returns) (body (assign := x (int 1))))
(func main (params) (returns) (body (assign := x (int 1))))
(parse-error)
(parse-error)
machin: installed 5 skill(s) -> /tmp/TestSkillInstallWritesAllSkillsToExplicitDir533829185/001
machin: installed 1 skill(s) -> /tmp/TestSkillInstallSingleNamedSkill3299792569/001
machin: --static + TLS/crypto: linking a static OpenSSL (needs libssl-dev's static archives — .a files — on the build host; a plain `apt install libssl-dev` provides them, no musl needed for this part, unlike --static SQLite). Bundling a CA root store so the binary verifies certificates with no external files (FROM scratch).
2026/07/13 08:15:52 http: TLS handshake error from 127.0.0.1:39132: local error: tls: bad record MAC
TEST_SUMMARY passed=1 failed=0
TEST_SUMMARY passed=1 failed=0
0 root=0 kind=int
1 root=1 kind=func fsig=|0
err=0
0 root=0 kind=var
1 root=1 kind=num
2 root=2 kind=int
3 root=3 kind=float
4 root=4 kind=bool
5 root=5 kind=string
6 root=6 kind=void
7 root=7 kind=bytes
8 root=8 kind=slice elem=2
9 root=9 kind=chan elem=2
10 root=10 kind=struct sname=Bar
11 root=11 kind=map mkey=0 mval=1
12 root=12 kind=func fsig=0,1|2
err=1
0 root=0 kind=int
1 root=1 kind=string
err=1
err=0
FAIL
FAIL	machin	84.356s
FAIL
[verify environment problem — the command can't run in the worktree; not auto-fixable]
```

**Diff:**
```
CHANGELOG.md                    | 10 +++++++
 codegen.go                      |  9 +++++-
 parse_null_string_field_test.go | 47 +++++++++++++++++++++++++++++
 parse_unset_field_paths_test.go | 65 +++++++++++++++++++++++++++++++++++++++++
 4 files changed, 130 insertions(+), 1 deletion(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when parsed JSON omits string fields in structs.
  * Omitted string fields now safely default to empty strings, including within nested structs, arrays, and map keys.
  * String operations such as length checks, concatenation, and hashing now work safely on absent fields.

* **Tests**
  * Added regression coverage for top-level, nested, array, and deeply nested struct fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->