### PR TITLE
test(parser): pin parseFuncLit closure-literal parse-error branches

### DIFF
--- a/math_sign_contracts_test.go
+++ b/math_sign_contracts_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The existing math-builtin tests (mathstr2/mathstr3) only exercise the
+// positive, happy-path branch of each function: cbrt(27), fmod(7,3),
+// pow(2,10), hypot(3,4), etc. The subtle, regression-prone behavior of these
+// libm-backed builtins is how they treat *signs* and non-integer exponents —
+// exactly the cases a wrong-libm-call or a naive reimplementation gets wrong:
+//
+//   - cbrt is defined for negatives (unlike sqrt): cbrt(-27) == -3.
+//   - pow with a negative base + odd integer exponent stays negative; a
+//     negative exponent is a reciprocal; a 0.5 exponent is a square root; any
+//     base to the 0 power is 1.
+//   - fmod follows the *dividend's* sign (C99 semantics), not the divisor's —
+//     a Go `%`-style or abs-based implementation would flip fmod(-7,3).
+//   - trunc rounds toward zero while floor rounds toward -inf: for a negative
+//     operand they differ by one (trunc(-3.9)==-3 vs floor(-3.9)==-4), which
+//     pins that trunc is not secretly implemented via floor.
+//   - hypot is sign-independent (a magnitude): hypot(-3,4) == 5.
+//
+// None of these signed/edge contracts are covered elsewhere, so a regression
+// in any one of them would otherwise slip through silently.
+func TestMathSignAndExponentContracts(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    // cbrt of a negative — well-defined, unlike sqrt.
+    println("cbrt_neg=" + str(cbrt(-27.0)))
+
+    // pow: negative base with odd exponent, negative exponent (reciprocal),
+    // fractional exponent (square root), and the x^0 == 1 identity.
+    println("pow_negbase_odd=" + str(pow(-2.0, 3.0)))
+    println("pow_negexp=" + str(pow(2.0, -1.0)))
+    println("pow_half=" + str(pow(9.0, 0.5)))
+    println("pow_zero=" + str(pow(5.0, 0.0)))
+
+    // fmod result takes the sign of the dividend (the first argument).
+    println("fmod_negdividend=" + str(fmod(-7.0, 3.0)))
+    println("fmod_negdivisor=" + str(fmod(7.0, -3.0)))
+
+    // trunc rounds toward zero; floor rounds toward -inf — they disagree on
+    // negatives, which proves trunc is not floor in disguise.
+    println("trunc_neg=" + str(trunc(-3.9)))
+    println("floor_neg=" + str(floor(-3.9)))
+    println("ceil_neg=" + str(ceil(-3.1)))
+
+    // hypot is a magnitude: independent of argument signs.
+    println("hypot_neg=" + str(hypot(-3.0, 4.0)))
+
+    // exp and log are inverses: log(exp(1)) round-trips back to 1.
+    println("explog_roundtrip=" + str(log(exp(1.0))))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"cbrt_neg=-3",
+		"pow_negbase_odd=-8",
+		"pow_negexp=0.5",
+		"pow_half=3",
+		"pow_zero=1",
+		"fmod_negdividend=-1",
+		"fmod_negdivisor=1",
+		"trunc_neg=-3",
+		"floor_neg=-4",
+		"ceil_neg=-3",
+		"hypot_neg=5",
+		"explog_roundtrip=1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/parse_funclit_error_test.go
+++ b/parse_funclit_error_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// parseFuncLit parses anonymous closures `func(a, b) { ... }` in expression
+// position (parser.go). Its happy path is exercised elsewhere; these tests pin
+// the four parse-error branches so a regression that swallows one of them (or
+// changes its message shape) is caught.
+
+// TestFuncLitValidForms confirms the well-formed closure shapes still parse so
+// the error-path tests below are pinning rejection, not a broken happy path.
+func TestFuncLitValidForms(t *testing.T) {
+	valid := []string{
+		`func main() { f := func(a, b) { return } print(f) }`,
+		`func main() { f := func() { } print(f) }`,
+		`func main() { f := func(a) { println(a) } print(f) }`,
+	}
+	for _, src := range valid {
+		if _, err := ParseProgram([]string{src}); err != nil {
+			t.Errorf("expected %q to parse, got error: %v", src, err)
+		}
+	}
+}
+
+// TestFuncLitMissingOpenParen pins the branch where `func` is not followed by
+// the mandatory parameter-list open paren.
+func TestFuncLitMissingOpenParen(t *testing.T) {
+	_, err := ParseProgram([]string{`func main() { f := func { } }`})
+	if err == nil {
+		t.Fatal("expected error for closure missing '(' after func")
+	}
+	if !strings.Contains(err.Error(), `expected "("`) {
+		t.Errorf("expected missing-'(' message, got: %v", err)
+	}
+}
+
+// TestFuncLitBadParamToken pins the branch where a parameter position holds a
+// non-identifier token (here a numeric literal).
+func TestFuncLitBadParamToken(t *testing.T) {
+	_, err := ParseProgram([]string{`func main() { f := func(1) { } }`})
+	if err == nil {
+		t.Fatal("expected error for non-identifier parameter")
+	}
+	// expect(TIdent, "") reports the offending token value with an empty
+	// expected string.
+	if !strings.Contains(err.Error(), `got "1"`) {
+		t.Errorf("expected bad-param-token message naming '1', got: %v", err)
+	}
+}
+
+// TestFuncLitMissingCloseParen pins the branch where the parameter list runs
+// into the body without a closing paren (the comma/break loop exits, then the
+// close-paren expect fails).
+func TestFuncLitMissingCloseParen(t *testing.T) {
+	_, err := ParseProgram([]string{`func main() { f := func(a { } }`})
+	if err == nil {
+		t.Fatal("expected error for closure missing ')' after params")
+	}
+	if !strings.Contains(err.Error(), `expected ")"`) {
+		t.Errorf("expected missing-')' message, got: %v", err)
+	}
+}
+
+// TestFuncLitMissingBlock pins the branch where the closure has a valid
+// parameter list but no `{ ... }` body block.
+func TestFuncLitMissingBlock(t *testing.T) {
+	_, err := ParseProgram([]string{`func main() { f := func(a) }`})
+	if err == nil {
+		t.Fatal("expected error for closure missing body block")
+	}
+	if !strings.Contains(err.Error(), `expected "{"`) {
+		t.Errorf("expected missing-block message, got: %v", err)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #455 (am/am-7b5889-ti408k): test(builtins): pin cos/tan numeric contracts + even/odd symmetry
    touches: loop_control_flow_test.go, trig_cos_tan_test.go
- PR #454 (am/am-7b5889-ti3y9i): test(builtins): pin trim() whitespace-class + empty/one-sided edges
    touches: main.go, tighten_test.go, trim_edge_test.go
- PR #452 (am/am-7b5889-ti3v45): test(encode): pin brace-counting through strings with braces + escaped quotes
    touches: encode_brace_string_test.go
- PR #450 (am/am-7b5889-ti3t65): [needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL
    touches: CHANGELOG.md, codegen.go, parse_null_string_field_test.go, parse_unset_field_paths_test.go
- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go


**Branch:** `am/am-7b5889-ti424g`

**Diff:**
```
math_sign_contracts_test.go | 78 +++++++++++++++++++++++++++++++++++++++++++++
 parse_funclit_error_test.go | 77 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 155 insertions(+)
```
