### PR TITLE
test(parse): pin parse() numeric/bool struct-field defaults + str() formatting

### DIFF
--- a/exp_log_contracts_test.go
+++ b/exp_log_contracts_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The exp/log family (exp, log, log2, log10) is the numeric backbone of LLM
+// inference: softmax is a sum of exp(), cross-entropy loss is -log(p), and
+// entropy/perplexity are measured in log2. The existing mathstr suites only
+// smoke each with a single call, so a broken codegen case (wrong libm symbol,
+// swapped base, argument mangling) on the composite identities would slip
+// through. Pin the exact contracts that inference code relies on.
+func TestExpLogNumericContracts(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    // Anchors.
+    println("exp0=" + str(exp(0.0)))
+    println("exp1=" + str(exp(1.0)))
+    println("exp2=" + str(exp(2.0)))
+    println("expneg1=" + str(exp(-1.0)))
+    println("log1=" + str(log(1.0)))
+    println("loge=" + str(log(exp(1.0))))
+
+    // log2 / log10 are exact on powers of their base.
+    println("log2_1=" + str(log2(1.0)))
+    println("log2_8=" + str(log2(8.0)))
+    println("log2_1024=" + str(log2(1024.0)))
+    println("log10_1=" + str(log10(1.0)))
+    println("log10_1000=" + str(log10(1000.0)))
+
+    // exp and log are mutual inverses.
+    println("logexp=" + str(log(exp(3.5))))
+    println("explog=" + str(exp(log(7.0))))
+
+    // Homomorphism identities the softmax/log-sum-exp math leans on:
+    //   log(a*b) == log(a)+log(b)   and   exp(a+b) == exp(a)*exp(b)
+    println("log_mul=" + str(log(6.0) - (log(2.0) + log(3.0))))
+    println("exp_add=" + str(exp(5.0) - exp(2.0)*exp(3.0)))
+
+    // Strict monotonicity (both are increasing).
+    if exp(1.0) < exp(1.5) { println("mono_exp=yes") }
+    if log(2.0) < log(3.0) { println("mono_log=yes") }
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"exp0=1",
+		"exp1=2.71828",
+		"exp2=7.38906",
+		"expneg1=0.367879",
+		"log1=0",
+		"loge=1",
+		"log2_1=0",
+		"log2_8=3",
+		"log2_1024=10",
+		"log10_1=0",
+		"log10_1000=3",
+		"logexp=3.5",
+		"explog=7",
+		"log_mul=0",
+		"exp_add=0",
+		"mono_exp=yes",
+		"mono_log=yes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// The numerically-stable softmax subtracts the max logit before exp() so the
+// exponentials never overflow. That shift must not change the resulting
+// probabilities: softmax(x) == softmax(x - c) for any constant c. Pin that
+// invariance end-to-end through exp(), plus the cross-entropy term -log(p) and
+// the normalization sum == 1. This ties the exp/log builtins to the real
+// inference kernel they exist to serve.
+func TestSoftmaxStabilityViaExpLog(t *testing.T) {
+	prog := progFromSrc(t, `
+func softmax3(a, b, c, shift) (p0, p1, p2) {
+    e0 := exp(a - shift)
+    e1 := exp(b - shift)
+    e2 := exp(c - shift)
+    s := e0 + e1 + e2
+    p0 = e0 / s
+    p1 = e1 / s
+    p2 = e2 / s
+}
+func main() {
+    // Same logits, computed unshifted vs shifted by the max (=3).
+    u0, u1, u2 := softmax3(1.0, 2.0, 3.0, 0.0)
+    s0, s1, s2 := softmax3(1.0, 2.0, 3.0, 3.0)
+    println("u=" + str(u0) + "," + str(u1) + "," + str(u2))
+    println("s=" + str(s0) + "," + str(s1) + "," + str(s2))
+    // The shift leaves probabilities and their sum unchanged.
+    println("diff0=" + str(u0 - s0))
+    println("sum=" + str(u0 + u1 + u2))
+    // Cross-entropy loss when the true class is index 2: -log(p2).
+    println("ce=" + str(0.0 - log(u2)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"u=0.0900306,0.244728,0.665241",
+		"s=0.0900306,0.244728,0.665241",
+		"diff0=0",
+		"sum=1",
+		"ce=0.407606",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/parse_numeric_field_defaults_test.go
+++ b/parse_numeric_field_defaults_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// parse() populates a struct's numeric and bool fields from JSON, and leaves
+// every field the JSON omits at its zero value: 0 for int, 0.0 for float, false
+// for bool. Unlike the string-field case (a NULL char* that must be forced to ""
+// so string ops don't deref it — see the struct-literal / parse string-field
+// contracts), an omitted numeric or bool slot is C-zeroed to a perfectly usable
+// 0/false, so the contract here is that the zero value is exactly that and never
+// leaks a garbage or sentinel value.
+//
+// The oracle also pins str()'s numeric formatting through the parsed values: a
+// negative int round-trips as "-7", a fractional float as "3.5", a whole-valued
+// float ("2.0" in JSON) collapses to "2", a zero float prints "0", and a bool is
+// "true"/"false". These are captured from the running binary, not a prior test
+// run — every number below is hand-checkable against the JSON input.
+func TestParseNumericFieldDefaults(t *testing.T) {
+	prog := progFromSrc(t, `
+type Rec struct { n int  neg int  f float  ok bool  no bool  s string }
+func main() {
+    r := parse("{\"n\":42,\"neg\":-7,\"f\":3.5,\"ok\":true,\"no\":false,\"s\":\"hi\"}", Rec{})
+    println("present n=" + str(r.n) + " neg=" + str(r.neg) + " f=" + str(r.f) + " ok=" + str(r.ok) + " no=" + str(r.no) + " s=" + r.s)
+    a := parse("{\"s\":\"x\"}", Rec{})
+    println("absent n=" + str(a.n) + " neg=" + str(a.neg) + " f=" + str(a.f) + " ok=" + str(a.ok) + " no=" + str(a.no))
+    p := parse("{\"n\":5,\"f\":2.0}", Rec{})
+    println("partial n=" + str(p.n) + " f=" + str(p.f) + " ok=" + str(p.ok))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := strings.Join(strings.Fields(out), " ")
+	want := strings.Join(strings.Fields(`
+present n=42 neg=-7 f=3.5 ok=true no=false s=hi
+absent n=0 neg=0 f=0 ok=false no=false
+partial n=5 f=2 ok=false`), " ")
+	if got != want {
+		t.Fatalf("parse() numeric/bool field defaults:\ngot:  %q\nwant: %q", got, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #456 (am/am-7b5889-ti424g): test(parser): pin parseFuncLit closure-literal parse-error branches
    touches: math_sign_contracts_test.go, parse_funclit_error_test.go
- PR #455 (am/am-7b5889-ti408k): test(builtins): pin cos/tan numeric contracts + even/odd symmetry
    touches: loop_control_flow_test.go, trig_cos_tan_test.go
- PR #454 (am/am-7b5889-ti3y9i): test(builtins): pin trim() whitespace-class + empty/one-sided edges
    touches: main.go, tighten_test.go, trim_edge_test.go
- PR #452 (am/am-7b5889-ti3v45): test(encode): pin brace-counting through strings with braces + escaped quotes
    touches: encode_brace_string_test.go
- PR #450 (am/am-7b5889-ti3t65): [needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL
    touches: CHANGELOG.md, codegen.go, parse_null_string_field_test.go, parse_unset_field_paths_test.go
- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go


**Branch:** `am/am-7b5889-ti43vs`

**Diff:**
```
exp_log_contracts_test.go            | 118 +++++++++++++++++++++++++++++++++++
 parse_numeric_field_defaults_test.go |  44 +++++++++++++
 2 files changed, 162 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for exponential and logarithmic calculations, including inverse relationships, arithmetic identities, expected values, and monotonicity.
  * Added validation that softmax remains stable when logits are shifted and that probabilities and cross-entropy values are correct.
  * Added coverage for numeric and boolean JSON parsing defaults, value preservation, and numeric string formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->