### PR TITLE
test(build): pin BuildWasm/RunCaptured build-error paths + firstMeaningfulLine coverage

### DIFF
--- a/buildwasm_test.go
+++ b/buildwasm_test.go
@@ -6,8 +6,9 @@ import (
 )
 
 // BuildWasm must reject a program with no `export func` before ever invoking
-// the zig/cc toolchain — this is the only branch of BuildWasm testable
-// without a wasm32-wasi cross-compiler installed in CI.
+// the zig/cc toolchain — this is one of two branches of BuildWasm testable
+// without a wasm32-wasi cross-compiler installed in CI (the other being a
+// CompileToCTarget failure, covered by TestBuildWasmCompileError below).
 func TestBuildWasmNoExports(t *testing.T) {
 	prog, err := ParseProgram([]string{
 		`func main() { println("hi") }`,
@@ -21,5 +22,23 @@ func TestBuildWasmNoExports(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no exported functions") {
 		t.Fatalf("BuildWasm error = %q, want it to mention no exported functions", err.Error())
+	}
+}
+
+// A CompileToCTarget failure (here, a call to an undefined function) must
+// surface from BuildWasm before it ever shells out to zig/cc.
+func TestBuildWasmCompileError(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`export func main() { undefinedFunc() }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	err = BuildWasm(prog, "/tmp/mfl-buildwasm-test-compile-error.wasm", false)
+	if err == nil {
+		t.Fatal("BuildWasm: expected an error for a call to an undefined function, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined function") {
+		t.Fatalf("BuildWasm error = %q, want it to mention the undefined function", err.Error())
 	}
 }

--- a/check_helpers_test.go
+++ b/check_helpers_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestDeclName covers declName's three declaration shapes: plain, exported,
 // and a decl with no ident (which must fall back to "").
@@ -19,10 +22,30 @@ func TestDeclName(t *testing.T) {
 	}
 }
 
-// firstMeaningfulLine's blank/comment-skipping and long-line-truncation branches
-// are covered by TestFirstMeaningfulLine in check_test.go (this file previously
-// had a second, functionally-identical copy of that test under the same name,
-// which broke the build — see the fix/duplicate-testfirstmeaningfulline branch).
+// TestFirstMeaningfulLine covers leading blank/comment lines being skipped, a
+// normal line returned as-is, long-line truncation past 120 chars (with a "..."
+// suffix), and an all-blank/all-comment block falling through to "".
+func TestFirstMeaningfulLine(t *testing.T) {
+	if got := firstMeaningfulLine("\n// a comment\n\n    x := 1\n"); got != "x := 1" {
+		t.Errorf("firstMeaningfulLine: got %q, want %q", got, "x := 1")
+	}
+
+	long := ""
+	for len(long) < 130 {
+		long += "a"
+	}
+	got := firstMeaningfulLine(long)
+	if len(got) != 120 || !strings.HasSuffix(got, "...") {
+		t.Errorf("firstMeaningfulLine on a %d-char line: got len %d (%q), want len 120 ending in \"...\"", len(long), len(got), got)
+	}
+	if got[:117] != long[:117] {
+		t.Errorf("firstMeaningfulLine truncation: got prefix %q, want %q", got[:117], long[:117])
+	}
+
+	if got := firstMeaningfulLine("\n// only comments\n   \n// more\n"); got != "" {
+		t.Errorf("firstMeaningfulLine on an all-blank/comment block: got %q, want \"\"", got)
+	}
+}
 
 // TestSeedStructNames covers both type and cstruct declarations, and that
 // unrelated declarations don't seed anything.

--- a/run_captured_error_test.go
+++ b/run_captured_error_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// RunCaptured must surface a BuildBinary failure (here, a call to an
+// undefined function, caught during type-checking) rather than attempt to
+// run a binary that was never produced.
+func TestRunCapturedBuildError(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { undefinedFunc() }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, rerr := RunCaptured(prog)
+	if rerr == nil {
+		t.Fatal("RunCaptured: expected an error for a call to an undefined function, got nil")
+	}
+	if out != "" {
+		t.Fatalf("RunCaptured: expected empty output on build failure, got %q", out)
+	}
+	if !strings.Contains(rerr.Error(), "undefined function") {
+		t.Fatalf("RunCaptured error = %q, want it to mention the undefined function", rerr.Error())
+	}
+}

--- a/types_mappart_test.go
+++ b/types_mappart_test.go
@@ -1,0 +1,87 @@
+package main
+
+import "testing"
+
+// TestMapPartOnMapNode covers MapKeyKind, MapKeyCType, and MapValCType
+// against a genuinely map-typed node (the KMap branch of mapPart).
+func TestMapPartOnMapNode(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { m := make(map[string]int) m["a"] = 1 for k, v := range m { println(k) println(v) } }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	var inst string
+	var m Expr
+	for _, r := range c.Reps() {
+		if c.SrcFunc(r).Name != "main" {
+			continue
+		}
+		inst = r
+		for _, stmt := range c.SrcFunc(r).Body {
+			if rs, ok := stmt.(*RangeStmt); ok {
+				m = rs.X
+			}
+		}
+	}
+	if inst == "" || m == nil {
+		t.Fatal("no main instance / range base node found")
+	}
+
+	if got := c.MapKeyKind(inst, m); got != KString {
+		t.Errorf("MapKeyKind(m) = %v, want %v", got, KString)
+	}
+	if got := c.MapKeyCType(inst, m); got != "char*" {
+		t.Errorf("MapKeyCType(m) = %q, want %q", got, "char*")
+	}
+	if got := c.MapValCType(inst, m); got != "int64_t" {
+		t.Errorf("MapValCType(m) = %q, want %q", got, "int64_t")
+	}
+}
+
+// TestMapPartFallbackOnNonMap covers the slot<0 default-value fallback
+// branch of mapPart (KInt/"int64_t") when the queried node isn't a map.
+func TestMapPartFallbackOnNonMap(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { n := 5 println(n) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("typecheck: %v", err)
+	}
+
+	var inst string
+	var n Expr
+	for _, r := range c.Reps() {
+		if c.SrcFunc(r).Name != "main" {
+			continue
+		}
+		inst = r
+		for _, stmt := range c.SrcFunc(r).Body {
+			if as, ok := stmt.(*AssignStmt); ok && as.Name == "n" {
+				n = as.Val
+			}
+		}
+	}
+	if inst == "" || n == nil {
+		t.Fatal("no main instance / assign node found")
+	}
+
+	if got := c.MapKeyKind(inst, n); got != KInt {
+		t.Errorf("MapKeyKind(n) fallback = %v, want %v", got, KInt)
+	}
+	if got := c.MapKeyCType(inst, n); got != "int64_t" {
+		t.Errorf("MapKeyCType(n) fallback = %q, want %q", got, "int64_t")
+	}
+	if got := c.MapValCType(inst, n); got != "int64_t" {
+		t.Errorf("MapValCType(n) fallback = %q, want %q", got, "int64_t")
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #459 (am/am-7b5889-ti47l5): test(builtins): pin int()/float() cast contracts (trunc-toward-zero + integer type)
    touches: f64_bits_contract_test.go, int_float_conv_test.go
- PR #458 (am/am-7b5889-ti45ts): test(builtins): pin parse_int/parse_float strtoll/strtod partial-parse contract
    touches: math_domain_contracts_test.go, parse_int_float_edge_test.go
- PR #456 (am/am-7b5889-ti424g): test(parser): pin parseFuncLit closure-literal parse-error branches
    touches: math_sign_contracts_test.go, parse_funclit_error_test.go
- PR #455 (am/am-7b5889-ti408k): test(builtins): pin cos/tan numeric contracts + even/odd symmetry
    touches: loop_control_flow_test.go, trig_cos_tan_test.go
- PR #454 (am/am-7b5889-ti3y9i): test(builtins): pin trim() whitespace-class + empty/one-sided edges
    touches: main.go, tighten_test.go, trim_edge_test.go
- PR #452 (am/am-7b5889-ti3v45): test(encode): pin brace-counting through strings with braces + escaped quotes
    touches: encode_brace_string_test.go
- PR #450 (am/am-7b5889-ti3t65): [needs work] fix(codegen): parse() must default absent struct string fields to "" not NULL
    touches: CHANGELOG.md, codegen.go, parse_null_string_field_test.go, parse_unset_field_paths_test.go
- PR #446 (am/am-7b5889-ti1vmu): [needs work] feat(examples): pure-MFL decode-step kernels (rmsnorm + stable softmax + argmax)
    touches: decode_step_example_test.go, examples/complex/decode_step.mfl, examples/complex/ffn_activation.mfl, ffn_activation_example_test.go


**Branch:** `am/am-7b5889-ti49ft`

**Diff:**
```
buildwasm_test.go          | 23 ++++++++++--
 check_helpers_test.go      | 33 +++++++++++++++---
 run_captured_error_test.go | 28 +++++++++++++++
 types_mappart_test.go      | 87 ++++++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 164 insertions(+), 7 deletions(-)
```
