### PR TITLE
The Falsifier — Phase 2: self-host port (oracle-identical, full parity)

### DIFF
--- a/docs/falsify-phase1-plan.md
+++ b/docs/falsify-phase1-plan.md
@@ -239,11 +239,32 @@ bugs across arithmetic, calls, and struct fields; surfaces them advisorily in
 runtime-confirmed repros; and is guarded by Go tests + `verify-falsify.sh`.
 Deferred, documented: maps + `FALS003`. Next: Phase 2 (self-host port).
 
-## After Phase 1 (outline, not committed)
+## Phase 2 — self-host port: ✅ COMPLETE
 
-- **Phase 2 — self-host port**: port `falsify.go` → `selfhost/falsify.src` over the
-  MFL IR, oracle-diffed via a `falsifytest --program` dumper (hex-encoded findings,
-  sorted) exactly like `racetest`. So machin-in-machin both compiles and falsifies.
+Ported `falsify.go` → `selfhost/falsify.src` over the self-hosted IR (`nodes[]` +
+`g_insts`), oracle-diffed via a `falsifytest --program` hex dumper exactly like
+`racetest`/`racecheck.src`. **machin-in-machin now both compiles AND falsifies,
+byte-identically.** Driver: `selfhost/falsifymain.src`. Gate:
+`selfhost/verify-falsify.sh` (38/38) + a broad corpus sweep (47/47 example files
+where both pipelines parse+check).
+
+The one architectural problem: **MFL has no panic/recover and no closures**, so the
+Go interpreter's `panic(fviol)`/`panic(funknown)` unwinding and `ctrl` returns are
+replaced by threaded status globals (`g_fstatus`, `g_freturned`/`g_fbreak`/
+`g_fcontinue`), and interprocedural inlining saves/restores the global env around
+each call instead of using call frames. The value model is an `FV` struct (int /
+`[]int` / float / string / bool / struct) — MFL has no `[][]FV`, so slice and struct
+domains are enumerated as flat `[]FV` / decoded on-the-fly from the enumeration index.
+
+Slices: 2.1 scalar-int spike (proved status-threading + byte-exact render/hex),
+2.2 `[]int` + `FALS001` + len/while/for-range, 2.3 float + string, 2.4 struct +
+bool (bool renders `true`/`false`, value-semantics clone), 2.5 interprocedural
+inlining (recursion-capped) → **full parity**. The 9 corpus files that differ are
+pre-existing shared self-hosted pipeline gaps (multi-line parse, closures,
+variadic, globals) — the already-shipped race pass diverges on them identically.
+
+## After Phase 2 (outline, not committed)
+
 - **Phase 3 — user contracts**: `requires`/`ensures`/`invariant` as syntax; the
   same enumerator checks them; a violated `ensures` yields a counterexample. This
   is where it stops being "free properties" and becomes real design-by-contract.

--- a/falsifytest.go
+++ b/falsifytest.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// cmdFalsifyTest is the self-hosting oracle for the falsify pass:
+//
+//	machin falsifytest --program <file.mfl>
+//
+// It runs parse → liftClosures → check → detectFalsifiable and dumps every
+// counterexample in a canonical, escaping-free form (one per line, fields
+// hex-encoded, in detectFalsifiable's stable sort order) so the MFL port
+// (selfhost/falsify.src) can be byte-diffed against it.
+func cmdFalsifyTest(args []string) error {
+	if len(args) < 2 || args[0] != "--program" {
+		return fmt.Errorf("usage: machin falsifytest --program <file.mfl>")
+	}
+	data, err := os.ReadFile(args[1])
+	if err != nil {
+		return err
+	}
+	var decls []string
+	for _, ln := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(ln) != "" {
+			decls = append(decls, ln)
+		}
+	}
+	prog, err := ParseProgram(decls)
+	if err != nil {
+		fmt.Println("(parse-error)")
+		return nil
+	}
+	liftClosures(prog)
+	c, err := Check(prog)
+	if err != nil {
+		fmt.Println("(check-error)")
+		return nil
+	}
+	hx := func(s string) string { return hex.EncodeToString([]byte(s)) }
+	var b strings.Builder
+	for _, f := range detectFalsifiable(prog, c) {
+		b.WriteString(hx(f.Decl) + "|" + hx(f.Code) + "|" + hx(f.Prop) + "|" + hx(f.Expr) + "|" + hx(f.Bind) + "\n")
+	}
+	os.Stdout.WriteString(b.String())
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,12 @@ func main() {
 			os.Exit(1)
 		}
 		return
+	case "falsifytest":
+		if err := cmdFalsifyTest(os.Args[2:]); err != nil { // self-hosting oracle: dump falsify findings canonically
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
 	case "uftest":
 		if err := cmdUFTest(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "error:", err)

--- a/selfhost/falsify.src
+++ b/selfhost/falsify.src
@@ -1,122 +1,184 @@
 // selfhost/falsify.src — The Falsifier, self-hosted (Phase 2).
 //
 // Ports falsify.go's detectFalsifiable over the self-hosted IR (nodes[] + g_insts),
-// oracle-diffed against `machin falsifytest --program`. The one structural change
-// forced by MFL: there is NO panic/recover, so the Go interpreter's panic(fviol)/
-// panic(funknown) unwinding is replaced by a threaded status global (g_fstatus)
-// that every eval site checks and early-returns on.
+// oracle-diffed against `machin falsifytest --program`. MFL has NO panic/recover,
+// so the Go interpreter's panic(fviol)/panic(funknown) unwinding + ctrl returns
+// are replaced by threaded status globals: g_fstatus (ok/violation/unknown),
+// g_freturned / g_fbreak / g_fcontinue (control flow).
 //
-// Phase 2 slice 2.1 (feasibility spike): scalar-int params, arithmetic +
-// div/modulo-by-zero (FALS002). This proves the status-threading + enumeration +
-// precedence-rendering + hex-dump all reproduce the Go reference byte-for-byte.
-// Slices, structs, index-OOB (FALS001) and interprocedural inlining follow.
+// Slice 2.2 scope: int + []int params; arithmetic, comparisons, if/while/for-range,
+// index (FALS001 out-of-range), len, div/mod-by-zero (FALS002). Value model is the
+// FV struct (MFL has no [][]int, but a []int field inside a []struct is fine).
+// Floats/strings, structs and interprocedural inlining follow in later slices.
 
-// interpreter status: 0 ok, 1 violation (counterexample), 2 unknown (inconclusive)
-var g_fstatus = 0
+// ---- value model: FV is int (k=0) or []int slice (k=1) ----
+type FV struct { k int  i int  sl []int }
+
+func fv_int(x) (fv) { fv = FV{k: 0, i: x} }
+func fv_slice(xs) (fv) { fv = FV{k: 1, sl: xs} }
+
+func fv_str(fv) (s) {
+    if fv.k == 0 { s = str(fv.i)  return s }
+    s = "[]int{"
+    i := 0
+    for i < len(fv.sl) {
+        if i > 0 { s = s + ", " }
+        s = s + str(fv.sl[i])
+        i = i + 1
+    }
+    s = s + "}"
+    return s
+}
+
+// ---- interpreter status + control flow (replace panic/recover + ctrl returns) ----
+var g_fstatus = 0        // 0 ok, 1 violation (counterexample), 2 unknown
 var g_fviol_prop = ""
 var g_fviol_expr = ""
-// returned-flag: MFL has no ctrlReturn, so a K_RETURN sets this and every stmt
-// loop stops on it (else execution falls through past a guarded early return).
 var g_freturned = 0
+var g_fbreak = 0
+var g_fcontinue = 0
+var g_fsteps = 0         // step budget guard (matches falsStepBudget); non-terminating -> unknown on both sides
 
-// environment: parallel arrays, int scalars only (spike)
+func f_tick() {
+    g_fsteps = g_fsteps + 1
+    if g_fsteps > 200000 { g_fstatus = 2 }
+}
+
+// ---- environment: parallel arrays of (name, FV) ----
 var g_env_names = []string{}
-var g_env_vals = []int{}
+var g_env_vals = []FV{}
 
 func f_env_reset() {
     g_env_names = []string{}
-    g_env_vals = []int{}
+    g_env_vals = []FV{}
 }
 
-func f_env_set(name, v) {
+func f_env_set(name, fv) {
     i := 0
     for i < len(g_env_names) {
-        if g_env_names[i] == name { g_env_vals[i] = v  return }
+        if g_env_names[i] == name { g_env_vals[i] = fv  return }
         i = i + 1
     }
     g_env_names = append(g_env_names, name)
-    g_env_vals = append(g_env_vals, v)
+    g_env_vals = append(g_env_vals, fv)
 }
 
-func f_env_get(name) (v) {
-    v = 0
+func f_env_get(name) (fv) {
+    fv = fv_int(0)
     i := 0
     for i < len(g_env_names) {
-        if g_env_names[i] == name { v = g_env_vals[i]  return v }
+        if g_env_names[i] == name { fv = g_env_vals[i]  return fv }
         i = i + 1
     }
-    g_fstatus = 2   // free ident -> inconclusive (matches funknown)
-    return v
+    g_fstatus = 2   // free ident -> inconclusive
+    return fv
 }
 
-// ---- expression evaluation (int; status in g_fstatus) ----
+// ---- expression evaluation -> FV (status in g_fstatus) ----
 
 func f_eval(ni) (v) {
-    v = 0
+    v = fv_int(0)
+    if g_fstatus != 0 { return v }
+    f_tick()
     if g_fstatus != 0 { return v }
     n := nodes[ni]
-    if n.kind == K_INT { v = n.ival  return v }
+    if n.kind == K_INT { v = fv_int(n.ival)  return v }
+    if n.kind == K_BOOL { if n.ival != 0 { v = fv_int(1) } else { v = fv_int(0) }  return v }
     if n.kind == K_ID { v = f_env_get(n.s)  return v }
     if n.kind == K_UNARY {
         x := f_eval(n.a)
         if g_fstatus != 0 { return v }
-        if n.s == "-" { v = 0 - x  return v }
-        if n.s == "!" { if x == 0 { v = 1 }  return v }
+        if x.k != 0 { g_fstatus = 2  return v }
+        if n.s == "-" { v = fv_int(0 - x.i)  return v }
+        if n.s == "!" { if x.i == 0 { v = fv_int(1) } else { v = fv_int(0) }  return v }
         g_fstatus = 2  return v
     }
     if n.kind == K_BIN { v = f_eval_bin(ni)  return v }
-    g_fstatus = 2   // any other expr kind -> inconclusive (spike scope)
+    if n.kind == K_INDEX {
+        base := f_eval(n.a)
+        if g_fstatus != 0 { return v }
+        ix := f_eval(n.b)
+        if g_fstatus != 0 { return v }
+        if base.k != 1 { g_fstatus = 2  return v }   // index non-slice (string) -> unknown (later slice)
+        if ix.k != 0 { g_fstatus = 2  return v }
+        if ix.i < 0 || ix.i >= len(base.sl) {
+            g_fstatus = 1  g_fviol_prop = "index out of range"  g_fviol_expr = f_render(ni, 0)  return v
+        }
+        v = fv_int(base.sl[ix.i])  return v
+    }
+    if n.kind == K_CALL {
+        if n.s == "len" && len(n.kids) == 1 {
+            a := f_eval(n.kids[0])
+            if g_fstatus != 0 { return v }
+            if a.k == 1 { v = fv_int(len(a.sl))  return v }
+            g_fstatus = 2  return v   // len of non-slice (string) -> unknown (later slice)
+        }
+        g_fstatus = 2  return v   // other calls -> unknown (interprocedural is a later slice)
+    }
+    g_fstatus = 2   // any other expr kind -> inconclusive
     return v
 }
 
 func f_eval_bin(ni) (v) {
-    v = 0
+    v = fv_int(0)
     n := nodes[ni]
     op := n.s
     l := f_eval(n.a)
     if g_fstatus != 0 { return v }
-    // short-circuit boolean ops (values modeled as 0/1)
-    if op == "&&" { if l == 0 { v = 0  return v }  r := f_eval(n.b)  if r != 0 { v = 1 }  return v }
-    if op == "||" { if l != 0 { v = 1  return v }  r := f_eval(n.b)  if r != 0 { v = 1 }  return v }
+    if l.k != 0 { g_fstatus = 2  return v }
+    // short-circuit boolean ops (0/1)
+    if op == "&&" { if l.i == 0 { v = fv_int(0)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
+    if op == "||" { if l.i != 0 { v = fv_int(1)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
     r := f_eval(n.b)
     if g_fstatus != 0 { return v }
-    if op == "+" { v = l + r  return v }
-    if op == "-" { v = l - r  return v }
-    if op == "*" { v = l * r  return v }
+    if r.k != 0 { g_fstatus = 2  return v }
+    a := l.i
+    b := r.i
+    if op == "+" { v = fv_int(a + b)  return v }
+    if op == "-" { v = fv_int(a - b)  return v }
+    if op == "*" { v = fv_int(a * b)  return v }
     if op == "/" {
-        if r == 0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
-        v = l / r  return v
+        if b == 0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
+        v = fv_int(a / b)  return v
     }
     if op == "%" {
-        if r == 0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
-        v = l % r  return v
+        if b == 0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
+        v = fv_int(a % b)  return v
     }
-    if op == "&" { v = l & r  return v }
-    if op == "|" { v = l | r  return v }
-    if op == "^" { v = l ^ r  return v }
-    if op == "<<" { v = l << r  return v }
-    if op == ">>" { v = l >> r  return v }
-    if op == "<" { if l < r { v = 1 }  return v }
-    if op == "<=" { if l <= r { v = 1 }  return v }
-    if op == ">" { if l > r { v = 1 }  return v }
-    if op == ">=" { if l >= r { v = 1 }  return v }
-    if op == "==" { if l == r { v = 1 }  return v }
-    if op == "!=" { if l != r { v = 1 }  return v }
+    if op == "&" { v = fv_int(a & b)  return v }
+    if op == "|" { v = fv_int(a | b)  return v }
+    if op == "^" { v = fv_int(a ^ b)  return v }
+    if op == "<<" { v = fv_int(a << b)  return v }
+    if op == ">>" { v = fv_int(a >> b)  return v }
+    if op == "<" { if a < b { v = fv_int(1) }  return v }
+    if op == "<=" { if a <= b { v = fv_int(1) }  return v }
+    if op == ">" { if a > b { v = fv_int(1) }  return v }
+    if op == ">=" { if a >= b { v = fv_int(1) }  return v }
+    if op == "==" { if a == b { v = fv_int(1) }  return v }
+    if op == "!=" { if a != b { v = fv_int(1) }  return v }
     g_fstatus = 2  return v
 }
 
-// ---- statement evaluation (spike: return + assign + if) ----
+// ---- statement evaluation ----
+
+func f_stopped() (s) {
+    s = 0
+    if g_fstatus != 0 || g_freturned == 1 || g_fbreak == 1 || g_fcontinue == 1 { s = 1 }
+    return s
+}
 
 func f_eval_stmts(kids) {
     i := 0
     for i < len(kids) {
         f_eval_stmt(kids[i])
-        if g_fstatus != 0 || g_freturned == 1 { return }
+        if f_stopped() == 1 { return }
         i = i + 1
     }
 }
 
 func f_eval_stmt(si) {
+    f_tick()
+    if g_fstatus != 0 { return }
     n := nodes[si]
     if n.kind == K_RETURN {
         i := 0
@@ -134,10 +196,66 @@ func f_eval_stmt(si) {
         f_env_set(n.s, val)
         return
     }
+    if n.kind == K_EXPRSTMT { f_eval(n.a)  return }
+    if n.kind == K_BREAK { g_fbreak = 1  return }
+    if n.kind == K_CONTINUE { g_fcontinue = 1  return }
     if n.kind == K_IF {
         c := f_eval(n.a)
         if g_fstatus != 0 { return }
-        if c != 0 { f_eval_stmts(n.kids) } else { f_eval_stmts(n.kids2) }
+        if c.k != 0 { g_fstatus = 2  return }
+        if c.i != 0 { f_eval_stmts(n.kids) } else { f_eval_stmts(n.kids2) }
+        return
+    }
+    if n.kind == K_WHILE {
+        loop := 1
+        for loop == 1 {
+            c := f_eval(n.a)
+            if g_fstatus != 0 { return }
+            if c.k != 0 { g_fstatus = 2  return }
+            if c.i == 0 { loop = 0 } else {
+                f_eval_stmts(n.kids)
+                if g_fstatus != 0 { return }
+                if g_freturned == 1 { return }
+                if g_fbreak == 1 { g_fbreak = 0  loop = 0 } else {
+                    if g_fcontinue == 1 { g_fcontinue = 0 }
+                }
+            }
+        }
+        return
+    }
+    if n.kind == K_RANGE {
+        base := f_eval(n.a)
+        if g_fstatus != 0 { return }
+        if base.k != 1 { g_fstatus = 2  return }   // range over non-slice (string/map) -> unknown (later)
+        ix := 0
+        for ix < len(base.sl) {
+            if n.s != "" && n.s != "_" { f_env_set(n.s, fv_int(ix)) }
+            if n.s2 != "" && n.s2 != "_" { f_env_set(n.s2, fv_int(base.sl[ix])) }
+            f_eval_stmts(n.kids)
+            if g_fstatus != 0 { return }
+            if g_freturned == 1 { return }
+            if g_fbreak == 1 { g_fbreak = 0  ix = len(base.sl) } else {
+                if g_fcontinue == 1 { g_fcontinue = 0 }
+                ix = ix + 1
+            }
+        }
+        return
+    }
+    if n.kind == K_IDXASSIGN {
+        idxn := nodes[n.a]
+        base := f_eval(idxn.a)
+        if g_fstatus != 0 { return }
+        ixv := f_eval(idxn.b)
+        if g_fstatus != 0 { return }
+        if base.k != 1 { g_fstatus = 2  return }
+        if ixv.k != 0 { g_fstatus = 2  return }
+        if ixv.i < 0 || ixv.i >= len(base.sl) {
+            g_fstatus = 1  g_fviol_prop = "index out of range"  g_fviol_expr = f_render(n.a, 0)  return
+        }
+        val := f_eval(n.b)
+        if g_fstatus != 0 { return }
+        if val.k != 0 { g_fstatus = 2  return }
+        base.sl[ixv.i] = val.i   // slices share backing (MFL reference semantics)
         return
     }
     g_fstatus = 2   // unsupported stmt -> inconclusive
@@ -159,8 +277,21 @@ func f_render(ni, parent) (out) {
     out = "?"
     n := nodes[ni]
     if n.kind == K_INT { out = str(n.ival)  return out }
+    if n.kind == K_BOOL { if n.ival != 0 { out = "true" } else { out = "false" }  return out }
     if n.kind == K_ID { out = n.s  return out }
     if n.kind == K_UNARY { out = n.s + f_render(n.a, 6)  return out }
+    if n.kind == K_INDEX { out = f_render(n.a, 7) + "[" + f_render(n.b, 0) + "]"  return out }
+    if n.kind == K_CALL {
+        out = n.s + "("
+        i := 0
+        for i < len(n.kids) {
+            if i > 0 { out = out + ", " }
+            out = out + f_render(n.kids[i], 0)
+            i = i + 1
+        }
+        out = out + ")"
+        return out
+    }
     if n.kind == K_BIN {
         p := f_binprec(n.s)
         s := f_render(n.a, p) + " " + n.s + " " + f_render(n.b, p + 1)
@@ -197,59 +328,122 @@ func f_bind(names, vals) (out) {
     i := 0
     for i < len(names) {
         if i > 0 { out = out + ", " }
-        out = out + names[i] + "=" + str(vals[i])
+        out = out + names[i] + "=" + fv_str(vals[i])
         i = i + 1
     }
     return out
 }
 
+// ---- domains ----
+
 // int domain — MUST match falsIntDomain = {0, 1, -1, 2, 3} order exactly
 func f_intdom(i) (v) {
-    v = 0
-    if i == 1 { v = 1 }
-    if i == 2 { v = 0 - 1 }
-    if i == 3 { v = 2 }
-    if i == 4 { v = 3 }
+    v = fv_int(0)
+    if i == 1 { v = fv_int(1) }
+    if i == 2 { v = fv_int(0 - 1) }
+    if i == 3 { v = fv_int(2) }
+    if i == 4 { v = fv_int(3) }
     return v
+}
+
+// []int domain — MUST match falsify.go domain(KSlice): lengths 0..3, elements from
+// {0,1,2}, in gen()'s lexicographic order (first element outermost). 40 values.
+var g_slicedom = []FV{}
+var g_slicedom_ready = 0
+
+func f_init_slicedom() {
+    if g_slicedom_ready == 1 { return }
+    g_slicedom = []FV{}
+    g_slicedom = append(g_slicedom, fv_slice([]int{}))     // length 0
+    a := 0
+    for a < 3 {                                            // length 1
+        g_slicedom = append(g_slicedom, fv_slice([]int{a}))
+        a = a + 1
+    }
+    a = 0
+    for a < 3 {                                            // length 2
+        b := 0
+        for b < 3 {
+            g_slicedom = append(g_slicedom, fv_slice([]int{a, b}))
+            b = b + 1
+        }
+        a = a + 1
+    }
+    a = 0
+    for a < 3 {                                            // length 3
+        b := 0
+        for b < 3 {
+            c := 0
+            for c < 3 {
+                g_slicedom = append(g_slicedom, fv_slice([]int{a, b, c}))
+                c = c + 1
+            }
+            b = b + 1
+        }
+        a = a + 1
+    }
+    g_slicedom_ready = 1
+}
+
+// f_dom_size / f_dom_val: pkind 0 = int (5 values), 1 = []int (40 values)
+func f_dom_size(pkind) (n) {
+    n = 5
+    if pkind == 1 { n = len(g_slicedom) }
+    return n
+}
+func f_dom_val(pkind, i) (fv) {
+    fv = f_intdom(i)
+    if pkind == 1 { fv = g_slicedom[i] }
+    return fv
 }
 
 // ---- the pass ----
 
-func f_one(iid, fr) {
+func f_one(iid, fr, pkinds) {
     ins := g_insts[iid]
     np := len(ins.pnames)
     body := nodes[fr].kids
 
     idx := []int{}
+    sizes := []int{}
     k := 0
-    for k < np { idx = append(idx, 0)  k = k + 1 }
+    for k < np {
+        idx = append(idx, 0)
+        sizes = append(sizes, f_dom_size(pkinds[k]))
+        k = k + 1
+    }
 
     done := 0
     for done == 0 {
         f_env_reset()
-        vals := []int{}
+        vals := []FV{}
         pi := 0
         for pi < np {
-            v := f_intdom(idx[pi])
-            f_env_set(ins.pnames[pi], v)
-            vals = append(vals, v)
+            fv := f_dom_val(pkinds[pi], idx[pi])
+            f_env_set(ins.pnames[pi], fv)
+            vals = append(vals, fv)
             pi = pi + 1
         }
         g_fstatus = 0
         g_fviol_prop = ""
         g_fviol_expr = ""
         g_freturned = 0
+        g_fbreak = 0
+        g_fcontinue = 0
+        g_fsteps = 0
         f_eval_stmts(body)
         if g_fstatus == 1 {
-            f_record(ins.src, "FALS002", g_fviol_prop, g_fviol_expr, f_bind(ins.pnames, vals))
-            return   // first counterexample per function
+            code := "FALS002"
+            if has_prefix(g_fviol_prop, "index") { code = "FALS001" }
+            f_record(ins.src, code, g_fviol_prop, g_fviol_expr, f_bind(ins.pnames, vals))
+            return
         }
         // mixed-radix increment (idx[0] least significant), matching falsifyOne
         carried := 1
         kk := 0
         for kk < np {
             idx[kk] = idx[kk] + 1
-            if idx[kk] < 5 { carried = 0  break }
+            if idx[kk] < sizes[kk] { carried = 0  break }
             idx[kk] = 0
             kk = kk + 1
         }
@@ -258,30 +452,39 @@ func f_one(iid, fr) {
 }
 
 func detect_falsifiable() {
+    f_init_slicedom()
     ri := 0
     for ri < len(g_insts) {
         ins := g_insts[ri]
         fr := func_root(ins.src)
         if fr >= 0 {
             scoped := 1
+            pkinds := []int{}
             pi := 0
             for pi < len(ins.pslots) {
-                if kind_of(ins.pslots[pi]) != 2 { scoped = 0 }   // 2 = KInt
+                s := ins.pslots[pi]
+                ks := kind_of(s)
+                pk := 0
+                if ks == 2 { pk = 0 } else {
+                    if ks == 7 {
+                        es := g_elem[find(s)]
+                        if kind_of(es) == 2 { pk = 1 } else { scoped = 0 }
+                    } else { scoped = 0 }
+                }
+                pkinds = append(pkinds, pk)
                 pi = pi + 1
             }
-            if scoped == 1 { f_one(ri, fr) }
+            if scoped == 1 { f_one(ri, fr, pkinds) }
         }
         ri = ri + 1
     }
 }
 
-// dump: findings sorted by (decl, code, expr), one hex line each — matches the
-// Go oracle's detectFalsifiable sort order + falsifytest hex form.
+// dump: findings sorted by (decl, code, expr), one hex line each.
 func f_dump() (out) {
     order := []int{}
     k := 0
     for k < len(g_ff_decl) {
-        // insertion into `order` by (decl, code, expr)
         pos := len(order)
         j := 0
         for j < len(order) {

--- a/selfhost/falsify.src
+++ b/selfhost/falsify.src
@@ -73,6 +73,8 @@ var g_freturned = 0
 var g_fbreak = 0
 var g_fcontinue = 0
 var g_fsteps = 0         // step budget guard (matches falsStepBudget); non-terminating -> unknown on both sides
+var g_fretval = FV{k: 0, i: 0}   // last function's return value (read right after a call returns)
+var g_fdepth = 0                 // interprocedural inlining depth (recursion guard)
 
 func f_tick() {
     g_fsteps = g_fsteps + 1
@@ -166,7 +168,19 @@ func f_eval(ni) (v) {
             if a.k == 3 { v = fv_int(len(a.s))  return v }
             g_fstatus = 2  return v
         }
-        g_fstatus = 2  return v   // other calls -> unknown (interprocedural is a later slice)
+        if n.s == "abs" && len(n.kids) == 1 {
+            a := f_eval(n.kids[0])            // MFL abs is (number) -> float
+            if g_fstatus != 0 { return v }
+            if a.k == 0 { v = fv_float(f_absf(float(a.i)))  return v }
+            if a.k == 2 { v = fv_float(f_absf(a.f))  return v }
+            g_fstatus = 2  return v
+        }
+        // user function: inline it (interprocedural). Spread calls + non-user
+        // callees (str/println/other builtins) are inconclusive — and, crucially,
+        // their args are NOT evaluated (matches falsify.go evalCall).
+        fr := func_root(n.s)
+        if fr >= 0 && n.ival == 0 { v = f_call_user(fr, n.kids)  return v }
+        g_fstatus = 2  return v
     }
     if n.kind == K_STRUCT { v = f_eval_struct(ni)  return v }
     if n.kind == K_FIELD {
@@ -232,6 +246,65 @@ func f_zero_for_type(t) (v) {
     if t == "bool" { v = fv_bool(0) }
     if t == "string" { v = fv_string("") }
     return v
+}
+
+func f_absf(x) (r) {
+    r = x
+    if x < 0.0 { r = 0.0 - x }
+    return r
+}
+
+// f_call_user inlines a user function: evaluate args in the caller frame, then
+// run the callee body in a fresh env (MFL has no closures/call stack, so the
+// global env is saved and restored around the call). A trap inside the callee is
+// reported against the ENCLOSING function with the callee's expression; the
+// callee's status/return propagate via the globals. Matches falsify.go callUser.
+func f_call_user(fnroot, argnodes) (rv) {
+    rv = fv_int(0)
+    if g_fdepth + 1 > 24 { g_fstatus = 2  return rv }   // falsCallDepth (recursion guard)
+    args := []FV{}
+    i := 0
+    for i < len(argnodes) {
+        a := f_eval(argnodes[i])
+        if g_fstatus != 0 { return rv }
+        args = append(args, a)
+        i = i + 1
+    }
+    fn := nodes[fnroot]
+    params := fn.names
+    rets := fn.names2
+
+    saved_names := g_env_names
+    saved_vals := g_env_vals
+    saved_returned := g_freturned
+    saved_break := g_fbreak
+    saved_continue := g_fcontinue
+
+    g_env_names = []string{}
+    g_env_vals = []FV{}
+    i = 0
+    for i < len(params) {
+        if i < len(args) { f_env_set(params[i], f_clone(args[i])) }
+        i = i + 1
+    }
+    i = 0
+    for i < len(rets) { f_env_set(rets[i], fv_int(0))  i = i + 1 }   // named returns zero-init
+
+    g_freturned = 0
+    g_fbreak = 0
+    g_fcontinue = 0
+    g_fretval = fv_int(0)
+    g_fdepth = g_fdepth + 1
+    f_eval_stmts(fn.kids)
+    rv = g_fretval
+    g_fdepth = g_fdepth - 1
+
+    g_env_names = saved_names
+    g_env_vals = saved_vals
+    g_freturned = saved_returned
+    g_fbreak = saved_break
+    g_fcontinue = saved_continue
+    return rv
 }
 
 func f_eval_bin(ni) (v) {
@@ -338,11 +411,17 @@ func f_eval_stmt(si) {
     if g_fstatus != 0 { return }
     n := nodes[si]
     if n.kind == K_RETURN {
-        i := 0
-        for i < len(n.kids) {
-            f_eval(n.kids[i])
+        if len(n.kids) == 1 {
+            g_fretval = f_eval(n.kids[0])
             if g_fstatus != 0 { return }
-            i = i + 1
+        } else {
+            i := 0
+            for i < len(n.kids) {   // 0 or multi: eval all for trap-checking
+                f_eval(n.kids[i])
+                if g_fstatus != 0 { return }
+                i = i + 1
+            }
+            g_fretval = fv_int(0)   // multi-return in expression position doesn't occur
         }
         g_freturned = 1
         return

--- a/selfhost/falsify.src
+++ b/selfhost/falsify.src
@@ -1,0 +1,323 @@
+// selfhost/falsify.src — The Falsifier, self-hosted (Phase 2).
+//
+// Ports falsify.go's detectFalsifiable over the self-hosted IR (nodes[] + g_insts),
+// oracle-diffed against `machin falsifytest --program`. The one structural change
+// forced by MFL: there is NO panic/recover, so the Go interpreter's panic(fviol)/
+// panic(funknown) unwinding is replaced by a threaded status global (g_fstatus)
+// that every eval site checks and early-returns on.
+//
+// Phase 2 slice 2.1 (feasibility spike): scalar-int params, arithmetic +
+// div/modulo-by-zero (FALS002). This proves the status-threading + enumeration +
+// precedence-rendering + hex-dump all reproduce the Go reference byte-for-byte.
+// Slices, structs, index-OOB (FALS001) and interprocedural inlining follow.
+
+// interpreter status: 0 ok, 1 violation (counterexample), 2 unknown (inconclusive)
+var g_fstatus = 0
+var g_fviol_prop = ""
+var g_fviol_expr = ""
+// returned-flag: MFL has no ctrlReturn, so a K_RETURN sets this and every stmt
+// loop stops on it (else execution falls through past a guarded early return).
+var g_freturned = 0
+
+// environment: parallel arrays, int scalars only (spike)
+var g_env_names = []string{}
+var g_env_vals = []int{}
+
+func f_env_reset() {
+    g_env_names = []string{}
+    g_env_vals = []int{}
+}
+
+func f_env_set(name, v) {
+    i := 0
+    for i < len(g_env_names) {
+        if g_env_names[i] == name { g_env_vals[i] = v  return }
+        i = i + 1
+    }
+    g_env_names = append(g_env_names, name)
+    g_env_vals = append(g_env_vals, v)
+}
+
+func f_env_get(name) (v) {
+    v = 0
+    i := 0
+    for i < len(g_env_names) {
+        if g_env_names[i] == name { v = g_env_vals[i]  return v }
+        i = i + 1
+    }
+    g_fstatus = 2   // free ident -> inconclusive (matches funknown)
+    return v
+}
+
+// ---- expression evaluation (int; status in g_fstatus) ----
+
+func f_eval(ni) (v) {
+    v = 0
+    if g_fstatus != 0 { return v }
+    n := nodes[ni]
+    if n.kind == K_INT { v = n.ival  return v }
+    if n.kind == K_ID { v = f_env_get(n.s)  return v }
+    if n.kind == K_UNARY {
+        x := f_eval(n.a)
+        if g_fstatus != 0 { return v }
+        if n.s == "-" { v = 0 - x  return v }
+        if n.s == "!" { if x == 0 { v = 1 }  return v }
+        g_fstatus = 2  return v
+    }
+    if n.kind == K_BIN { v = f_eval_bin(ni)  return v }
+    g_fstatus = 2   // any other expr kind -> inconclusive (spike scope)
+    return v
+}
+
+func f_eval_bin(ni) (v) {
+    v = 0
+    n := nodes[ni]
+    op := n.s
+    l := f_eval(n.a)
+    if g_fstatus != 0 { return v }
+    // short-circuit boolean ops (values modeled as 0/1)
+    if op == "&&" { if l == 0 { v = 0  return v }  r := f_eval(n.b)  if r != 0 { v = 1 }  return v }
+    if op == "||" { if l != 0 { v = 1  return v }  r := f_eval(n.b)  if r != 0 { v = 1 }  return v }
+    r := f_eval(n.b)
+    if g_fstatus != 0 { return v }
+    if op == "+" { v = l + r  return v }
+    if op == "-" { v = l - r  return v }
+    if op == "*" { v = l * r  return v }
+    if op == "/" {
+        if r == 0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
+        v = l / r  return v
+    }
+    if op == "%" {
+        if r == 0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
+        v = l % r  return v
+    }
+    if op == "&" { v = l & r  return v }
+    if op == "|" { v = l | r  return v }
+    if op == "^" { v = l ^ r  return v }
+    if op == "<<" { v = l << r  return v }
+    if op == ">>" { v = l >> r  return v }
+    if op == "<" { if l < r { v = 1 }  return v }
+    if op == "<=" { if l <= r { v = 1 }  return v }
+    if op == ">" { if l > r { v = 1 }  return v }
+    if op == ">=" { if l >= r { v = 1 }  return v }
+    if op == "==" { if l == r { v = 1 }  return v }
+    if op == "!=" { if l != r { v = 1 }  return v }
+    g_fstatus = 2  return v
+}
+
+// ---- statement evaluation (spike: return + assign + if) ----
+
+func f_eval_stmts(kids) {
+    i := 0
+    for i < len(kids) {
+        f_eval_stmt(kids[i])
+        if g_fstatus != 0 || g_freturned == 1 { return }
+        i = i + 1
+    }
+}
+
+func f_eval_stmt(si) {
+    n := nodes[si]
+    if n.kind == K_RETURN {
+        i := 0
+        for i < len(n.kids) {
+            f_eval(n.kids[i])
+            if g_fstatus != 0 { return }
+            i = i + 1
+        }
+        g_freturned = 1
+        return
+    }
+    if n.kind == K_ASSIGN {
+        val := f_eval(n.a)
+        if g_fstatus != 0 { return }
+        f_env_set(n.s, val)
+        return
+    }
+    if n.kind == K_IF {
+        c := f_eval(n.a)
+        if g_fstatus != 0 { return }
+        if c != 0 { f_eval_stmts(n.kids) } else { f_eval_stmts(n.kids2) }
+        return
+    }
+    g_fstatus = 2   // unsupported stmt -> inconclusive
+}
+
+// ---- precedence-correct rendering (must match falsify.go exprPrec byte-for-byte) ----
+
+func f_binprec(op) (p) {
+    p = 0
+    if op == "||" { p = 1  return p }
+    if op == "&&" { p = 2  return p }
+    if op == "==" || op == "!=" || op == "<" || op == "<=" || op == ">" || op == ">=" { p = 3  return p }
+    if op == "+" || op == "-" || op == "|" || op == "^" { p = 4  return p }
+    if op == "*" || op == "/" || op == "%" || op == "&" || op == "<<" || op == ">>" { p = 5  return p }
+    return p
+}
+
+func f_render(ni, parent) (out) {
+    out = "?"
+    n := nodes[ni]
+    if n.kind == K_INT { out = str(n.ival)  return out }
+    if n.kind == K_ID { out = n.s  return out }
+    if n.kind == K_UNARY { out = n.s + f_render(n.a, 6)  return out }
+    if n.kind == K_BIN {
+        p := f_binprec(n.s)
+        s := f_render(n.a, p) + " " + n.s + " " + f_render(n.b, p + 1)
+        if p < parent { out = "(" + s + ")"  return out }
+        out = s  return out
+    }
+    return out
+}
+
+// ---- findings (parallel arrays) ----
+
+var g_ff_decl = []string{}
+var g_ff_code = []string{}
+var g_ff_prop = []string{}
+var g_ff_expr = []string{}
+var g_ff_bind = []string{}
+
+func f_record(decl, code, prop, expr, bind) {
+    key := decl + "|" + code + "|" + expr
+    i := 0
+    for i < len(g_ff_decl) {
+        if g_ff_decl[i] + "|" + g_ff_code[i] + "|" + g_ff_expr[i] == key { return }
+        i = i + 1
+    }
+    g_ff_decl = append(g_ff_decl, decl)
+    g_ff_code = append(g_ff_code, code)
+    g_ff_prop = append(g_ff_prop, prop)
+    g_ff_expr = append(g_ff_expr, expr)
+    g_ff_bind = append(g_ff_bind, bind)
+}
+
+func f_bind(names, vals) (out) {
+    out = ""
+    i := 0
+    for i < len(names) {
+        if i > 0 { out = out + ", " }
+        out = out + names[i] + "=" + str(vals[i])
+        i = i + 1
+    }
+    return out
+}
+
+// int domain — MUST match falsIntDomain = {0, 1, -1, 2, 3} order exactly
+func f_intdom(i) (v) {
+    v = 0
+    if i == 1 { v = 1 }
+    if i == 2 { v = 0 - 1 }
+    if i == 3 { v = 2 }
+    if i == 4 { v = 3 }
+    return v
+}
+
+// ---- the pass ----
+
+func f_one(iid, fr) {
+    ins := g_insts[iid]
+    np := len(ins.pnames)
+    body := nodes[fr].kids
+
+    idx := []int{}
+    k := 0
+    for k < np { idx = append(idx, 0)  k = k + 1 }
+
+    done := 0
+    for done == 0 {
+        f_env_reset()
+        vals := []int{}
+        pi := 0
+        for pi < np {
+            v := f_intdom(idx[pi])
+            f_env_set(ins.pnames[pi], v)
+            vals = append(vals, v)
+            pi = pi + 1
+        }
+        g_fstatus = 0
+        g_fviol_prop = ""
+        g_fviol_expr = ""
+        g_freturned = 0
+        f_eval_stmts(body)
+        if g_fstatus == 1 {
+            f_record(ins.src, "FALS002", g_fviol_prop, g_fviol_expr, f_bind(ins.pnames, vals))
+            return   // first counterexample per function
+        }
+        // mixed-radix increment (idx[0] least significant), matching falsifyOne
+        carried := 1
+        kk := 0
+        for kk < np {
+            idx[kk] = idx[kk] + 1
+            if idx[kk] < 5 { carried = 0  break }
+            idx[kk] = 0
+            kk = kk + 1
+        }
+        if carried == 1 { done = 1 }
+    }
+}
+
+func detect_falsifiable() {
+    ri := 0
+    for ri < len(g_insts) {
+        ins := g_insts[ri]
+        fr := func_root(ins.src)
+        if fr >= 0 {
+            scoped := 1
+            pi := 0
+            for pi < len(ins.pslots) {
+                if kind_of(ins.pslots[pi]) != 2 { scoped = 0 }   // 2 = KInt
+                pi = pi + 1
+            }
+            if scoped == 1 { f_one(ri, fr) }
+        }
+        ri = ri + 1
+    }
+}
+
+// dump: findings sorted by (decl, code, expr), one hex line each — matches the
+// Go oracle's detectFalsifiable sort order + falsifytest hex form.
+func f_dump() (out) {
+    order := []int{}
+    k := 0
+    for k < len(g_ff_decl) {
+        // insertion into `order` by (decl, code, expr)
+        pos := len(order)
+        j := 0
+        for j < len(order) {
+            oj := order[j]
+            less := 0
+            if g_ff_decl[k] < g_ff_decl[oj] { less = 1 }
+            if g_ff_decl[k] == g_ff_decl[oj] {
+                if g_ff_code[k] < g_ff_code[oj] { less = 1 }
+                if g_ff_code[k] == g_ff_code[oj] {
+                    if g_ff_expr[k] < g_ff_expr[oj] { less = 1 }
+                }
+            }
+            if less == 1 { pos = j  break }
+            j = j + 1
+        }
+        order = insert_at(order, pos, k)
+        k = k + 1
+    }
+    out = ""
+    m := 0
+    for m < len(order) {
+        e := order[m]
+        out = out + to_hex(bytes(g_ff_decl[e])) + "|" + to_hex(bytes(g_ff_code[e])) + "|" + to_hex(bytes(g_ff_prop[e])) + "|" + to_hex(bytes(g_ff_expr[e])) + "|" + to_hex(bytes(g_ff_bind[e])) + "\n"
+        m = m + 1
+    }
+    return out
+}
+
+func insert_at(xs, pos, val) (out) {
+    out = []int{}
+    i := 0
+    for i < len(xs) {
+        if i == pos { out = append(out, val) }
+        out = append(out, xs[i])
+        i = i + 1
+    }
+    if pos >= len(xs) { out = append(out, val) }
+    return out
+}

--- a/selfhost/falsify.src
+++ b/selfhost/falsify.src
@@ -11,20 +11,49 @@
 // FV struct (MFL has no [][]int, but a []int field inside a []struct is fine).
 // Floats/strings, structs and interprocedural inlining follow in later slices.
 
-// ---- value model: FV is int (k=0), []int slice (k=1), float (k=2) or string (k=3) ----
-type FV struct { k int  i int  f float  s string  sl []int }
+// ---- value model ----
+// FV kinds: 0 int, 1 []int slice, 2 float, 3 string, 4 struct, 5 bool.
+type FV struct { k int  i int  f float  s string  sl []int  sname string  fields []FV  fnames []string }
 
 func fv_int(x) (fv) { fv = FV{k: 0, i: x} }
 func fv_slice(xs) (fv) { fv = FV{k: 1, sl: xs} }
 func fv_float(x) (fv) { fv = FV{k: 2, f: x} }
 func fv_string(x) (fv) { fv = FV{k: 3, s: x} }
+func fv_bool(bi) (fv) { fv = FV{k: 5, i: bi} }   // bi is 0/1
+
+// f_clone gives structs value semantics: a copy binds a fresh fields slice, so
+// mutating a copy's field cannot alias the original (matches falsify.go clone()).
+func f_clone(fv) (out) {
+    out = fv
+    if fv.k != 4 { return out }
+    nf := []FV{}
+    i := 0
+    for i < len(fv.fields) {
+        nf = append(nf, f_clone(fv.fields[i]))
+        i = i + 1
+    }
+    out.fields = nf
+    return out
+}
 
 // fv_str renders a value as its Go fval.String() form (%d int, %g float, %q
-// string, []int{...} slice) — used for counterexample bindings + must byte-match.
+// string, %v bool, []int{...} slice, T{f: v} struct) — must byte-match.
 func fv_str(fv) (out) {
     if fv.k == 0 { out = str(fv.i)  return out }
     if fv.k == 2 { out = str(fv.f)  return out }
     if fv.k == 3 { out = "\"" + fv.s + "\""  return out }
+    if fv.k == 5 { if fv.i != 0 { out = "true" } else { out = "false" }  return out }
+    if fv.k == 4 {
+        out = fv.sname + "{"
+        i := 0
+        for i < len(fv.fnames) {
+            if i > 0 { out = out + ", " }
+            out = out + fv.fnames[i] + ": " + fv_str(fv.fields[i])
+            i = i + 1
+        }
+        out = out + "}"
+        return out
+    }
     out = "[]int{"
     i := 0
     for i < len(fv.sl) {
@@ -91,7 +120,7 @@ func f_eval(ni) (v) {
     if n.kind == K_INT { v = fv_int(n.ival)  return v }
     if n.kind == K_FLOAT { v = fv_float(parse_float(n.s))  return v }
     if n.kind == K_STR { v = fv_string(n.s)  return v }
-    if n.kind == K_BOOL { if n.ival != 0 { v = fv_int(1) } else { v = fv_int(0) }  return v }
+    if n.kind == K_BOOL { v = fv_bool(n.ival)  return v }
     if n.kind == K_ID { v = f_env_get(n.s)  return v }
     if n.kind == K_UNARY {
         x := f_eval(n.a)
@@ -102,8 +131,8 @@ func f_eval(ni) (v) {
             g_fstatus = 2  return v
         }
         if n.s == "!" {
-            if x.k != 0 { g_fstatus = 2  return v }
-            if x.i == 0 { v = fv_int(1) } else { v = fv_int(0) }
+            if x.k != 5 { g_fstatus = 2  return v }
+            if x.i == 0 { v = fv_bool(1) } else { v = fv_bool(0) }
             return v
         }
         g_fstatus = 2  return v
@@ -139,7 +168,69 @@ func f_eval(ni) (v) {
         }
         g_fstatus = 2  return v   // other calls -> unknown (interprocedural is a later slice)
     }
+    if n.kind == K_STRUCT { v = f_eval_struct(ni)  return v }
+    if n.kind == K_FIELD {
+        base := f_eval(n.a)
+        if g_fstatus != 0 { return v }
+        if base.k != 4 { g_fstatus = 2  return v }
+        j := 0
+        for j < len(base.fnames) {
+            if base.fnames[j] == n.s { v = base.fields[j]  return v }
+            j = j + 1
+        }
+        g_fstatus = 2  return v
+    }
     g_fstatus = 2   // any other expr kind -> inconclusive
+    return v
+}
+
+// f_eval_struct builds a struct value from a K_STRUCT literal, in the struct's
+// DECLARED field order (named literals matched by name, positional by index,
+// omitted fields zero-filled) — mirrors falsify.go evalStructLit.
+func f_eval_struct(ni) (v) {
+    v = fv_int(0)
+    n := nodes[ni]
+    nm := n.s
+    nf := struct_field_count(nm)
+    fnames := []string{}
+    fields := []FV{}
+    named := 0
+    if len(n.names) > 0 { named = 1 }
+    k := 0
+    for k < nf {
+        fnm := f_struct_fname(nm, k)
+        val := f_zero_for_type(struct_field_type_at(nm, k))
+        if named == 1 {
+            j := 0
+            for j < len(n.names) {
+                if n.names[j] == fnm { val = f_eval(n.kids[j]) }
+                j = j + 1
+            }
+        } else {
+            if k < len(n.kids) { val = f_eval(n.kids[k]) }
+        }
+        if g_fstatus != 0 { return v }
+        fnames = append(fnames, fnm)
+        fields = append(fields, val)
+        k = k + 1
+    }
+    v = FV{k: 4, sname: nm, fields: fields, fnames: fnames}
+    return v
+}
+
+func f_struct_fname(nm, ix) (out) {
+    out = ""
+    for _, d := range g_structdefs {
+        if d.name == nm { out = d.fnames[ix]  return out }
+    }
+    return out
+}
+
+func f_zero_for_type(t) (v) {
+    v = fv_int(0)
+    if t == "float" { v = fv_float(0.0) }
+    if t == "bool" { v = fv_bool(0) }
+    if t == "string" { v = fv_string("") }
     return v
 }
 
@@ -149,11 +240,18 @@ func f_eval_bin(ni) (v) {
     op := n.s
     l := f_eval(n.a)
     if g_fstatus != 0 { return v }
-    // short-circuit boolean ops (0/1); operands are int-modeled bools
-    if op == "&&" { if l.k != 0 { g_fstatus = 2  return v }  if l.i == 0 { v = fv_int(0)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
-    if op == "||" { if l.k != 0 { g_fstatus = 2  return v }  if l.i != 0 { v = fv_int(1)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
+    // short-circuit boolean ops (operands are bool k=5); result bool
+    if op == "&&" { if l.k != 5 { g_fstatus = 2  return v }  if l.i == 0 { v = fv_bool(0)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 5 { g_fstatus = 2  return v }  v = fv_bool(r.i)  return v }
+    if op == "||" { if l.k != 5 { g_fstatus = 2  return v }  if l.i != 0 { v = fv_bool(1)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 5 { g_fstatus = 2  return v }  v = fv_bool(r.i)  return v }
     r := f_eval(n.b)
     if g_fstatus != 0 { return v }
+    // bool branch (==, != between bools)
+    if l.k == 5 {
+        if r.k != 5 { g_fstatus = 2  return v }
+        if op == "==" { if l.i == r.i { v = fv_bool(1) } else { v = fv_bool(0) }  return v }
+        if op == "!=" { if l.i != r.i { v = fv_bool(1) } else { v = fv_bool(0) }  return v }
+        g_fstatus = 2  return v
+    }
     // float branch (Go: either operand KFloat) — int operands promote
     if l.k == 2 || r.k == 2 {
         if l.k != 0 && l.k != 2 { g_fstatus = 2  return v }
@@ -169,24 +267,24 @@ func f_eval_bin(ni) (v) {
             if rf == 0.0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
             v = fv_float(lf / rf)  return v
         }
-        if op == "<" { if lf < rf { v = fv_int(1) }  return v }
-        if op == "<=" { if lf <= rf { v = fv_int(1) }  return v }
-        if op == ">" { if lf > rf { v = fv_int(1) }  return v }
-        if op == ">=" { if lf >= rf { v = fv_int(1) }  return v }
-        if op == "==" { if lf == rf { v = fv_int(1) }  return v }
-        if op == "!=" { if lf != rf { v = fv_int(1) }  return v }
+        if op == "<" { v = fv_bool(0)  if lf < rf { v = fv_bool(1) }  return v }
+        if op == "<=" { v = fv_bool(0)  if lf <= rf { v = fv_bool(1) }  return v }
+        if op == ">" { v = fv_bool(0)  if lf > rf { v = fv_bool(1) }  return v }
+        if op == ">=" { v = fv_bool(0)  if lf >= rf { v = fv_bool(1) }  return v }
+        if op == "==" { v = fv_bool(0)  if lf == rf { v = fv_bool(1) }  return v }
+        if op == "!=" { v = fv_bool(0)  if lf != rf { v = fv_bool(1) }  return v }
         g_fstatus = 2  return v
     }
     // string branch
     if l.k == 3 {
         if r.k != 3 { g_fstatus = 2  return v }
         if op == "+" { v = fv_string(l.s + r.s)  return v }
-        if op == "==" { if l.s == r.s { v = fv_int(1) }  return v }
-        if op == "!=" { if l.s != r.s { v = fv_int(1) }  return v }
-        if op == "<" { if l.s < r.s { v = fv_int(1) }  return v }
-        if op == ">" { if l.s > r.s { v = fv_int(1) }  return v }
-        if op == "<=" { if l.s <= r.s { v = fv_int(1) }  return v }
-        if op == ">=" { if l.s >= r.s { v = fv_int(1) }  return v }
+        if op == "==" { v = fv_bool(0)  if l.s == r.s { v = fv_bool(1) }  return v }
+        if op == "!=" { v = fv_bool(0)  if l.s != r.s { v = fv_bool(1) }  return v }
+        if op == "<" { v = fv_bool(0)  if l.s < r.s { v = fv_bool(1) }  return v }
+        if op == ">" { v = fv_bool(0)  if l.s > r.s { v = fv_bool(1) }  return v }
+        if op == "<=" { v = fv_bool(0)  if l.s <= r.s { v = fv_bool(1) }  return v }
+        if op == ">=" { v = fv_bool(0)  if l.s >= r.s { v = fv_bool(1) }  return v }
         g_fstatus = 2  return v
     }
     // int branch
@@ -209,12 +307,12 @@ func f_eval_bin(ni) (v) {
     if op == "^" { v = fv_int(a ^ b)  return v }
     if op == "<<" { v = fv_int(a << b)  return v }
     if op == ">>" { v = fv_int(a >> b)  return v }
-    if op == "<" { if a < b { v = fv_int(1) }  return v }
-    if op == "<=" { if a <= b { v = fv_int(1) }  return v }
-    if op == ">" { if a > b { v = fv_int(1) }  return v }
-    if op == ">=" { if a >= b { v = fv_int(1) }  return v }
-    if op == "==" { if a == b { v = fv_int(1) }  return v }
-    if op == "!=" { if a != b { v = fv_int(1) }  return v }
+    if op == "<" { v = fv_bool(0)  if a < b { v = fv_bool(1) }  return v }
+    if op == "<=" { v = fv_bool(0)  if a <= b { v = fv_bool(1) }  return v }
+    if op == ">" { v = fv_bool(0)  if a > b { v = fv_bool(1) }  return v }
+    if op == ">=" { v = fv_bool(0)  if a >= b { v = fv_bool(1) }  return v }
+    if op == "==" { v = fv_bool(0)  if a == b { v = fv_bool(1) }  return v }
+    if op == "!=" { v = fv_bool(0)  if a != b { v = fv_bool(1) }  return v }
     g_fstatus = 2  return v
 }
 
@@ -252,7 +350,26 @@ func f_eval_stmt(si) {
     if n.kind == K_ASSIGN {
         val := f_eval(n.a)
         if g_fstatus != 0 { return }
-        f_env_set(n.s, val)
+        f_env_set(n.s, f_clone(val))   // value semantics for struct copies
+        return
+    }
+    if n.kind == K_FLDASSIGN {
+        fld := nodes[n.a]              // K_FIELD node: a = X, s = field name
+        xn := nodes[fld.a]
+        if xn.kind != K_ID { g_fstatus = 2  return }
+        base := f_env_get(xn.s)
+        if g_fstatus != 0 { return }
+        if base.k != 4 { g_fstatus = 2  return }
+        val := f_eval(n.b)
+        if g_fstatus != 0 { return }
+        j := 0
+        done := 0
+        for j < len(base.fnames) {
+            if base.fnames[j] == fld.s { base.fields[j] = val  done = 1 }
+            j = j + 1
+        }
+        if done == 0 { g_fstatus = 2  return }
+        f_env_set(xn.s, base)
         return
     }
     if n.kind == K_EXPRSTMT { f_eval(n.a)  return }
@@ -261,7 +378,7 @@ func f_eval_stmt(si) {
     if n.kind == K_IF {
         c := f_eval(n.a)
         if g_fstatus != 0 { return }
-        if c.k != 0 { g_fstatus = 2  return }
+        if c.k != 5 { g_fstatus = 2  return }
         if c.i != 0 { f_eval_stmts(n.kids) } else { f_eval_stmts(n.kids2) }
         return
     }
@@ -270,7 +387,7 @@ func f_eval_stmt(si) {
         for loop == 1 {
             c := f_eval(n.a)
             if g_fstatus != 0 { return }
-            if c.k != 0 { g_fstatus = 2  return }
+            if c.k != 5 { g_fstatus = 2  return }
             if c.i == 0 { loop = 0 } else {
                 f_eval_stmts(n.kids)
                 if g_fstatus != 0 { return }
@@ -346,6 +463,7 @@ func f_render(ni, parent) (out) {
     if n.kind == K_ID { out = n.s  return out }
     if n.kind == K_UNARY { out = n.s + f_render(n.a, 6)  return out }
     if n.kind == K_INDEX { out = f_render(n.a, 7) + "[" + f_render(n.b, 0) + "]"  return out }
+    if n.kind == K_FIELD { out = f_render(n.a, 7) + "." + n.s  return out }
     if n.kind == K_CALL {
         out = n.s + "("
         i := 0
@@ -467,25 +585,87 @@ func f_init_slicedom() {
     g_slicedom_ready = 1
 }
 
-// f_dom_size / f_dom_val: pkind 0=int(5), 1=[]int(40), 2=float(4), 3=string(3)
-func f_dom_size(pkind) (n) {
+// scalar field domains (used inside struct enumeration) — match falsify.go
+// scalarDomain: int {0,1,-1}, float {0,1}, bool {false,true}, string {"","a"}.
+func f_scalar_dom_size(t) (n) {
+    n = 0
+    if t == "int" { n = 3 }
+    if t == "float" { n = 2 }
+    if t == "bool" { n = 2 }
+    if t == "string" { n = 2 }
+    return n
+}
+func f_scalar_dom_val(t, j) (v) {
+    v = fv_int(0)
+    if t == "int" { if j == 1 { v = fv_int(1) }  if j == 2 { v = fv_int(0 - 1) }  return v }
+    if t == "float" { if j == 1 { v = fv_float(1.0) } else { v = fv_float(0.0) }  return v }
+    if t == "bool" { if j == 1 { v = fv_bool(1) } else { v = fv_bool(0) }  return v }
+    if t == "string" { if j == 1 { v = fv_string("a") } else { v = fv_string("") }  return v }
+    return v
+}
+
+// f_struct_dom_size: product of the struct's scalar-field domains, or 0 if any
+// field is non-scalar or the product exceeds falsStructDomCap (-> out of scope).
+func f_struct_dom_size(nm) (n) {
+    n = 1
+    nf := struct_field_count(nm)
+    k := 0
+    for k < nf {
+        sz := f_scalar_dom_size(struct_field_type_at(nm, k))
+        if sz == 0 { n = 0  return n }
+        n = n * sz
+        if n > 4096 { n = 0  return n }
+        k = k + 1
+    }
+    return n
+}
+
+// f_struct_dom_val: the idx-th struct value (mixed-radix over fields, field[0]
+// least significant — matches falsify.go structDomain's counter order).
+func f_struct_dom_val(nm, idx) (v) {
+    v = fv_int(0)
+    nf := struct_field_count(nm)
+    fnames := []string{}
+    fields := []FV{}
+    tmp := idx
+    k := 0
+    for k < nf {
+        t := struct_field_type_at(nm, k)
+        sz := f_scalar_dom_size(t)
+        ck := tmp % sz
+        tmp = tmp / sz
+        fnames = append(fnames, f_struct_fname(nm, k))
+        fields = append(fields, f_scalar_dom_val(t, ck))
+        k = k + 1
+    }
+    v = FV{k: 4, sname: nm, fields: fields, fnames: fnames}
+    return v
+}
+
+// f_dom_size / f_dom_val: pkind 0=int(5), 1=[]int(40), 2=float(4), 3=string(3),
+// 4=bool(2), 5=struct (sname's product). sname is "" for non-struct params.
+func f_dom_size(pkind, sname) (n) {
     n = 5
     if pkind == 1 { n = len(g_slicedom) }
     if pkind == 2 { n = 4 }
     if pkind == 3 { n = 3 }
+    if pkind == 4 { n = 2 }
+    if pkind == 5 { n = f_struct_dom_size(sname) }
     return n
 }
-func f_dom_val(pkind, i) (fv) {
+func f_dom_val(pkind, sname, i) (fv) {
     fv = f_intdom(i)
     if pkind == 1 { fv = g_slicedom[i] }
     if pkind == 2 { fv = f_floatdom(i) }
     if pkind == 3 { fv = f_stringdom(i) }
+    if pkind == 4 { fv = fv_bool(0)  if i == 1 { fv = fv_bool(1) } }
+    if pkind == 5 { fv = f_struct_dom_val(sname, i) }
     return fv
 }
 
 // ---- the pass ----
 
-func f_one(iid, fr, pkinds) {
+func f_one(iid, fr, pkinds, psnames) {
     ins := g_insts[iid]
     np := len(ins.pnames)
     body := nodes[fr].kids
@@ -495,18 +675,19 @@ func f_one(iid, fr, pkinds) {
     k := 0
     for k < np {
         idx = append(idx, 0)
-        sizes = append(sizes, f_dom_size(pkinds[k]))
+        sizes = append(sizes, f_dom_size(pkinds[k], psnames[k]))
         k = k + 1
     }
 
+    tried := 0
     done := 0
     for done == 0 {
         f_env_reset()
         vals := []FV{}
         pi := 0
         for pi < np {
-            fv := f_dom_val(pkinds[pi], idx[pi])
-            f_env_set(ins.pnames[pi], fv)
+            fv := f_dom_val(pkinds[pi], psnames[pi], idx[pi])
+            f_env_set(ins.pnames[pi], f_clone(fv))
             vals = append(vals, fv)
             pi = pi + 1
         }
@@ -524,6 +705,8 @@ func f_one(iid, fr, pkinds) {
             f_record(ins.src, code, g_fviol_prop, g_fviol_expr, f_bind(ins.pnames, vals))
             return
         }
+        tried = tried + 1
+        if tried >= 200000 { done = 1 }   // falsInputCap: cap tuples per function
         // mixed-radix increment (idx[0] least significant), matching falsifyOne
         carried := 1
         kk := 0
@@ -546,25 +729,36 @@ func detect_falsifiable() {
         if fr >= 0 {
             scoped := 1
             pkinds := []int{}
+            psnames := []string{}
             pi := 0
             for pi < len(ins.pslots) {
                 s := ins.pslots[pi]
                 ks := kind_of(s)
                 pk := 0
+                sn := ""
                 if ks == 2 { pk = 0 } else {
                     if ks == 3 { pk = 2 } else {              // KFloat
-                        if ks == 5 { pk = 3 } else {          // KString
-                            if ks == 7 {                       // KSlice
-                                es := g_elem[find(s)]
-                                if kind_of(es) == 2 { pk = 1 } else { scoped = 0 }
-                            } else { scoped = 0 }
+                        if ks == 4 { pk = 4 } else {          // KBool
+                            if ks == 5 { pk = 3 } else {      // KString
+                                if ks == 7 {                   // KSlice
+                                    es := g_elem[find(s)]
+                                    if kind_of(es) == 2 { pk = 1 } else { scoped = 0 }
+                                } else {
+                                    if ks == 8 {               // KStruct
+                                        pk = 5
+                                        sn = g_sname[find(s)]
+                                        if f_struct_dom_size(sn) == 0 { scoped = 0 }
+                                    } else { scoped = 0 }
+                                }
+                            }
                         }
                     }
                 }
                 pkinds = append(pkinds, pk)
+                psnames = append(psnames, sn)
                 pi = pi + 1
             }
-            if scoped == 1 { f_one(ri, fr, pkinds) }
+            if scoped == 1 { f_one(ri, fr, pkinds, psnames) }
         }
         ri = ri + 1
     }

--- a/selfhost/falsify.src
+++ b/selfhost/falsify.src
@@ -11,23 +11,29 @@
 // FV struct (MFL has no [][]int, but a []int field inside a []struct is fine).
 // Floats/strings, structs and interprocedural inlining follow in later slices.
 
-// ---- value model: FV is int (k=0) or []int slice (k=1) ----
-type FV struct { k int  i int  sl []int }
+// ---- value model: FV is int (k=0), []int slice (k=1), float (k=2) or string (k=3) ----
+type FV struct { k int  i int  f float  s string  sl []int }
 
 func fv_int(x) (fv) { fv = FV{k: 0, i: x} }
 func fv_slice(xs) (fv) { fv = FV{k: 1, sl: xs} }
+func fv_float(x) (fv) { fv = FV{k: 2, f: x} }
+func fv_string(x) (fv) { fv = FV{k: 3, s: x} }
 
-func fv_str(fv) (s) {
-    if fv.k == 0 { s = str(fv.i)  return s }
-    s = "[]int{"
+// fv_str renders a value as its Go fval.String() form (%d int, %g float, %q
+// string, []int{...} slice) — used for counterexample bindings + must byte-match.
+func fv_str(fv) (out) {
+    if fv.k == 0 { out = str(fv.i)  return out }
+    if fv.k == 2 { out = str(fv.f)  return out }
+    if fv.k == 3 { out = "\"" + fv.s + "\""  return out }
+    out = "[]int{"
     i := 0
     for i < len(fv.sl) {
-        if i > 0 { s = s + ", " }
-        s = s + str(fv.sl[i])
+        if i > 0 { out = out + ", " }
+        out = out + str(fv.sl[i])
         i = i + 1
     }
-    s = s + "}"
-    return s
+    out = out + "}"
+    return out
 }
 
 // ---- interpreter status + control flow (replace panic/recover + ctrl returns) ----
@@ -83,14 +89,23 @@ func f_eval(ni) (v) {
     if g_fstatus != 0 { return v }
     n := nodes[ni]
     if n.kind == K_INT { v = fv_int(n.ival)  return v }
+    if n.kind == K_FLOAT { v = fv_float(parse_float(n.s))  return v }
+    if n.kind == K_STR { v = fv_string(n.s)  return v }
     if n.kind == K_BOOL { if n.ival != 0 { v = fv_int(1) } else { v = fv_int(0) }  return v }
     if n.kind == K_ID { v = f_env_get(n.s)  return v }
     if n.kind == K_UNARY {
         x := f_eval(n.a)
         if g_fstatus != 0 { return v }
-        if x.k != 0 { g_fstatus = 2  return v }
-        if n.s == "-" { v = fv_int(0 - x.i)  return v }
-        if n.s == "!" { if x.i == 0 { v = fv_int(1) } else { v = fv_int(0) }  return v }
+        if n.s == "-" {
+            if x.k == 2 { v = fv_float(0.0 - x.f)  return v }
+            if x.k == 0 { v = fv_int(0 - x.i)  return v }
+            g_fstatus = 2  return v
+        }
+        if n.s == "!" {
+            if x.k != 0 { g_fstatus = 2  return v }
+            if x.i == 0 { v = fv_int(1) } else { v = fv_int(0) }
+            return v
+        }
         g_fstatus = 2  return v
     }
     if n.kind == K_BIN { v = f_eval_bin(ni)  return v }
@@ -99,19 +114,28 @@ func f_eval(ni) (v) {
         if g_fstatus != 0 { return v }
         ix := f_eval(n.b)
         if g_fstatus != 0 { return v }
-        if base.k != 1 { g_fstatus = 2  return v }   // index non-slice (string) -> unknown (later slice)
         if ix.k != 0 { g_fstatus = 2  return v }
-        if ix.i < 0 || ix.i >= len(base.sl) {
-            g_fstatus = 1  g_fviol_prop = "index out of range"  g_fviol_expr = f_render(ni, 0)  return v
+        if base.k == 1 {
+            if ix.i < 0 || ix.i >= len(base.sl) {
+                g_fstatus = 1  g_fviol_prop = "index out of range"  g_fviol_expr = f_render(ni, 0)  return v
+            }
+            v = fv_int(base.sl[ix.i])  return v
         }
-        v = fv_int(base.sl[ix.i])  return v
+        if base.k == 3 {
+            if ix.i < 0 || ix.i >= len(base.s) {
+                g_fstatus = 1  g_fviol_prop = "index out of range"  g_fviol_expr = f_render(ni, 0)  return v
+            }
+            v = fv_string(substr(base.s, ix.i, ix.i + 1))  return v
+        }
+        g_fstatus = 2  return v
     }
     if n.kind == K_CALL {
         if n.s == "len" && len(n.kids) == 1 {
             a := f_eval(n.kids[0])
             if g_fstatus != 0 { return v }
             if a.k == 1 { v = fv_int(len(a.sl))  return v }
-            g_fstatus = 2  return v   // len of non-slice (string) -> unknown (later slice)
+            if a.k == 3 { v = fv_int(len(a.s))  return v }
+            g_fstatus = 2  return v
         }
         g_fstatus = 2  return v   // other calls -> unknown (interprocedural is a later slice)
     }
@@ -125,13 +149,48 @@ func f_eval_bin(ni) (v) {
     op := n.s
     l := f_eval(n.a)
     if g_fstatus != 0 { return v }
-    if l.k != 0 { g_fstatus = 2  return v }
-    // short-circuit boolean ops (0/1)
-    if op == "&&" { if l.i == 0 { v = fv_int(0)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
-    if op == "||" { if l.i != 0 { v = fv_int(1)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
+    // short-circuit boolean ops (0/1); operands are int-modeled bools
+    if op == "&&" { if l.k != 0 { g_fstatus = 2  return v }  if l.i == 0 { v = fv_int(0)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
+    if op == "||" { if l.k != 0 { g_fstatus = 2  return v }  if l.i != 0 { v = fv_int(1)  return v }  r := f_eval(n.b)  if g_fstatus != 0 { return v }  if r.k != 0 { g_fstatus = 2  return v }  if r.i != 0 { v = fv_int(1) }  return v }
     r := f_eval(n.b)
     if g_fstatus != 0 { return v }
-    if r.k != 0 { g_fstatus = 2  return v }
+    // float branch (Go: either operand KFloat) — int operands promote
+    if l.k == 2 || r.k == 2 {
+        if l.k != 0 && l.k != 2 { g_fstatus = 2  return v }
+        if r.k != 0 && r.k != 2 { g_fstatus = 2  return v }
+        lf := l.f
+        if l.k == 0 { lf = float(l.i) }
+        rf := r.f
+        if r.k == 0 { rf = float(r.i) }
+        if op == "+" { v = fv_float(lf + rf)  return v }
+        if op == "-" { v = fv_float(lf - rf)  return v }
+        if op == "*" { v = fv_float(lf * rf)  return v }
+        if op == "/" {
+            if rf == 0.0 { g_fstatus = 1  g_fviol_prop = "division by zero"  g_fviol_expr = f_render(ni, 0)  return v }
+            v = fv_float(lf / rf)  return v
+        }
+        if op == "<" { if lf < rf { v = fv_int(1) }  return v }
+        if op == "<=" { if lf <= rf { v = fv_int(1) }  return v }
+        if op == ">" { if lf > rf { v = fv_int(1) }  return v }
+        if op == ">=" { if lf >= rf { v = fv_int(1) }  return v }
+        if op == "==" { if lf == rf { v = fv_int(1) }  return v }
+        if op == "!=" { if lf != rf { v = fv_int(1) }  return v }
+        g_fstatus = 2  return v
+    }
+    // string branch
+    if l.k == 3 {
+        if r.k != 3 { g_fstatus = 2  return v }
+        if op == "+" { v = fv_string(l.s + r.s)  return v }
+        if op == "==" { if l.s == r.s { v = fv_int(1) }  return v }
+        if op == "!=" { if l.s != r.s { v = fv_int(1) }  return v }
+        if op == "<" { if l.s < r.s { v = fv_int(1) }  return v }
+        if op == ">" { if l.s > r.s { v = fv_int(1) }  return v }
+        if op == "<=" { if l.s <= r.s { v = fv_int(1) }  return v }
+        if op == ">=" { if l.s >= r.s { v = fv_int(1) }  return v }
+        g_fstatus = 2  return v
+    }
+    // int branch
+    if l.k != 0 || r.k != 0 { g_fstatus = 2  return v }
     a := l.i
     b := r.i
     if op == "+" { v = fv_int(a + b)  return v }
@@ -226,15 +285,19 @@ func f_eval_stmt(si) {
     if n.kind == K_RANGE {
         base := f_eval(n.a)
         if g_fstatus != 0 { return }
-        if base.k != 1 { g_fstatus = 2  return }   // range over non-slice (string/map) -> unknown (later)
+        if base.k != 1 && base.k != 3 { g_fstatus = 2  return }   // range over map -> unknown (later)
+        blen := len(base.sl)
+        if base.k == 3 { blen = len(base.s) }
         ix := 0
-        for ix < len(base.sl) {
+        for ix < blen {
             if n.s != "" && n.s != "_" { f_env_set(n.s, fv_int(ix)) }
-            if n.s2 != "" && n.s2 != "_" { f_env_set(n.s2, fv_int(base.sl[ix])) }
+            if n.s2 != "" && n.s2 != "_" {
+                if base.k == 1 { f_env_set(n.s2, fv_int(base.sl[ix])) } else { f_env_set(n.s2, fv_string(substr(base.s, ix, ix + 1))) }
+            }
             f_eval_stmts(n.kids)
             if g_fstatus != 0 { return }
             if g_freturned == 1 { return }
-            if g_fbreak == 1 { g_fbreak = 0  ix = len(base.sl) } else {
+            if g_fbreak == 1 { g_fbreak = 0  ix = blen } else {
                 if g_fcontinue == 1 { g_fcontinue = 0 }
                 ix = ix + 1
             }
@@ -277,6 +340,8 @@ func f_render(ni, parent) (out) {
     out = "?"
     n := nodes[ni]
     if n.kind == K_INT { out = str(n.ival)  return out }
+    if n.kind == K_FLOAT { out = str(parse_float(n.s))  return out }   // %g, matches Go FloatLit render
+    if n.kind == K_STR { out = "\"" + n.s + "\""  return out }         // %q for simple strings
     if n.kind == K_BOOL { if n.ival != 0 { out = "true" } else { out = "false" }  return out }
     if n.kind == K_ID { out = n.s  return out }
     if n.kind == K_UNARY { out = n.s + f_render(n.a, 6)  return out }
@@ -346,6 +411,23 @@ func f_intdom(i) (v) {
     return v
 }
 
+// float domain — MUST match falsFloatDomain = {0, 1, -1, 2}
+func f_floatdom(i) (v) {
+    v = fv_float(0.0)
+    if i == 1 { v = fv_float(1.0) }
+    if i == 2 { v = fv_float(0.0 - 1.0) }
+    if i == 3 { v = fv_float(2.0) }
+    return v
+}
+
+// string domain — MUST match falsStringDomain = {"", "a", "ab"}
+func f_stringdom(i) (v) {
+    v = fv_string("")
+    if i == 1 { v = fv_string("a") }
+    if i == 2 { v = fv_string("ab") }
+    return v
+}
+
 // []int domain — MUST match falsify.go domain(KSlice): lengths 0..3, elements from
 // {0,1,2}, in gen()'s lexicographic order (first element outermost). 40 values.
 var g_slicedom = []FV{}
@@ -385,15 +467,19 @@ func f_init_slicedom() {
     g_slicedom_ready = 1
 }
 
-// f_dom_size / f_dom_val: pkind 0 = int (5 values), 1 = []int (40 values)
+// f_dom_size / f_dom_val: pkind 0=int(5), 1=[]int(40), 2=float(4), 3=string(3)
 func f_dom_size(pkind) (n) {
     n = 5
     if pkind == 1 { n = len(g_slicedom) }
+    if pkind == 2 { n = 4 }
+    if pkind == 3 { n = 3 }
     return n
 }
 func f_dom_val(pkind, i) (fv) {
     fv = f_intdom(i)
     if pkind == 1 { fv = g_slicedom[i] }
+    if pkind == 2 { fv = f_floatdom(i) }
+    if pkind == 3 { fv = f_stringdom(i) }
     return fv
 }
 
@@ -466,10 +552,14 @@ func detect_falsifiable() {
                 ks := kind_of(s)
                 pk := 0
                 if ks == 2 { pk = 0 } else {
-                    if ks == 7 {
-                        es := g_elem[find(s)]
-                        if kind_of(es) == 2 { pk = 1 } else { scoped = 0 }
-                    } else { scoped = 0 }
+                    if ks == 3 { pk = 2 } else {              // KFloat
+                        if ks == 5 { pk = 3 } else {          // KString
+                            if ks == 7 {                       // KSlice
+                                es := g_elem[find(s)]
+                                if kind_of(es) == 2 { pk = 1 } else { scoped = 0 }
+                            } else { scoped = 0 }
+                        }
+                    }
                 }
                 pkinds = append(pkinds, pk)
                 pi = pi + 1

--- a/selfhost/falsifymain.src
+++ b/selfhost/falsifymain.src
@@ -1,0 +1,98 @@
+// selfhost/falsifymain.src — `machin falsifytest --program <file.mfl>` for the self-hosted
+// falsify pass. Runs the same parse -> check pipeline as checkmain, then the falsify
+// analysis, dumping counterexamples in the canonical hex form the Go oracle emits.
+
+func main() {
+    a := args()
+    if len(a) < 3 { write(2, "usage: falsifytest --program <file.mfl>\n")  exit(2) }
+    if a[1] != "--program" { write(2, "only --program is supported\n")  exit(2) }
+    data := read_file(a[2])
+    lines := split(data, "\n")
+
+    // pass 1: seed struct names so T{...} parses
+    for _, ln := range lines {
+        reset(ln)
+        i := 0
+        while i + 1 < len(T) {
+            if T[i].val == "type" || T[i].val == "cstruct" {
+                if T[i + 1].kind == 1 { g_structs = append(g_structs, T[i + 1].val) }
+            }
+            i = i + 1
+        }
+    }
+    // pass 1b: register struct field names/types + extern cstructs/fns
+    for _, ln := range lines {
+        if has_prefix(ln, "type ") {
+            reset(ln)
+            tidx := parse_type_decl()
+            if g_err == 0 { register_struct(nodes[tidx].s, nodes[tidx].names, nodes[tidx].names2) }
+        }
+        if has_prefix(ln, "extern ") {
+            reset(ln)
+            eidx := parse_extern_decl()
+            if g_err == 0 {
+                for _, ci := range nodes[eidx].kids {
+                    cn := nodes[ci]
+                    register_struct(cn.s, cn.names, cn.names2)
+                }
+                for _, fi := range nodes[eidx].kids2 {
+                    fnn := nodes[fi]
+                    register_extfn(fnn.s, fnn.names, fnn.s2)
+                }
+            }
+        }
+    }
+
+    // pass 2: parse every function + global into the shared nodes array
+    nodes = []Node{}
+    global_names := []string{}
+    global_inits := []int{}
+    for _, ln := range lines {
+        if has_prefix(ln, "func ") || has_prefix(ln, "export func ") {
+            lex_only(ln)
+            r := parse_func_decl()
+            if g_err == 1 || pk().kind != 0 { write(1, "(parse-error)\n")  return }
+            g_func_names = append(g_func_names, nodes[r].s)
+            g_func_roots = append(g_func_roots, r)
+        }
+        if has_prefix(ln, "var ") {
+            lex_only(ln)
+            r := parse_global()
+            if g_err == 0 && pk().kind == 0 {
+                global_names = append(global_names, nodes[r].s)
+                global_inits = append(global_inits, nodes[r].a)
+            }
+        }
+    }
+
+    has_main := 0
+    if func_root("main") >= 0 { has_main = 1 }
+    exported := []string{}
+    i := 0
+    for i < len(g_func_names) {
+        if nodes[g_func_roots[i]].ival == 1 { exported = append(exported, g_func_names[i]) }
+        i = i + 1
+    }
+    if has_main == 0 && len(exported) == 0 { write(1, "(check-error)\n")  return }
+
+    init_consts()
+    gi := 0
+    for gi < len(global_names) {
+        vs := gen_expr(global_inits[gi])
+        gslot := new_slot(0)
+        add_pair(gslot, vs)
+        register_global(global_names[gi], gslot)
+        gi = gi + 1
+    }
+    if has_main == 1 { instantiate("main") }
+    for _, en := range exported { instantiate(en) }
+    if g_unsupported == 1 { write(1, "(unsupported)\n")  return }
+    solve()
+    resolve_deferred()
+    finalize()
+    if g_terr == 1 || g_check_err == 1 { write(1, "(check-error)\n")  return }
+
+    // the falsify pass
+    detect_falsifiable()
+    write(1, f_dump())
+}

--- a/selfhost/verify-falsify.sh
+++ b/selfhost/verify-falsify.sh
@@ -5,9 +5,9 @@
 # (Distinct from the repo-root verify-falsify.sh, which behaviorally tests the Go
 # pass. This one proves the MFL port reproduces the Go oracle exactly.)
 #
-# Phase 2 slices 2.1-2.2: int + []int params; arithmetic, if/while/for-range,
-# index (FALS001 out-of-range), len, div/modulo-by-zero (FALS002). Structs and
-# interprocedural inlining land in later slices.
+# Phase 2 slices 2.1-2.3: int + []int + float + string params; arithmetic,
+# comparisons, if/while/for-range (incl. string range), index (FALS001), len,
+# div/modulo-by-zero (FALS002). Structs and interprocedural inlining land next.
 set -u
 N="nice -n 15"
 MACHIN=./bin/machin
@@ -51,6 +51,16 @@ printf 'func firstgap(xs){return xs[len(xs)-5]}\nfunc main(){println(str(firstga
 printf 'func at(xs,i){if i<0{return 0}if i>=len(xs){return 0}return xs[i]}\nfunc main(){println(str(at([]int{1,2},5)))}\n' > "$T/v6"; run "$T/v6" "guarded index (clean)"
 printf 'func first(xs){return xs[0]}\nfunc main(){println(str(first([]int{9})))}\n' > "$T/v7"; run "$T/v7" "xs[0] on empty (FALS001)"
 [ -f examples/complex/multi_return.mfl ] && run examples/complex/multi_return.mfl "corpus multi_return (minmax+divmod)"
+
+# float + string fixtures.
+printf 'func fdiv(a){return 1.0/a}\nfunc main(){println(str(fdiv(2.0)))}\n' > "$T/f1"; run "$T/f1" "float 1.0/a div (FALS002)"
+printf 'func fmath(a,b){c:=a+b-a*b if c<b||c>a{return c}return a}\nfunc main(){println(str(fmath(1.0,2.0)))}\n' > "$T/f2"; run "$T/f2" "float arith+cmp (clean)"
+printf 'func mix(a,x){return x/float(a)}\nfunc main(){println(str(mix(2,3.0)))}\n' > "$T/f3"; run "$T/f3" "mixed int/float div"
+printf 'func fg(a){if a==0.0{return 0.0}return 1.0/a}\nfunc main(){println(str(fg(2.0)))}\n' > "$T/f4"; run "$T/f4" "float guarded (clean)"
+printf 'func scat(s,t){if s==t{return len(s)}if s<t{return 0}if s>t{return 1}return len(s+t)}\nfunc main(){println(str(scat("a","b")))}\n' > "$T/f5"; run "$T/f5" "string concat+cmp (clean)"
+printf 'func slen(s){return 10/len(s)}\nfunc main(){println(str(slen("hi")))}\n' > "$T/f6"; run "$T/f6" "10/len(s) empty-string div (FALS002)"
+printf 'func vowels(s){n:=0 for _,c:=range s{if c=="a"{n=n+1}}return 100/n}\nfunc main(){println(str(vowels("aaa")))}\n' > "$T/f7"; run "$T/f7" "string range + div"
+printf 'func firstc(s){return s[0]}\nfunc main(){println(firstc("x"))}\n' > "$T/f8"; run "$T/f8" "string index s[0] (FALS001)"
 
 echo
 echo "self-hosted falsify oracle-diff: $pass pass, $fail fail"

--- a/selfhost/verify-falsify.sh
+++ b/selfhost/verify-falsify.sh
@@ -5,10 +5,10 @@
 # (Distinct from the repo-root verify-falsify.sh, which behaviorally tests the Go
 # pass. This one proves the MFL port reproduces the Go oracle exactly.)
 #
-# Phase 2 slices 2.1-2.4: int + []int + float + string + bool + struct params;
+# Phase 2 slices 2.1-2.5: int + []int + float + string + bool + struct params;
 # arithmetic, comparisons, if/while/for-range (incl. string range), index
-# (FALS001), len, field access/assign, div/modulo-by-zero (FALS002).
-# Interprocedural inlining lands next.
+# (FALS001), len, abs, field access/assign, interprocedural inlining (recursion-
+# capped), div/modulo-by-zero (FALS002). This is full parity with the Go pass.
 set -u
 N="nice -n 15"
 MACHIN=./bin/machin
@@ -70,6 +70,15 @@ printf 'type P struct{n int}\nfunc vs(c){d:=c d.n=d.n+1 return d.n}\nfunc main()
 printf 'type M struct{a int b bool}\nfunc g(m){if m.b{return 0}return 10/m.a}\nfunc main(){println(str(g(M{a:1,b:true})))}\n' > "$T/t4"; run "$T/t4" "struct with bool field"
 printf 'func bs(flag,a){if flag{return 0}return 10/a}\nfunc main(){println(str(bs(true,2)))}\n' > "$T/t5"; run "$T/t5" "bool param (true/false render)"
 printf 'type S struct{name string cnt int}\nfunc h(s){return len(s.name)/s.cnt}\nfunc main(){println(str(h(S{name:"x",cnt:1})))}\n' > "$T/t6"; run "$T/t6" "struct string+int fields"
+
+# interprocedural inlining fixtures.
+printf 'func helper(n){return 100/n}\nfunc caller(n){return helper(n)+1}\nfunc main(){println(str(caller(2)))}\n' > "$T/i1"; run "$T/i1" "interproc div-by-zero"
+printf 'func dbl(y){return y*2}\nfunc use(x){return x+dbl(x)}\nfunc main(){println(str(use(3)))}\n' > "$T/i2"; run "$T/i2" "interproc clean"
+printf 'func fact(n){if n<=1{return 1}return n*fact(n-1)}\nfunc main(){println(str(fact(3)))}\n' > "$T/i3"; run "$T/i3" "recursion (depth guard)"
+printf 'func idx(xs,i){return xs[i]}\nfunc get(xs){return idx(xs,5)}\nfunc main(){println(str(get([]int{1,2})))}\n' > "$T/i4"; run "$T/i4" "interproc index-OOB (FALS001)"
+printf 'func mag(a){return abs(a)}\nfunc r(a){return 10/(mag(a)-1.0)}\nfunc main(){println(str(r(2)))}\n' > "$T/i5"; run "$T/i5" "abs + interproc float"
+printf 'type Cfg struct{n int}\nfunc div(c){return 100/c.n}\nfunc run(c){return div(c)}\nfunc main(){println(str(run(Cfg{n:1})))}\n' > "$T/i6"; run "$T/i6" "interproc struct-field div"
+printf 'func chain3(n){return n}\nfunc chain2(n){return chain3(n)+1}\nfunc chain1(n){return 9/chain2(n)}\nfunc main(){println(str(chain1(1)))}\n' > "$T/i7"; run "$T/i7" "3-deep call chain"
 
 echo
 echo "self-hosted falsify oracle-diff: $pass pass, $fail fail"

--- a/selfhost/verify-falsify.sh
+++ b/selfhost/verify-falsify.sh
@@ -5,9 +5,10 @@
 # (Distinct from the repo-root verify-falsify.sh, which behaviorally tests the Go
 # pass. This one proves the MFL port reproduces the Go oracle exactly.)
 #
-# Phase 2 slices 2.1-2.3: int + []int + float + string params; arithmetic,
-# comparisons, if/while/for-range (incl. string range), index (FALS001), len,
-# div/modulo-by-zero (FALS002). Structs and interprocedural inlining land next.
+# Phase 2 slices 2.1-2.4: int + []int + float + string + bool + struct params;
+# arithmetic, comparisons, if/while/for-range (incl. string range), index
+# (FALS001), len, field access/assign, div/modulo-by-zero (FALS002).
+# Interprocedural inlining lands next.
 set -u
 N="nice -n 15"
 MACHIN=./bin/machin
@@ -61,6 +62,14 @@ printf 'func scat(s,t){if s==t{return len(s)}if s<t{return 0}if s>t{return 1}ret
 printf 'func slen(s){return 10/len(s)}\nfunc main(){println(str(slen("hi")))}\n' > "$T/f6"; run "$T/f6" "10/len(s) empty-string div (FALS002)"
 printf 'func vowels(s){n:=0 for _,c:=range s{if c=="a"{n=n+1}}return 100/n}\nfunc main(){println(str(vowels("aaa")))}\n' > "$T/f7"; run "$T/f7" "string range + div"
 printf 'func firstc(s){return s[0]}\nfunc main(){println(firstc("x"))}\n' > "$T/f8"; run "$T/f8" "string index s[0] (FALS001)"
+
+# struct + bool fixtures.
+printf 'type Cfg struct{n int}\nfunc run(c){return 100/c.n}\nfunc main(){println(str(run(Cfg{n:1})))}\n' > "$T/t1"; run "$T/t1" "div by struct field (FALS002)"
+printf 'type Box struct{sz int}\nfunc at(b,xs){return xs[b.sz]}\nfunc main(){println(str(at(Box{sz:0},[]int{1})))}\n' > "$T/t2"; run "$T/t2" "index by struct field (FALS001)"
+printf 'type P struct{n int}\nfunc vs(c){d:=c d.n=d.n+1 return d.n}\nfunc main(){println(str(vs(P{n:1})))}\n' > "$T/t3"; run "$T/t3" "struct copy value-semantics (clean)"
+printf 'type M struct{a int b bool}\nfunc g(m){if m.b{return 0}return 10/m.a}\nfunc main(){println(str(g(M{a:1,b:true})))}\n' > "$T/t4"; run "$T/t4" "struct with bool field"
+printf 'func bs(flag,a){if flag{return 0}return 10/a}\nfunc main(){println(str(bs(true,2)))}\n' > "$T/t5"; run "$T/t5" "bool param (true/false render)"
+printf 'type S struct{name string cnt int}\nfunc h(s){return len(s.name)/s.cnt}\nfunc main(){println(str(h(S{name:"x",cnt:1})))}\n' > "$T/t6"; run "$T/t6" "struct string+int fields"
 
 echo
 echo "self-hosted falsify oracle-diff: $pass pass, $fail fail"

--- a/selfhost/verify-falsify.sh
+++ b/selfhost/verify-falsify.sh
@@ -5,8 +5,9 @@
 # (Distinct from the repo-root verify-falsify.sh, which behaviorally tests the Go
 # pass. This one proves the MFL port reproduces the Go oracle exactly.)
 #
-# Phase 2 slice 2.1: scalar-int params, div/modulo-by-zero (FALS002). Slices,
-# index-OOB (FALS001), structs and interprocedural inlining land in later slices.
+# Phase 2 slices 2.1-2.2: int + []int params; arithmetic, if/while/for-range,
+# index (FALS001 out-of-range), len, div/modulo-by-zero (FALS002). Structs and
+# interprocedural inlining land in later slices.
 set -u
 N="nice -n 15"
 MACHIN=./bin/machin
@@ -40,6 +41,16 @@ printf 'func h(a,b){if b!=0{if a>0{return a/b}}return 0}\nfunc main(){println(st
 printf 'func n(a){return 5/(-a+a)}\nfunc main(){println(str(n(2)))}\n' > "$T/s7"; run "$T/s7" "unary -a+a=0"
 printf 'func p(a,b){c:=a-b return 9/c}\nfunc main(){println(str(p(1,2)))}\n' > "$T/s8"; run "$T/s8" "assign then div"
 printf 'func q(a,b){if b<1{if b>-1{return 0}}return a/b}\nfunc main(){println(str(q(1,2)))}\n' > "$T/s9"; run "$T/s9" "chained guard (clean)"
+
+# []int fixtures (the real Phase 1 patterns): index-OOB, len, while, for-range.
+printf 'func sumbad(xs){total:=0 i:=0 for i<=len(xs){total=total+xs[i] i=i+1}return total}\nfunc main(){println(str(sumbad([]int{1,2})))}\n' > "$T/v1"; run "$T/v1" "sumbad off-by-one (FALS001)"
+printf 'func avg(xs){total:=0 for _,v:=range xs{total=total+v}return total/len(xs)}\nfunc main(){println(str(avg([]int{1,2})))}\n' > "$T/v2"; run "$T/v2" "avg empty div (FALS002)"
+printf 'func safeavg(xs){if len(xs)==0{return 0}total:=0 for _,v:=range xs{total=total+v}return total/len(xs)}\nfunc main(){println(str(safeavg([]int{1,2})))}\n' > "$T/v3"; run "$T/v3" "safeavg guarded (clean)"
+printf 'func sumok(xs){total:=0 for _,v:=range xs{total=total+v}return total}\nfunc main(){println(str(sumok([]int{1,2})))}\n' > "$T/v4"; run "$T/v4" "sumok (clean)"
+printf 'func firstgap(xs){return xs[len(xs)-5]}\nfunc main(){println(str(firstgap([]int{1,2})))}\n' > "$T/v5"; run "$T/v5" "firstgap neg index (FALS001)"
+printf 'func at(xs,i){if i<0{return 0}if i>=len(xs){return 0}return xs[i]}\nfunc main(){println(str(at([]int{1,2},5)))}\n' > "$T/v6"; run "$T/v6" "guarded index (clean)"
+printf 'func first(xs){return xs[0]}\nfunc main(){println(str(first([]int{9})))}\n' > "$T/v7"; run "$T/v7" "xs[0] on empty (FALS001)"
+[ -f examples/complex/multi_return.mfl ] && run examples/complex/multi_return.mfl "corpus multi_return (minmax+divmod)"
 
 echo
 echo "self-hosted falsify oracle-diff: $pass pass, $fail fail"

--- a/selfhost/verify-falsify.sh
+++ b/selfhost/verify-falsify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Oracle-diff gate for the SELF-HOSTED falsify pass (selfhost/falsify.src): its
+# findings must be byte-identical to the Go reference `machin falsifytest --program`.
+#
+# (Distinct from the repo-root verify-falsify.sh, which behaviorally tests the Go
+# pass. This one proves the MFL port reproduces the Go oracle exactly.)
+#
+# Phase 2 slice 2.1: scalar-int params, div/modulo-by-zero (FALS002). Slices,
+# index-OOB (FALS001), structs and interprocedural inlining land in later slices.
+set -u
+N="nice -n 15"
+MACHIN=./bin/machin
+T=$(mktemp -d)
+pass=0; fail=0
+
+echo "building Go machin (oracle) + MFL falsify pass…"
+GOMAXPROCS=4 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
+$N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+    selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src \
+    selfhost/falsify.src selfhost/falsifymain.src > "$T/sh-falsify.mfl" || { echo "encode failed"; exit 1; }
+$N "$MACHIN" build "$T/sh-falsify.mfl" -o selfhost/mfl-falsify || { echo "build failed"; exit 1; }
+echo "built selfhost/mfl-falsify"
+
+run() { # file label
+  $N "$MACHIN" falsifytest --program "$1" > "$T/o.txt" 2>/dev/null
+  $N ./selfhost/mfl-falsify --program "$1" > "$T/m.txt" 2>/dev/null
+  if diff -q "$T/o.txt" "$T/m.txt" >/dev/null; then pass=$((pass+1)); echo "ok   $2"; else
+    fail=$((fail+1)); echo "MISMATCH: $2"; echo " oracle:"; cat "$T/o.txt"; echo " mfl:"; cat "$T/m.txt"; fi
+}
+
+# s1 mod-by-(a-b), s2 a/b, s3 guarded (clean), s4 10/(a*a-a), s5 3-param a/(b-c),
+# s6 nested-if guard (clean), s7 unary -a+a=0, s8 assign-then-div, s9 chained guard (clean)
+printf 'func wrap(a,b){return 100%%(a-b)}\nfunc main(){println(str(wrap(1,2)))}\n' > "$T/s1"; run "$T/s1" "mod by (a-b)"
+printf 'func d(a,b){return a/b}\nfunc main(){println(str(d(6,2)))}\n' > "$T/s2"; run "$T/s2" "a/b"
+printf 'func g(a,b){if b==0{return 0}return a/b}\nfunc main(){println(str(g(6,2)))}\n' > "$T/s3"; run "$T/s3" "guarded (clean)"
+printf 'func k(a){return 10/(a*a-a)}\nfunc main(){println(str(k(3)))}\n' > "$T/s4"; run "$T/s4" "10/(a*a-a)"
+printf 'func m(a,b,c){return a/(b-c)}\nfunc main(){println(str(m(1,2,3)))}\n' > "$T/s5"; run "$T/s5" "3-param a/(b-c)"
+printf 'func h(a,b){if b!=0{if a>0{return a/b}}return 0}\nfunc main(){println(str(h(1,2)))}\n' > "$T/s6"; run "$T/s6" "nested-if guard (clean)"
+printf 'func n(a){return 5/(-a+a)}\nfunc main(){println(str(n(2)))}\n' > "$T/s7"; run "$T/s7" "unary -a+a=0"
+printf 'func p(a,b){c:=a-b return 9/c}\nfunc main(){println(str(p(1,2)))}\n' > "$T/s8"; run "$T/s8" "assign then div"
+printf 'func q(a,b){if b<1{if b>-1{return 0}}return a/b}\nfunc main(){println(str(q(1,2)))}\n' > "$T/s9"; run "$T/s9" "chained guard (clean)"
+
+echo
+echo "self-hosted falsify oracle-diff: $pass pass, $fail fail"
+rm -rf "$T"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## The Falsifier — Phase 2: self-host port

Ports the Phase-1 falsifier (`falsify.go`) into MFL (`selfhost/falsify.src` + `selfhost/falsifymain.src`), running over the self-hosted IR (`nodes[]` + `g_insts`) and oracle-diffed against a Go reference dumper (`machin falsifytest --program`, hex-encoded findings) — exactly the `racetest`/`racecheck.src` pattern. **machin-in-machin now both compiles AND falsifies, byte-identically.**

### The hard part
MFL has **no panic/recover and no closures**, so the Go interpreter's `panic(fviol)`/`panic(funknown)` unwinding and `ctrl` returns are replaced by **threaded status globals** (`g_fstatus`, `g_freturned`/`g_fbreak`/`g_fcontinue`), and interprocedural inlining **saves/restores the global env** around each call instead of using call frames. The value model is an `FV` struct (int / `[]int` / float / string / bool / struct); MFL has no `[][]FV`, so the slice domain is a flat `[]FV` and struct domains are decoded on-the-fly from the enumeration index.

### Slices (each oracle-diffed before the next)
- **2.1** scalar-int spike — proved status-threading + byte-exact render/hex
- **2.2** `[]int` + `FALS001` (index-OOB) + `len`/`while`/`for`-range
- **2.3** float + string (rendering matches Go `%g`/`%q`)
- **2.4** struct + bool (bool renders `true`/`false`; value-semantics `clone`)
- **2.5** interprocedural inlining (recursion-capped) → **full parity**

### Verification
- `selfhost/verify-falsify.sh`: **38/38** oracle-diff (every value kind, both properties, interprocedural).
- Broad corpus sweep: **47/47** example files match the Go oracle wherever both pipelines parse+check. The 9 that differ are **pre-existing shared self-hosted pipeline gaps** (multi-line parse, closures, variadic, globals) — the already-shipped race pass diverges on the exact same files identically.
- `go test .` green; `selfhost/verify-race.sh` 22/0 (unaffected).

Additive: `falsifytest.go` + one `main.go` dispatch line on the Go side; `selfhost/falsify.src`, `selfhost/falsifymain.src`, `selfhost/verify-falsify.sh` on the MFL side. No changes to `racecheck.go`/`codegen.go`/existing selfhost stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `falsifytest` command for analyzing MFL programs and reporting canonical counterexamples.
  - Added a self-hosted falsification runner supporting supported values, control flow, function calls, and input enumeration.
  - Added clear output for parse, checking, unsupported-feature, and falsification results.

- **Documentation**
  - Documented the completed self-hosted falsification phase, supported scope, validation results, and remaining limitations.

- **Tests**
  - Added automated verification comparing self-hosted results with the reference implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->