### PR TITLE
test(builtins): pin parse_int/parse_float strtoll/strtod partial-parse contract

### DIFF
--- a/math_domain_contracts_test.go
+++ b/math_domain_contracts_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The existing math builtin tests (mathstr2/mathstr3) only exercise the
+// happy path — cbrt(27)=3, fmod(7,3)=1, hypot(3,4)=5, pow(...)=1024. Those
+// pass even if codegen picks the wrong libm entry point or mishandles sign,
+// because every input is positive and every result is a clean integer. The
+// contracts below pin the *distinguishing* numeric behavior — the cases where
+// a subtly-wrong implementation (e.g. cbrt routed through sqrt, fmod taking
+// the sign of the divisor, pow special-casing 0^0 differently) would produce
+// a different answer.
+
+// cbrt is the real cube root: unlike sqrt, it is defined for negatives and
+// returns a negative result. cbrt(-27) = -3, not NaN and not +3.
+func TestCbrtNegativeAndZeroContract(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("neg27=" + str(cbrt(0.0 - 27.0)))
+    println("neg8=" + str(cbrt(0.0 - 8.0)))
+    println("zero=" + str(cbrt(0.0)))
+    println("one=" + str(cbrt(1.0)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"neg27=-3", "neg8=-2", "zero=0", "one=1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cbrt: missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// fmod follows C: the result takes the sign of the dividend (the first arg),
+// never the divisor. fmod(-7,3) = -1 (not +2, which is what a mod that follows
+// the divisor's sign would give); fmod(7,-3) = +1.
+func TestFmodSignOfDividendContract(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("negdiv=" + str(fmod(0.0 - 7.0, 3.0)))
+    println("negmod=" + str(fmod(7.0, 0.0 - 3.0)))
+    println("frac=" + str(fmod(5.5, 2.0)))
+    println("exact=" + str(fmod(6.0, 3.0)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"negdiv=-1", "negmod=1", "frac=1.5", "exact=0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("fmod: missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// hypot(x,y) = sqrt(x*x + y*y): symmetric in its arguments, insensitive to the
+// sign of either, and equal to |x| when the other leg is zero. These pin that
+// the two args aren't accidentally swapped-sensitive or sign-sensitive.
+func TestHypotSymmetryAndZeroContract(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("zerozero=" + str(hypot(0.0, 0.0)))
+    println("negx=" + str(hypot(0.0 - 3.0, 4.0)))
+    println("swap=" + str(hypot(4.0, 3.0)))
+    println("legzero=" + str(hypot(5.0, 0.0)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"zerozero=0", "negx=5", "swap=5", "legzero=5",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("hypot: missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// pow identities: anything to the 0 power is 1 (including 0^0, the C/IEEE
+// convention), a negative exponent yields a reciprocal, a negative base with an
+// odd integer exponent stays negative, and a 0.5 exponent is the square root.
+func TestPowIdentityContract(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("x0=" + str(pow(7.0, 0.0)))
+    println("zerozero=" + str(pow(0.0, 0.0)))
+    println("negexp=" + str(pow(2.0, 0.0 - 2.0)))
+    println("negbase=" + str(pow(0.0 - 2.0, 3.0)))
+    println("half=" + str(pow(9.0, 0.5)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"x0=1", "zerozero=1", "negexp=0.25", "negbase=-8", "half=3",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("pow: missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/parse_int_float_edge_test.go
+++ b/parse_int_float_edge_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+// parse_int / parse_float lower to C's strtoll(s, NULL, 10) / strtod(s, NULL).
+// That pins a specific, easy-to-regress contract: leading whitespace is skipped,
+// a leading '+'/'-' sign is honored, and parsing stops at the first character
+// that cannot extend the number (a "partial parse") rather than erroring. The
+// existing suite only covers the clean cases ("8080", "-42", "x", "") — these
+// tests nail down the whitespace / sign / partial-parse edges so a future swap
+// to a stricter parser can't silently change behavior.
+//
+// Each value below was confirmed against the native runtime before pinning.
+func TestParseIntStrtollContract(t *testing.T) {
+	cases := []struct {
+		in   string // MFL string literal passed to parse_int
+		want string // exact println output
+	}{
+		{`"  42"`, "42"},  // leading spaces are skipped
+		{`"\t5"`, "5"},    // leading tab is whitespace too
+		{`"12abc"`, "12"}, // partial parse: stops at first non-digit
+		{`"+7"`, "7"},     // explicit '+' sign
+		{`"  -9"`, "-9"},  // whitespace then a negative sign
+		{`"0x10"`, "0"},   // base 10 only: reads the leading 0, stops at 'x'
+		{`"3.9"`, "3"},    // integer parse stops at the '.'
+	}
+	for _, c := range cases {
+		src := `func main() { println(parse_int(` + c.in + `)) }`
+		if got := runNative(t, src); got != c.want+"\n" {
+			t.Errorf("parse_int(%s): got %q, want %q", c.in, got, c.want+"\n")
+		}
+	}
+}
+
+// parse_float mirrors parse_int's tolerance via strtod: whitespace-skipping,
+// scientific notation, a bare leading '.', partial parses, and 0 on empty input.
+func TestParseFloatStrtodContract(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`"3.14xyz"`, "3.14"}, // partial parse: trailing junk ignored
+		{`"1e3"`, "1000"},     // scientific notation, printed without a fraction
+		{`".5"`, "0.5"},       // a leading '.' is a valid float
+		{`"  2.5"`, "2.5"},    // leading whitespace is skipped
+		{`""`, "0"},           // empty input yields 0, not an error
+		{`"-0.25"`, "-0.25"},  // negative fractional value round-trips
+	}
+	for _, c := range cases {
+		src := `func main() { println(parse_float(` + c.in + `)) }`
+		if got := runNative(t, src); got != c.want+"\n" {
+			t.Errorf("parse_float(%s): got %q, want %q", c.in, got, c.want+"\n")
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #456 (am/am-7b5889-ti424g): test(parser): pin parseFuncLit closure-literal parse-error branches
    touches: math_sign_contracts_test.go, parse_funclit_error_test.go
- PR #455 (am/am-7b5889-ti408k): test(builtins): pin cos/tan numeric contracts + even/odd symmetry
    touches: loop_control_flow_test.go, trig_cos_tan_test.go
- PR #454 (am/am-7b5889-ti3y9i): test(builtins): pin trim() whitespace-class + empty/one-sided edges
    touches: main.go, tighten_test.go, trim_edge_test.go
- PR #452 (am/am-7b5889-ti3v45): test(encode): pin brace-counting through strings with braces + escaped quotes
    touches: encode_brace_string_test.go
- PR #450 (am/am-7b5889-ti3t65): [needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL
    touches: CHANGELOG.md, codegen.go, parse_null_string_field_test.go, parse_unset_field_paths_test.go
- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go


**Branch:** `am/am-7b5889-ti45ts`

**Diff:**
```
math_domain_contracts_test.go | 111 ++++++++++++++++++++++++++++++++++++++++++
 parse_int_float_edge_test.go  |  55 +++++++++++++++++++++
 2 files changed, 166 insertions(+)
```
