### PR TITLE
test(arena): harden inline-arena RSS floor 5x -> 3x (CI base-RSS inflation)

### DIFF
--- a/arena_inline_test.go
+++ b/arena_inline_test.go
@@ -30,11 +30,16 @@ func TestScopedArenaReclaimsInlineAllocations(t *testing.T) {
 	if scopedOut != unscopedOut {
 		t.Fatalf("arena changed program output: scoped %q vs unscoped %q", scopedOut, unscopedOut)
 	}
-	// The unscoped loop retains ~all inline allocations; the scoped one frees
-	// each iteration. Require at least a 5x reduction (the real gap is ~65x).
-	// If inline allocations ever stop being reclaimed (#426), this regresses to
-	// roughly parity and trips the guard.
-	if scopedRSS*5 >= unscopedRSS {
-		t.Fatalf("arena did not reclaim inline allocations: scoped RSS %d KB vs unscoped %d KB", scopedRSS, unscopedRSS)
+	// The unscoped loop retains ~all inline allocations; the scoped one frees each
+	// iteration. The true reduction is ~65x, but the floor is 3x, not 5x: ru_maxrss
+	// carries a large, environment-dependent fixed base that does not shrink with the
+	// arena — for the identical scoped binary it reads ~1.4 MB on a dev box but ~19 MB on
+	// a CI runner (glibc arena / overcommit accounting), which drags the ratio down even
+	// though reclamation works. 3x still collapses toward 1x on a real regression (inline
+	// allocations not reclaimed, #426) while tolerating that base-RSS inflation. Mirrors
+	// the same floor in TestScopedArenaBoundsMemory.
+	if scopedRSS*3 >= unscopedRSS {
+		t.Fatalf("arena did not reclaim inline allocations: scoped RSS %d KB vs unscoped %d KB (ratio %.1fx, want >3x)",
+			scopedRSS, unscopedRSS, float64(unscopedRSS)/float64(scopedRSS))
 	}
 }


### PR DESCRIPTION
`TestScopedArenaReclaimsInlineAllocations` (the #426 regression test) carried the same fragile **5x** RSS ratio that `TestScopedArenaBoundsMemory` had before it was hardened to 3x. `ru_maxrss` includes a large, environment-dependent fixed base that doesn't shrink with the arena — the identical scoped binary reads ~1.4 MB on a dev box but ~19 MB on a CI runner (glibc arena / overcommit accounting) — which drags the scoped/unscoped ratio toward the 5x line even though inline reclamation works (true gap ~65x).

Loosen to a **3x** floor (still collapses toward 1x on a real regression — inline allocations not reclaimed, #426) and report the measured ratio on failure. Mirrors the earlier fix to its twin test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed the RSS reduction threshold for inline allocation reclamation checks to better accommodate environment-dependent memory baselines.
  * Enhanced failure diagnostics with the calculated reduction ratio and measured RSS values.
  * Preserved existing output-equality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->