### PR TITLE
test(kernels): pin dot_q4 split-nibble fidelity + dot_f32/axpy_f32 edge contracts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -90,8 +90,11 @@ The decoded text of a declaration is tokenized as follows.
   (`0o17`); underscores allowed as digit-group separators in any base
   (`1_000_000`, `0xff_00`). Underscores may only sit between digits — a leading,
   trailing, or doubled `_` is a parse error.
-- **Float literals.** digits with a `.`, e.g. `3.14`, `0.5`; underscores are
-  likewise allowed as separators between digits (`3_000.5`).
+- **Float literals.** digits with a `.`, e.g. `3.14`, `0.5`, or with a decimal
+  exponent (`e`/`E`, optionally signed), e.g. `1e3`, `1.5e-9`, `6.022e23` — a
+  literal carrying an exponent is a float even without a `.` (`1e3`). Underscores
+  are likewise allowed as separators between digits in either the mantissa or the
+  exponent (`3_000.5`, `1_000e1_0`).
 - **String literals.** `"..."` with escapes `\n \t \r \" \\`. No `\uXXXX`
   escape form — embed non-ASCII as raw UTF-8 bytes in the source file instead
   (a tool generating `.src`/`.mfl` text should emit real UTF-8, not escape it —

--- a/kernel_q4_float_edge_test.go
+++ b/kernel_q4_float_edge_test.go
@@ -1,0 +1,102 @@
+package main
+
+import "testing"
+
+// These tests pin the documented numeric contracts of the int4 / float LLM-inference
+// kernels (dot_q4, dot_f32, axpy_f32). The happy-path lines in mfl_test.go show each
+// works once; dot_q8/dot_i8 already have dedicated edge tests (kernel_q8_edge_test.go)
+// but the q4 and float kernels did not. These guard the guarantees those kernels are
+// relied on for in a real decode loop:
+//   - dot_q4 (split-nibble int4 weights) is numerically identical to dot_q8 fed the
+//     same logical weights as full int8 — the halved-bytes packing must not change the
+//     answer, and the exact nibble layout (byte k = w[k] low | w[k+gs/2] high, +8 bias)
+//     must be honored,
+//   - dot_f32 uses an fp32 accumulator and returns 0 for an empty count,
+//   - axpy_f32 *accumulates* into y (y += s*x), respects the n bound, and is a no-op at
+//     n=0.
+
+// dot_q4 exists to halve the weight bytes moved in a memory-bound decode by packing two
+// int4 weights per byte (see the dot_q4 guide entry). That packing is only safe if it
+// returns the *same* value as the equivalent int8 (dot_q8) inner product. Here the same
+// logical weights are fed to both kernels in one program — as split-nibble bytes to
+// dot_q4 and as plain int8 to dot_q8 — and the outputs must be byte-identical.
+//
+// The weights are hand-packed to pin the exact layout dot_q4 decodes. With gs=4 (half=2)
+// a group's two bytes hold, each value stored as value+8 in 0..15:
+//
+//	byte0 = (w0+8) | (w2+8)<<4 ,  byte1 = (w1+8) | (w3+8)<<4
+//	group0 w=[3,-2,1,0]  -> byte0 = 11 | 9<<4  = 155 , byte1 = 6  | 8<<4  = 134
+//	group1 w=[7,-8,-1,2] -> byte2 = 15 | 7<<4  = 127 , byte3 = 0  | 10<<4 = 160
+//
+// Activations xq (int8): group0 [1,2,3,4], group1 [-5,6,-7,8]. Scales are powers of two
+// so every product is exact and the whole-number result ("-58") leaves no room for a
+// formatting mismatch to hide a real divergence:
+//
+//	group0 int32 dot = 1*3+2*-2+3*1+4*0 = 2 ; xs=0.5 ws=2.0 -> 2*1.0  = 2
+//	group1 int32 dot = -5*7+6*-8+-7*-1+8*2 = -60 ; xs=0.25 ws=4.0 -> -60*1.0 = -60
+//	total = -58
+func TestDotQ4MatchesDotQ8(t *testing.T) {
+	// pi8 writes a signed byte (-128..127) into an unsigned-byte cell.
+	pi8 := `func pi8(p, i, v) { if v < 0 { v = v + 256 } poke_u8(p, i, v) }`
+	main := `func main() {
+		xq := alloc(8)
+		xs := alloc(8)  ws := alloc(8)
+		wq4 := alloc(4)  wq8 := alloc(8)
+		pi8(xq, 0, 1)  pi8(xq, 1, 2)   pi8(xq, 2, 3)   pi8(xq, 3, 4)
+		pi8(xq, 4, -5) pi8(xq, 5, 6)   pi8(xq, 6, -7)  pi8(xq, 7, 8)
+		poke_u8(wq4, 0, 155)  poke_u8(wq4, 1, 134)
+		poke_u8(wq4, 2, 127)  poke_u8(wq4, 3, 160)
+		pi8(wq8, 0, 3)  pi8(wq8, 1, -2)  pi8(wq8, 2, 1)   pi8(wq8, 3, 0)
+		pi8(wq8, 4, 7)  pi8(wq8, 5, -8)  pi8(wq8, 6, -1)  pi8(wq8, 7, 2)
+		poke_f32(xs, 0, 0.5)  poke_f32(xs, 4, 0.25)
+		poke_f32(ws, 0, 2.0)  poke_f32(ws, 4, 4.0)
+		q4 := dot_q4(xq, xs, wq4, ws, 8, 4)
+		q8 := dot_q8(xq, xs, wq8, ws, 8, 4)
+		println(str(q4) + " " + str(q8))
+		free(xq) free(xs) free(ws) free(wq4) free(wq8)
+	}`
+	out, _ := buildRun(t, main, pi8)
+	if out != "-58 -58\n" {
+		t.Fatalf("dot_q4 vs dot_q8: got %q, want %q", out, "-58 -58\n")
+	}
+}
+
+// dot_f32 is the vectorized fp32 inner product (attention q.k). Its contract is an fp32
+// accumulator over a[k]*b[k] for k<n, and 0 for an empty count (an attention head can be
+// asked for a zero-length span). Values are chosen so the products and their sum are
+// exactly representable — 1.5*2 + -2*3 + 4*-0.5 = 3 - 6 - 2 = -5 — so a whole-number
+// result pins the value with no float-formatting slack. The n=0 call must return 0.
+func TestDotF32AccumulatesAndEmpty(t *testing.T) {
+	main := `func main() {
+		a := alloc(12)  b := alloc(12)
+		poke_f32(a, 0, 1.5)  poke_f32(a, 4, -2.0)  poke_f32(a, 8, 4.0)
+		poke_f32(b, 0, 2.0)  poke_f32(b, 4, 3.0)   poke_f32(b, 8, -0.5)
+		println(str(dot_f32(a, b, 3)) + " " + str(dot_f32(a, b, 0)))
+		free(a) free(b)
+	}`
+	out, _ := buildRun(t, main)
+	if out != "-5 0\n" {
+		t.Fatalf("dot_f32 accumulate/empty: got %q, want %q", out, "-5 0\n")
+	}
+}
+
+// axpy_f32 is the attention value accumulation: y[k] += s*x[k] for k<n. Three things
+// must hold and are each exercised here: it *accumulates* into the existing y (not
+// overwrite), it stops at n (y[3] is left untouched), and n=0 is a no-op. Starting from
+// y=[10,20,30,40], s=-2, x=[1,2,3,4], n=3 gives y=[8,16,24,40]; a following n=0 call with
+// a different scale must change nothing.
+func TestAxpyF32AccumulatesAndBounds(t *testing.T) {
+	main := `func main() {
+		y := alloc(16)  x := alloc(16)
+		poke_f32(y, 0, 10.0)  poke_f32(y, 4, 20.0)  poke_f32(y, 8, 30.0)  poke_f32(y, 12, 40.0)
+		poke_f32(x, 0, 1.0)   poke_f32(x, 4, 2.0)   poke_f32(x, 8, 3.0)   poke_f32(x, 12, 4.0)
+		axpy_f32(y, -2.0, x, 3)
+		axpy_f32(y, 9.0, x, 0)
+		println(str(peek_f32(y, 0)) + " " + str(peek_f32(y, 4)) + " " + str(peek_f32(y, 8)) + " " + str(peek_f32(y, 12)))
+		free(y) free(x)
+	}`
+	out, _ := buildRun(t, main)
+	if out != "8 16 24 40\n" {
+		t.Fatalf("axpy_f32 accumulate/bounds: got %q, want %q", out, "8 16 24 40\n")
+	}
+}

--- a/lexer.go
+++ b/lexer.go
@@ -97,6 +97,23 @@ func (l *Lexer) lexNumber() {
 		}
 		l.pos++
 	}
+	// optional exponent: e/E, an optional sign, then one or more digits (scientific
+	// notation, e.g. 1e3, 1.5e-9, 2E+10). The mantissa may be integer-only (1e3 is a
+	// float). Only consume the 'e' when a valid exponent follows, so a trailing 'e'
+	// (e.g. `1e` or a number abutting an identifier) is left for the next token.
+	if l.pos < len(l.src) && (l.src[l.pos] == 'e' || l.src[l.pos] == 'E') {
+		j := l.pos + 1
+		if j < len(l.src) && (l.src[j] == '+' || l.src[j] == '-') {
+			j++
+		}
+		if j < len(l.src) && isDigit(l.src[j]) {
+			isFloat = true
+			l.pos = j
+			for l.pos < len(l.src) && (isDigit(l.src[l.pos]) || l.src[l.pos] == '_') {
+				l.pos++
+			}
+		}
+	}
 	kind := TInt
 	if isFloat {
 		kind = TFloat

--- a/lexer_scinum_test.go
+++ b/lexer_scinum_test.go
@@ -1,0 +1,132 @@
+package main
+
+import "testing"
+
+// The decimal number scanner accepts an optional exponent (scientific notation):
+// e/E, an optional +/- sign, then one or more digits. The mantissa may be
+// integer-only, so `1e3` is a float. Before this the scanner stopped at 'e', so
+// `1.5e3` mis-lexed as [1.5, e3] and any exponent literal was a parse error.
+
+func TestLexScientificNotationSingleFloatToken(t *testing.T) {
+	cases := []string{
+		"1e3",
+		"1E3",
+		"1e+3",
+		"1e-3",
+		"1.5e3",
+		"1.5E3",
+		"2.5e-3",
+		"2.5e+3",
+		"6.022e23",
+		"1_000e1_0", // underscores are separators in both mantissa and exponent
+	}
+	for _, src := range cases {
+		toks, err := Lex(src)
+		if err != nil {
+			t.Errorf("Lex(%q) error: %v", src, err)
+			continue
+		}
+		// Expect exactly one real token plus TEOF.
+		if len(toks) != 2 || toks[1].Kind != TEOF {
+			t.Errorf("Lex(%q) = %d tokens (%+v), want 1 literal + EOF", src, len(toks), toks)
+			continue
+		}
+		if toks[0].Kind != TFloat {
+			t.Errorf("Lex(%q) kind = %v, want TFloat", src, toks[0].Kind)
+		}
+		if toks[0].Val != src {
+			t.Errorf("Lex(%q) val = %q, want the raw literal preserved", src, toks[0].Val)
+		}
+	}
+}
+
+// The lexed exponent literal parses to the numerically correct float64.
+func TestParseScientificNotationValues(t *testing.T) {
+	floats := map[string]float64{
+		"1e3":      1000,
+		"1e-3":     0.001,
+		"1.5e3":    1500,
+		"1.5E3":    1500,
+		"2.5e-3":   0.0025,
+		"2.5e+3":   2500,
+		"6.022e23": 6.022e23,
+		"1_000e10": 1e13,
+	}
+	for src, want := range floats {
+		toks, err := Lex(src)
+		if err != nil {
+			t.Fatalf("Lex(%q) error: %v", src, err)
+		}
+		p := &Parser{toks: toks}
+		x, err := p.parsePrimary()
+		if err != nil {
+			t.Errorf("parse(%q) error: %v", src, err)
+			continue
+		}
+		lit, ok := x.(*FloatLit)
+		if !ok {
+			t.Errorf("parse(%q) = %T, want *FloatLit", src, x)
+			continue
+		}
+		if lit.Val != want {
+			t.Errorf("parse(%q) = %g, want %g", src, lit.Val, want)
+		}
+	}
+}
+
+// The 'e' must only be consumed when a valid exponent (optionally signed digits)
+// follows. A bare trailing 'e', or a hex literal whose digits include 'e', must
+// NOT be swallowed into a spurious exponent.
+func TestLexExponentBoundaries(t *testing.T) {
+	// `1e` with no exponent digits: 'e' stays a separate identifier token.
+	toks, err := Lex("1e")
+	if err != nil {
+		t.Fatalf("Lex(%q) error: %v", "1e", err)
+	}
+	want := []Token{
+		{Kind: TInt, Val: "1"},
+		{Kind: TIdent, Val: "e"},
+		{Kind: TEOF, Val: ""},
+	}
+	if len(toks) != len(want) {
+		t.Fatalf("Lex(%q) = %d tokens (%+v), want %d", "1e", len(toks), toks, len(want))
+	}
+	for i, w := range want {
+		if toks[i].Kind != w.Kind || toks[i].Val != w.Val {
+			t.Errorf("token %d = %+v, want Kind=%v Val=%q", i, toks[i], w.Kind, w.Val)
+		}
+	}
+
+	// Hex literals reach a distinct scanner branch: 0x1e3 is an integer, not a
+	// float with an exponent.
+	toks, err = Lex("0x1e3")
+	if err != nil {
+		t.Fatalf("Lex(%q) error: %v", "0x1e3", err)
+	}
+	if len(toks) != 2 || toks[0].Kind != TInt || toks[0].Val != "0x1e3" {
+		t.Errorf("Lex(%q) = %+v, want a single TInt 0x1e3", "0x1e3", toks)
+	}
+}
+
+// An exponent literal followed by an operator/identifier must still tokenize the
+// trailing tokens distinctly — the scanner stops at the end of the digits.
+func TestScientificLiteralDoesNotSwallowFollowing(t *testing.T) {
+	toks, err := Lex("1.5e3 + x")
+	if err != nil {
+		t.Fatalf("Lex error: %v", err)
+	}
+	want := []Token{
+		{Kind: TFloat, Val: "1.5e3"},
+		{Kind: TOp, Val: "+"},
+		{Kind: TIdent, Val: "x"},
+		{Kind: TEOF, Val: ""},
+	}
+	if len(toks) != len(want) {
+		t.Fatalf("got %d tokens (%+v), want %d", len(toks), toks, len(want))
+	}
+	for i, w := range want {
+		if toks[i].Kind != w.Kind || toks[i].Val != w.Val {
+			t.Errorf("token %d = %+v, want Kind=%v Val=%q", i, toks[i], w.Kind, w.Val)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #452 (am/am-7b5889-ti3v45): test(encode): pin brace-counting through strings with braces + escaped quotes
    touches: encode_brace_string_test.go
- PR #450 (am/am-7b5889-ti3t65): [needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL
    touches: CHANGELOG.md, codegen.go, parse_null_string_field_test.go, parse_unset_field_paths_test.go
- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go


**Branch:** `am/am-7b5889-ti3wyu`

**Diff:**
```
SPEC.md                      |   7 ++-
 kernel_q4_float_edge_test.go | 102 +++++++++++++++++++++++++++++++++
 lexer.go                     |  17 ++++++
 lexer_scinum_test.go         | 132 +++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 256 insertions(+), 2 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scientific-notation floating-point literals, including optional signs and underscore separators.
  * Updated numeric literal specifications to document exponent-based formats.

* **Bug Fixes**
  * Improved tokenization boundaries so incomplete exponents and hexadecimal literals are handled correctly.

* **Tests**
  * Added coverage for scientific-notation parsing and numeric edge cases.
  * Added kernel operation checks for dot products, accumulation, empty inputs, and bounds behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->