### PR TITLE
fix(falsify): interpreter must use a named-return helper's actual value

### DIFF
--- a/falsify.go
+++ b/falsify.go
@@ -482,9 +482,19 @@ func (ip *interp) callUser(fn *FuncDecl, argExprs []Expr) fval {
 		ip.env[r] = vint(0) // named returns: zero-init (scalar common case)
 	}
 	ip.depth++
+	savedRVS := ip.retValSet // callee's return state must not leak into the caller's ensures check
 	ip.retVal = fval{}
+	ip.retValSet = false
 	ip.evalStmts(fn.Body)
+	// The callee's value: an explicit `return <e>` sets retVal; a named-return
+	// function that falls off the end yields its named return local (env). Without
+	// this, any call to a named-return helper evaluated to zero — a silent
+	// mis-evaluation that could skew the falsifier's verdict on the caller.
 	ret := ip.retVal
+	if !ip.retValSet && len(fn.Returns) == 1 {
+		ret = ip.env[fn.Returns[0]]
+	}
+	ip.retValSet = savedRVS
 	ip.depth--
 	ip.env = savedEnv
 	return ret

--- a/falsify_named_return_test.go
+++ b/falsify_named_return_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+// Regression: the falsifier's interpreter must use a named-return helper's actual
+// value when inlining a call (callUser). It previously read only retVal — set by an
+// explicit `return <e>` — so a call to a named-return function evaluated to zero,
+// silently mis-evaluating the caller and MISSING real bugs.
+//
+// off(xs) returns len(xs) via a NAMED return. f guards the empty case, then indexes
+// xs[off(xs)] = xs[len(xs)] — an off-by-one that is out of range for EVERY non-empty
+// slice. Detectable only when off's named return is honored (len); folded to 0 it
+// becomes a valid xs[0] and the bug vanishes. The falsifier must report FALS001 on f.
+func TestFalsifyUsesNamedReturnValue(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func off(xs) (r) { r = len(xs) }`,
+		`func f(xs) { if len(xs) == 0 { return 0 }  return xs[off(xs)] }`,
+		`func main() { println(str(f([]int{1,2}))) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c, err := Check(prog)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	var got *falsifyFinding
+	for _, f := range detectFalsifiable(prog, c) {
+		if f.Decl == "f" && f.Code == "FALS001" {
+			g := f
+			got = &g
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("expected FALS001 on f (xs[off(xs)] off-by-one via a named-return helper)")
+	}
+	t.Logf("found the OOB a named-return helper's value drives: %s at %q when %s", got.Prop, got.Expr, got.Bind)
+}

--- a/selfhost/falsify.src
+++ b/selfhost/falsify.src
@@ -295,9 +295,16 @@ func f_call_user(fnroot, argnodes) (rv) {
     g_fbreak = 0
     g_fcontinue = 0
     g_fretval = fv_int(0)
+    saved_rvs := g_fretvalset   // callee's return state must not leak into the caller's ensures check
+    g_fretvalset = 0
     g_fdepth = g_fdepth + 1
     f_eval_stmts(fn.kids)
+    // an explicit `return <e>` sets g_fretval; a named-return function that falls off
+    // the end yields its named return local (env). Without this, a call to a named-return
+    // helper folded to 0 — silently mis-evaluating the caller. Matches falsify.go callUser.
     rv = g_fretval
+    if g_fretvalset == 0 && len(rets) == 1 { rv = f_env_get(rets[0]) }
+    g_fretvalset = saved_rvs
     g_fdepth = g_fdepth - 1
 
     g_env_names = saved_names


### PR DESCRIPTION
## The bug

The Falsifier's concrete interpreter inlines user calls via `callUser`, but only read `retVal` — set by an explicit `return <expr>`. A function that yields through a **named return** evaluated to **zero**:

```
func off(xs) (r) { r = len(xs) }   // no `return` — callUser folded this to 0
```

So any caller using such a helper was silently mis-evaluated, and real bugs that depend on the helper's value were **missed** — a false negative in an analysis that's supposed to be false-positive-free but complete-within-bounds.

## How it was found

Spiking **translation validation** (running the interpreter as the source-of-truth against the compiled binary over a bounded input space) flagged `nested(a,b) = mul(a,b) + clamp(a)` as diverging — and the **compiler was right** (`mul(-3,-3)=9`), the interpreter wrong (`0`). The reference had a bug.

## The fix

`callUser` falls back to the named return local (`env[returns[0]]`) when no explicit `return` ran, and saves/restores `retValSet` so a callee's return state can't leak into the caller's `ensures` check. Ported identically to the self-hosted interpreter (`selfhost/falsify.src` `f_call_user`), which had the same bug.

## Regression test

`off(xs)=len(xs)` via a named return; `f` guards empty then indexes `xs[off(xs)] = xs[len(xs)]` — an off-by-one OOB for every non-empty slice. Detectable **only** when the named return is honored (folded to 0 it's a valid `xs[0]` and the bug vanishes). Passes with the fix, fails without.

## Gates
- `go test .` (falsify + contracts + prove suites) → ok
- `selfhost/verify-falsify.sh` → **52 pass / 0 fail** (self-hosted oracle-identical)

_Groundwork for the self-certifying-compiler (translation validation) work — the reference interpreter has to be trustworthy first._

🤖 Generated with [Claude Code](https://claude.com/claude-code)