### PR TITLE
docs(certify): self-certifying-compiler doc + continuous codegen-path gate

### DIFF
--- a/certify_gate_test.go
+++ b/certify_gate_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+// TestCertifyCodegenPaths is the continuous-self-certification gate: a battery of dense,
+// certify-friendly programs that exercise a wide span of codegen paths (arithmetic,
+// comparisons, bitwise, shifts, boolean short-circuit, guarded modulo, control flow,
+// bounded recursion, slice literal/append/index/len/range, structs, strings, and
+// interprocedural calls). Every one must certify with NO miscompilation — this fires if a
+// codegen change ever makes a validatable function diverge from its source.
+func TestCertifyCodegenPaths(t *testing.T) {
+	programs := [][]string{
+		{`func arith(a, b) (r) { r = a + b - a * b + (a - b) }`,
+			`func main() { println(str(arith(2, 3))) }`},
+		{`func bits(a, b) (r) { r = ((a & b) | (a ^ b)) + (a << 1) + (b >> 1) }`,
+			`func main() { println(str(bits(6, 3))) }`},
+		{`func cmp(a, b) (r) { r = 0  if a < b { r = r + 1 }  if a <= b { r = r + 2 }  if a > b { r = r + 4 }  if a >= b { r = r + 8 }  if a == b { r = r + 16 }  if a != b { r = r + 32 } }`,
+			`func main() { println(str(cmp(1, 2))) }`},
+		{`func logic(a, b) (r) { r = 0  if a > 0 && b > 0 { r = 1 }  if a > 0 || b > 0 { r = r + 10 } }`,
+			`func main() { println(str(logic(1, -1))) }`},
+		{`func modrem(a) (r) { r = 0  if a != 0 { r = 100 % a + 100 / a } }`,
+			`func main() { println(str(modrem(3))) }`},
+		{`func fib(n) (r) { r = n  if n > 1 { r = fib(n - 1) + fib(n - 2) } }`,
+			`func main() { println(str(fib(3))) }`},
+		{`func build(n) (r) { r = []int{}  i := 0  for i < n { r = append(r, i * i)  i = i + 1 } }`,
+			`func main() { println(str(len(build(3)))) }`},
+		{`func total(xs) (r) { r = 0  for _, v := range xs { r = r + v } }`,
+			`func main() { println(str(total([]int{1, 2, 3}))) }`},
+		{`func at(xs, i) (r) { r = -1  if i >= 0 { if i < len(xs) { r = xs[i] } } }`,
+			`func main() { println(str(at([]int{5, 6}, 1))) }`},
+		{`type Pt struct { x int  y int }`,
+			`func mk(a, b) (r) { r = Pt{a, b} }`,
+			`func main() { println(str(mk(1, 2).x)) }`},
+		{`func label(a) (r) { r = "zero"  if a > 0 { r = "pos" }  if a < 0 { r = "neg" } }`,
+			`func main() { println(label(3)) }`},
+	}
+	for _, decls := range programs {
+		rep := certifyProg(t, decls...)
+		if !rep.OK {
+			t.Errorf("codegen-path battery: a program failed to certify: %+v", rep.Verdicts)
+		}
+		anyValidated := false
+		for _, v := range rep.Verdicts {
+			if v.Verdict == "miscompiled" {
+				t.Fatalf("MISCOMPILATION on a codegen-path fixture: %+v", v)
+			}
+			if v.Verdict == "certified" || v.Verdict == "certified-bounded" {
+				anyValidated = true
+			}
+		}
+		if !anyValidated {
+			t.Errorf("codegen-path program validated nothing (decls[0]=%q)", decls[0])
+		}
+	}
+}

--- a/docs/self-certifying-compiler.md
+++ b/docs/self-certifying-compiler.md
@@ -1,0 +1,74 @@
+# The self-certifying compiler (`machin certify`)
+
+Every guarantee machin makes — race-freedom, falsification, replay — quietly assumes
+one thing: **the compiler faithfully implemented your source.** `rustc` can't prove
+that (it has miscompilation bugs); Zig can't either. `machin certify` checks that
+assumption, per build.
+
+```
+machin certify app.mfl
+```
+
+## What it does
+
+For each function, machin runs it two ways over the same bounded input space and
+confirms they agree:
+
+- **the source semantics** — machin's own concrete interpreter (the very evaluator the
+  [Falsifier](falsify) uses), which *is* the meaning of your MFL; and
+- **the codegen semantics** — the actually-compiled binary.
+
+Every `(function, input)` pair is batched into one harness that prints
+`json(fn(args))`, compiled and run once; the output is diffed line-by-line against the
+interpreter's value. `json()` is one canonical serialization for every type, and the
+interpreter side (`renderCanonical`) reproduces it byte-for-byte (floats use `%.6g` to
+match C's `%g`, so a formatting quirk is never mistaken for a bug).
+
+A divergence is a **TRV001 miscompilation** — the compiler produced something other
+than what the source means — reported with the exact input and both values:
+
+```
+  MISCOMPILED  scale: scale(-3, -3) = 9 (source) but the compiler produced 0 (tried 25)
+certify: MISCOMPILATION found — the compiler diverged from the source.
+```
+
+`machin certify` exits non-zero when it finds one.
+
+## Verdicts
+
+| Verdict | Meaning |
+|---|---|
+| `certified` | finite input domain, whole space enumerated, every input agreed |
+| `certified-bounded` | agreed, but over a bounded (int/slice) domain — validated *up to the bounds* |
+| `partial` | agreed on the modeled inputs; some inputs weren't modeled |
+| `unknown` | not validatable — e.g. a return `json()` can't serialize, or a body the interpreter doesn't model |
+| `miscompiled` | a real source-vs-codegen divergence |
+
+## Honest by design
+
+Same discipline as the Falsifier: a clean result means **"no miscompilation found
+within the bounds,"** never "the compiler is proven correct." It's unsound-complete —
+every divergence reported is a *real* discrepancy between source and codegen (no false
+positives), but absence of a finding is not a proof of correctness.
+
+Two consequences worth stating plainly:
+
+- **Only instantiated functions are validated.** An uncalled function is dead code and
+  never reaches the binary, so there's nothing to certify.
+- **Coverage is bounded by what the interpreter models** — pure `int` / `[]int` /
+  `bool` / `struct` / `string` logic (arithmetic, comparisons, bitwise, shifts,
+  control flow, slice literals + `append` + index + `len` + `range`, and
+  interprocedural calls). A function using floats-as-domain, bytes, maps, channels, or
+  I/O comes back `unknown` — it is **never** falsely certified.
+
+## What this is for
+
+It turns "trust the compiler" — the assumption every language asks you to make — into
+per-build evidence. Run it in CI, and a codegen regression that miscompiles any
+validatable function fails the build with the exact input that exposes it. It is the
+foundation the rest of machin's evidence stands on: race-freedom, falsification, and
+replay are only as trustworthy as the binary faithfully implementing the source they
+reason about.
+
+*Rust proves your program is safe. Zig gives you control. machin proves the compiler
+didn't lie to you.*


### PR DESCRIPTION
Wraps up the self-certifying compiler (Slices 1.1/1.2) at its honest coverage ceiling.

- **`docs/self-certifying-compiler.md`** — what `machin certify` does (source interpreter vs compiled binary over the falsifier's bounded domain), the verdict taxonomy, and the honesty rules.
- **`certify_gate_test.go` — `TestCertifyCodegenPaths`**: a battery of 11 dense, certify-friendly programs spanning arithmetic, comparisons, bitwise, shifts, boolean short-circuit, guarded modulo, bounded recursion, slice literal/append/index/len/range, structs, strings, and interprocedural calls. Every one must certify with no miscompilation. Running under `go test`, it's the **continuous-self-certification gate**: a codegen change that miscompiles any validatable path fails the build.

### Gate
- `go test .` (incl. the new battery + coverage floor) → ok

_Next: #2 — deadlock-freedom (the Falsifier for schedules)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)