### PR TITLE
test(builtins): pin int()/float() cast contracts (trunc-toward-zero + integer type)

### DIFF
--- a/f64_bits_contract_test.go
+++ b/f64_bits_contract_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// f64_bits reinterprets a double's raw IEEE-754 storage as a signed int64 (a
+// bit-for-bit reinterpret, NOT numeric truncation), and f64_from_bits inverts
+// it. The existing convert_test.go coverage only checks that a value survives a
+// round trip (f64_from_bits(f64_bits(x)) == x); it never pins the *concrete*
+// bit layout f64_bits produces. That layout is the whole contract — callers use
+// these to hash doubles, to serialize a BSON double (see bson_test.go), and to
+// poke float bits into raw memory — so a hand-rolled reinterpret that silently
+// swapped byte order, sign-extended wrong, or truncated to int would still pass
+// the round-trip tests while corrupting every on-wire value. These pin the
+// exact int64 for known doubles so such a regression trips here.
+//
+// Reference layouts (IEEE-754 binary64, the raw 64 bits read as signed int64):
+//
+//	 1.0  = 0x3FF0000000000000 =  4607182418800017408
+//	 2.0  = 0x4000000000000000 =  4611686018427387904
+//	 0.5  = 0x3FE0000000000000 =  4602678819172646912
+//	-1.0  = 0xBFF0000000000000 = -4616189618054758400
+func TestF64BitsExactLayout(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("one=" + str(f64_bits(1.0)))
+    println("two=" + str(f64_bits(2.0)))
+    println("half=" + str(f64_bits(0.5)))
+    println("negone=" + str(f64_bits(-1.0)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"one=4607182418800017408",
+		"two=4611686018427387904",
+		"half=4602678819172646912",
+		"negone=-4616189618054758400",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// The sign bit and the exponent field are exactly where a byte-swapped or
+// numerically-truncated implementation goes wrong, so pin them directly:
+//
+//	+0.0        = 0x0000000000000000 =                    0
+//	-0.0        = 0x8000000000000000 = -9223372036854775808 (sign bit only; INT64_MIN)
+//	+Inf        = 0x7FF0000000000000 =  9218868437227405312
+//	-Inf        = 0xFFF0000000000000 =    -4503599627370496
+//	5e-324      = 0x0000000000000001 =                    1 (smallest positive subnormal)
+//
+// Positive and negative zero are numerically equal (0.0 == -0.0) yet must have
+// distinct bit patterns — the single most common reinterpret bug is collapsing
+// them, which this catches. -0.0 is built as 0.0 * -1.0 to avoid depending on a
+// negative-zero literal.
+func TestF64BitsSignZeroAndInfinities(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("poszero=" + str(f64_bits(0.0)))
+    println("negzero=" + str(f64_bits(0.0 * -1.0)))
+    println("posinf=" + str(f64_bits(1.0 / 0.0)))
+    println("neginf=" + str(f64_bits(-1.0 / 0.0)))
+    println("subnormal=" + str(f64_bits(5e-324)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"poszero=0",
+		"negzero=-9223372036854775808",
+		"posinf=9218868437227405312",
+		"neginf=-4503599627370496",
+		"subnormal=1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// f64_from_bits must reconstruct the double from a raw bit pattern — including
+// the non-finite ones. Feeding it the pinned integer layouts above must yield
+// back the exact values: 0x3FF0000000000000 -> 1.0, and the +Inf pattern must
+// produce a value that is larger than the largest finite double (1e308), i.e.
+// an actual infinity, not a garbage large-but-finite number. This closes the
+// loop the other direction from f64_bits and guards f64_from_bits' own
+// reinterpret path on the value classes round-trip-of-a-normal never reaches.
+func TestF64FromBitsReconstructsSpecials(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("one=" + str(f64_from_bits(4607182418800017408) == 1.0))
+    println("half=" + str(f64_from_bits(4602678819172646912) == 0.5))
+    inf := f64_from_bits(9218868437227405312)
+    println("inf=" + str(inf > 1.0e308))
+    println("infrt=" + str(f64_bits(inf) == 9218868437227405312))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"one=true", "half=true", "inf=true", "infrt=true"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/int_float_conv_test.go
+++ b/int_float_conv_test.go
@@ -1,0 +1,65 @@
+package main
+
+import "testing"
+
+// The int() / float() builtins are plain C casts in codegen.go
+// (`((int64_t)(x))` and `((double)(x))`). Those casts carry two contracts that
+// user code — especially the quantized-inference kernels that round floats into
+// int8 lanes — leans on but which nothing pins directly:
+//
+//  1. int(double) truncates toward ZERO, not toward negative infinity. It is the
+//     C cast, so it matches trunc(), NOT floor() or round(). int(-3.9) == -3,
+//     whereas floor(-3.9) == -4 and round(-3.9) == -4.
+//  2. int() actually changes the value's type to a machine integer, so the
+//     result participates in integer division and modulo — not float division.
+//
+// float() is the inverse widening: an int promoted to double so that a
+// subsequent `/` is real division instead of integer division.
+
+// TestIntConvTruncatesTowardZero pins that int() rounds toward zero for both
+// signs, agreeing with trunc() and disagreeing with floor()/round() on
+// negatives. -0.5 must land on plain 0 (not -0), and an already-integral double
+// is unchanged.
+func TestIntConvTruncatesTowardZero(t *testing.T) {
+	got := runNative(t, `func main() {
+		println(int(3.9))
+		println(int(-3.9))
+		println(int(-0.5))
+		println(int(2.0))
+		println(float(int(-3.9)) == trunc(-3.9))
+		println(floor(-3.9))
+	}`)
+	if want := "3\n-3\n0\n2\ntrue\n-4\n"; got != want {
+		t.Fatalf("int() truncation contract: got %q, want %q", got, want)
+	}
+}
+
+// TestIntConvYieldsIntegerType pins that int()'s result is a real integer: two
+// int() operands divide with integer (truncating) division and support %, and
+// an int() feeds ordinary integer arithmetic. If int() secretly stayed a double,
+// int(7.9)/int(2.1) would be 3.5 rather than 3.
+func TestIntConvYieldsIntegerType(t *testing.T) {
+	got := runNative(t, `func main() {
+		println(int(7.9) / int(2.1))
+		println(int(7.9) % 2)
+		println(int(3.7) + 1)
+	}`)
+	if want := "3\n1\n4\n"; got != want {
+		t.Fatalf("int() integer-type contract: got %q, want %q", got, want)
+	}
+}
+
+// TestFloatConvWidensForRealDivision pins float() as the inverse of int(): an
+// int promoted to double so `/` is real division (7/2 -> 3.5, not 3), and the
+// int->float->int round trip is exact for small magnitudes.
+func TestFloatConvWidensForRealDivision(t *testing.T) {
+	got := runNative(t, `func main() {
+		x := 7
+		println(float(x) / 2.0)
+		println(int(float(5)) == 5)
+		println(float(3) + float(4))
+	}`)
+	if want := "3.5\ntrue\n7\n"; got != want {
+		t.Fatalf("float() widening contract: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #458 (am/am-7b5889-ti45ts): test(builtins): pin parse_int/parse_float strtoll/strtod partial-parse contract
    touches: math_domain_contracts_test.go, parse_int_float_edge_test.go
- PR #456 (am/am-7b5889-ti424g): test(parser): pin parseFuncLit closure-literal parse-error branches
    touches: math_sign_contracts_test.go, parse_funclit_error_test.go
- PR #455 (am/am-7b5889-ti408k): test(builtins): pin cos/tan numeric contracts + even/odd symmetry
    touches: loop_control_flow_test.go, trig_cos_tan_test.go
- PR #454 (am/am-7b5889-ti3y9i): test(builtins): pin trim() whitespace-class + empty/one-sided edges
    touches: main.go, tighten_test.go, trim_edge_test.go
- PR #452 (am/am-7b5889-ti3v45): test(encode): pin brace-counting through strings with braces + escaped quotes
    touches: encode_brace_string_test.go
- PR #450 (am/am-7b5889-ti3t65): [needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL
    touches: CHANGELOG.md, codegen.go, parse_null_string_field_test.go, parse_unset_field_paths_test.go
- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go
- PR #443 (am/am-7b5889-ti1pfj): [needs work] docs(examples): Q8_0 quantized GEMV example + pinned-output test
    touches: examples/README.md, examples/complex/quant_matmul.mfl, quant_matmul_example_test.go


**Branch:** `am/am-7b5889-ti47l5`

**Diff:**
```
f64_bits_contract_test.go | 113 ++++++++++++++++++++++++++++++++++++++++++++++
 int_float_conv_test.go    |  65 ++++++++++++++++++++++++++
 2 files changed, 178 insertions(+)
```
