### PR TITLE
test(encode): pin brace-counting through strings with braces + escaped quotes

### DIFF
--- a/encode_brace_string_test.go
+++ b/encode_brace_string_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression coverage for #451: a string literal that contains BOTH brace
+// characters ("{"/"}") AND escaped double-quotes ('\"') must not be miscounted
+// as unbalanced braces when the loose-source splitter walks a line. The two
+// splitters (splitFunctions, used by `machin encode`, and splitFunctionsLoc,
+// used by `machin check`) are string- and comment-aware: braces that appear
+// inside a string literal are ignored, and a backslash escapes the following
+// byte so that '\"' does NOT close the string. These tests pin that contract
+// so a future edit to the brace walker cannot silently reintroduce the bug.
+
+// the exact three-function program from the #451 report.
+const issue451Src = `func a() (h) { h = "x {id} y" }
+func b() (h) { h = "x {\"id\":1} y" }
+func main() { println(a() + b()) }`
+
+func TestSplitFunctionsBraceInEscapedString(t *testing.T) {
+	blocks, err := splitFunctions(issue451Src)
+	if err != nil {
+		t.Fatalf("splitFunctions returned error on braces+escaped-quotes: %v", err)
+	}
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 function blocks, got %d: %#v", len(blocks), blocks)
+	}
+	// The escaped-quote body must survive intact in its own block, not bleed
+	// into a neighbour because the string was thought to still be open.
+	if !strings.Contains(blocks[1], `"x {\"id\":1} y"`) {
+		t.Errorf("block[1] lost its escaped-quote string body: %q", blocks[1])
+	}
+	if !strings.HasPrefix(strings.TrimSpace(blocks[2]), "func main()") {
+		t.Errorf("block[2] should be func main, got %q", blocks[2])
+	}
+}
+
+func TestSplitFunctionsLocBraceInEscapedString(t *testing.T) {
+	blocks, lines, err := splitFunctionsLoc(issue451Src)
+	if err != nil {
+		t.Fatalf("splitFunctionsLoc returned error on braces+escaped-quotes: %v", err)
+	}
+	if len(blocks) != 3 || len(lines) != 3 {
+		t.Fatalf("expected 3 blocks/lines, got %d/%d", len(blocks), len(lines))
+	}
+	// Each function starts on its own consecutive source line; a miscount would
+	// glue blocks together and skew these.
+	want := []int{1, 2, 3}
+	for i, w := range want {
+		if lines[i] != w {
+			t.Errorf("block %d: start line = %d, want %d", i, lines[i], w)
+		}
+	}
+}
+
+// A grab-bag of adversarial single-function bodies mixing braces, escaped
+// quotes, and escaped backslashes. Every one is brace-balanced at the block
+// level and must split into exactly one function.
+func TestSplitFunctionsBraceStringAdversarial(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"json-object", `func f() (h) { h = "{\"a\":1}" }`},
+		{"leading-brace-run", `func f() (h) { h = "}}}{{{ \" }}}" }`},
+		{"escaped-backslash-then-brace", `func f() (h) { h = "a\\b{c}" }`},
+		{"lone-escaped-quote", `func f() (h) { h = "\"" }`},
+		{"concat-brace-quote", `func f() (h) { h = "{" + "\"" + "}" }`},
+		{"nested-block-with-json", `func f() (h) { if h == "" { h = "{x}" } }`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks, err := splitFunctions(tc.body)
+			if err != nil {
+				t.Fatalf("splitFunctions(%q) errored: %v", tc.body, err)
+			}
+			if len(blocks) != 1 {
+				t.Fatalf("splitFunctions(%q) = %d blocks, want 1: %#v", tc.body, len(blocks), blocks)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #450 (am/am-7b5889-ti3t65): [needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL
    touches: CHANGELOG.md, codegen.go, parse_null_string_field_test.go, parse_unset_field_paths_test.go
- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go


**Branch:** `am/am-7b5889-ti3v45`

**Diff:**
```
encode_brace_string_test.go | 84 +++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 84 insertions(+)
```
