### PR TITLE
feat(deadlock): self-host the DL001 finder (oracle-identical to the Go pass)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 # coverage reports (make cover)
 coverage.out
 coverage.html
-selfhost/mfl-lex
-selfhost/mfl-parse
+# self-hosted oracle binaries (built by the verify-*.sh gates)
+selfhost/mfl-*

--- a/deadlock_check.go
+++ b/deadlock_check.go
@@ -1,5 +1,7 @@
 package main
 
+import "sort"
+
 // deadlock_check.go — a compile-time, sound-but-partial deadlock finder. machin channels
 // are unbounded (a send never blocks), so a receive on a channel that NOTHING ever sends to
 // or closes blocks forever in EVERY schedule — a guaranteed deadlock, detectable statically,
@@ -59,6 +61,13 @@ func detectDeadlocks(prog *Program, c *Checker) []dlFinding {
 			}
 		}
 	}
+	// deterministic order (per-function channel set is a map): sort by function, then channel.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Decl != out[j].Decl {
+			return out[i].Decl < out[j].Decl
+		}
+		return out[i].Chan < out[j].Chan
+	})
 	return out
 }
 

--- a/deadlock_check_test.go
+++ b/deadlock_check_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 // dlCheck parses + typechecks a program and returns the compile-time deadlock findings.
 func dlCheck(t *testing.T, decls ...string) []dlFinding {
@@ -122,4 +127,72 @@ func TestDeadlockFinderScanCoverage(t *testing.T) {
 	if d.Phase != "deadlock" || d.Code != "DL001" || d.Severity != "warning" {
 		t.Fatalf("diagnostic = phase %q code %q sev %q", d.Phase, d.Code, d.Severity)
 	}
+}
+
+// TestDeadlockTestCommand exercises the `machin deadlocktest` oracle command (the
+// self-hosting oracle): it dumps DL001 findings in the canonical hex form, and handles
+// the no-arg / missing-file / parse-error / check-error paths.
+func TestDeadlockTestCommand(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	// a program with a DL001 finding — capture stdout to confirm a canonical line is dumped.
+	dl := write("dl.mfl", "func main() { ch := make(chan int) v := <-ch println(str(v)) }\n")
+	out := captureStdoutDL(t, func() {
+		if err := cmdDeadlockTest([]string{"--program", dl}); err != nil {
+			t.Fatalf("deadlocktest: %v", err)
+		}
+	})
+	if !strings.Contains(out, "|444c303031|") { // hex("DL001")
+		t.Fatalf("expected a DL001 hex line, got %q", out)
+	}
+
+	// clean program — no findings, empty output.
+	clean := write("clean.mfl", "func s(c) { c <- 1 }\nfunc main() { ch := make(chan int) go s(ch) v := <-ch println(str(v)) }\n")
+	if out := captureStdoutDL(t, func() { _ = cmdDeadlockTest([]string{"--program", clean}) }); strings.TrimSpace(out) != "" {
+		t.Fatalf("clean program should dump nothing, got %q", out)
+	}
+
+	// error / edge paths.
+	if err := cmdDeadlockTest(nil); err == nil {
+		t.Fatal("expected usage error with no --program")
+	}
+	if err := cmdDeadlockTest([]string{"--program", filepath.Join(dir, "nope.mfl")}); err == nil {
+		t.Fatal("expected error for a missing file")
+	}
+	perr := write("perr.mfl", "func main() { x := }\n")
+	if out := captureStdoutDL(t, func() { _ = cmdDeadlockTest([]string{"--program", perr}) }); !strings.Contains(out, "(parse-error)") && !strings.Contains(out, "(check-error)") {
+		t.Fatalf("malformed source should report parse/check-error, got %q", out)
+	}
+}
+
+// captureStdoutDL runs fn with os.Stdout redirected to a pipe and returns what it wrote.
+func captureStdoutDL(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved := os.Stdout
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = saved
+	var b strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			b.Write(buf[:n])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return b.String()
 }

--- a/deadlocktest.go
+++ b/deadlocktest.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// cmdDeadlockTest is the self-hosting oracle for the compile-time deadlock finder:
+//
+//	machin deadlocktest --program <file.mfl>
+//
+// It runs parse → liftClosures → check → detectDeadlocks and dumps every DL001 finding
+// in a canonical, escaping-free form (one per line, fields hex-encoded, sorted by
+// function then channel) so the MFL port (selfhost/deadlock.src) can be byte-diffed.
+func cmdDeadlockTest(args []string) error {
+	var path string
+	for _, a := range args {
+		if a != "--program" {
+			path = a
+		}
+	}
+	if path == "" {
+		return fmt.Errorf("usage: machin deadlocktest --program <file.mfl>")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var decls []string
+	for _, ln := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(ln) != "" {
+			decls = append(decls, ln)
+		}
+	}
+	prog, err := ParseProgram(decls)
+	if err != nil {
+		fmt.Println("(parse-error)")
+		return nil
+	}
+	liftClosures(prog)
+	c, err := Check(prog)
+	if err != nil {
+		fmt.Println("(check-error)")
+		return nil
+	}
+	hx := func(s string) string { return hex.EncodeToString([]byte(s)) }
+	fs := detectDeadlocks(prog, c)
+	sort.Slice(fs, func(i, j int) bool {
+		if fs[i].Decl != fs[j].Decl {
+			return fs[i].Decl < fs[j].Decl
+		}
+		return fs[i].Chan < fs[j].Chan
+	})
+	var b strings.Builder
+	for _, f := range fs {
+		b.WriteString(hx(f.Decl) + "|" + hx(f.Code) + "|" + hx(f.Chan) + "|" + hx(f.Prop) + "\n")
+	}
+	os.Stdout.WriteString(b.String())
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -68,6 +68,12 @@ func main() {
 			os.Exit(1)
 		}
 		return
+	case "deadlocktest":
+		if err := cmdDeadlockTest(os.Args[2:]); err != nil { // self-hosting oracle: dump DL001 findings canonically
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
 	case "uftest":
 		if err := cmdUFTest(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "error:", err)

--- a/selfhost/deadlock.src
+++ b/selfhost/deadlock.src
@@ -1,0 +1,325 @@
+// selfhost/deadlock.src — compile-time deadlock finder (DL001), MFL port of
+// deadlock_check.go, byte-diffed against `machin deadlocktest --program`. Reports a
+// receive on a channel that nothing ever sends to or closes — a guaranteed deadlock
+// (machin channels are unbounded, so such a receive blocks in every schedule).
+// False-positive-free: a channel is treated as fed unless the analysis PROVES it never
+// is; any use it can't account for conservatively counts as a feed.
+//
+// Node kinds used: K_MAKECHAN(15) s=elem; K_RECV(17) a=chan; K_SEND(30) a=chan b=val;
+// K_GO(31) a=call; K_CALL(9) s=callee kids=args; K_RANGE(27) a=X kids=body;
+// K_ASSIGN(20) s=name s2=op a=val; K_IF(25) a=cond kids=then kids2=else;
+// K_WHILE(26) a=cond kids=body; K_ARENA(32) kids=body; K_MULTI(21) kids=rhs;
+// K_RETURN(22) kids=vals; K_EXPRSTMT(19) a=expr; K_SELECT(33) kids=cases kids2=deflt;
+// K_SELCASE ival=is_send a=chan b=val kids=body; K_ID(6) s=name; K_BIN(8) a=L b=R;
+// K_UNARY(7) a=X; K_INDEX(11) a=X b=idx; K_FIELD(12) a=X; K_SLICE(13)/K_STRUCT(14) kids.
+
+// findings, in discovery order: (function, channel var).
+var g_dl_fn = []string{}
+var g_dl_ch = []string{}
+
+// dl_sidx: index of v in a string slice, or -1.
+func dl_sidx(arr, v) (r) {
+    r = -1
+    i := 0
+    for i < len(arr) { if arr[i] == v { r = i  return r }  i = i + 1 }
+}
+
+// ---- feed fixpoint: which channel params does each function send to / close? ----
+// stored as parallel (function name, param index) pairs.
+var g_feed_fn = []string{}
+var g_feed_p = []int{}
+var g_feed_changed = 0
+
+func dl_feeds(fnname, p) (b) {
+    b = 0
+    i := 0
+    for i < len(g_feed_fn) {
+        if g_feed_fn[i] == fnname && g_feed_p[i] == p { b = 1  return b }
+        i = i + 1
+    }
+}
+func dl_add_feed(fnname, p) {
+    if p < 0 { return }
+    if dl_feeds(fnname, p) == 1 { return }
+    g_feed_fn = append(g_feed_fn, fnname)
+    g_feed_p = append(g_feed_p, p)
+    g_feed_changed = 1
+}
+// dl_param_idx: index of param `name` in function root fr, or -1.
+func dl_param_idx(fr, name) (idx) {
+    idx = -1
+    ps := nodes[fr].names
+    i := 0
+    for i < len(ps) { if ps[i] == name { idx = i  return idx }  i = i + 1 }
+}
+
+// dl_feed_call: mark feeds induced by a call node (close, or a user callee feeding a param).
+func dl_feed_call(fnname, fr, callidx) {
+    c := nodes[callidx]
+    if c.kind != K_CALL { return }
+    if c.s == "close" {
+        if len(c.kids) == 1 {
+            an := nodes[c.kids[0]]
+            if an.kind == K_ID { dl_add_feed(fnname, dl_param_idx(fr, an.s)) }
+        }
+        return
+    }
+    gr := func_root(c.s)
+    if gr < 0 { return }   // unknown/builtin callee
+    j := 0
+    for j < len(c.kids) {
+        an := nodes[c.kids[j]]
+        if an.kind == K_ID { if dl_feeds(c.s, j) == 1 { dl_add_feed(fnname, dl_param_idx(fr, an.s)) } }
+        j = j + 1
+    }
+}
+
+// dl_feed_stmts: accumulate feeds over a statement body (recurses into nested blocks).
+func dl_feed_stmts(fnname, fr, kids) {
+    for _, si := range kids {
+        n := nodes[si]
+        k := n.kind
+        if k == K_SEND {
+            chn := nodes[n.a]
+            if chn.kind == K_ID { dl_add_feed(fnname, dl_param_idx(fr, chn.s)) }
+        } else { if k == K_GO {
+            dl_feed_call(fnname, fr, n.a)
+        } else { if k == K_EXPRSTMT {
+            if nodes[n.a].kind == K_CALL { dl_feed_call(fnname, fr, n.a) }
+        } else { if k == K_ASSIGN {
+            if nodes[n.a].kind == K_CALL { dl_feed_call(fnname, fr, n.a) }
+        } else { if k == K_IF {
+            dl_feed_stmts(fnname, fr, n.kids)
+            dl_feed_stmts(fnname, fr, n.kids2)
+        } else { if k == K_WHILE {
+            dl_feed_stmts(fnname, fr, n.kids)
+        } else { if k == K_RANGE {
+            dl_feed_stmts(fnname, fr, n.kids)
+        } else { if k == K_ARENA {
+            dl_feed_stmts(fnname, fr, n.kids)
+        } else { if k == K_SELECT {
+            for _, ci := range n.kids { dl_feed_stmts(fnname, fr, nodes[ci].kids) }
+            dl_feed_stmts(fnname, fr, n.kids2)
+        }}}}}}}}}
+    }
+}
+
+func dl_compute_feeds() {
+    g_feed_changed = 1
+    for g_feed_changed == 1 {
+        g_feed_changed = 0
+        fi := 0
+        for fi < len(g_func_names) {
+            fr := g_func_roots[fi]
+            dl_feed_stmts(g_func_names[fi], fr, nodes[fr].kids)
+            fi = fi + 1
+        }
+    }
+}
+
+// ---- per-function scan: classify each channel-var use as received / fed ----
+var g_scan_chans = []string{}   // make(chan) locals in the current function
+var g_scan_recv = []string{}    // received-from
+var g_scan_fed = []string{}     // sent-to / closed / escaped (conservatively fed)
+
+func dl_is_chan(name) (b) { b = 0  if dl_sidx(g_scan_chans, name) >= 0 { b = 1 } }
+func dl_mark_recv(name) { if dl_sidx(g_scan_recv, name) < 0 { g_scan_recv = append(g_scan_recv, name) } }
+func dl_mark_fed(name)  { if dl_sidx(g_scan_fed, name)  < 0 { g_scan_fed  = append(g_scan_fed,  name) } }
+
+// dl_collect_chans: find `x := make(chan ...)` locals in a body (recurses).
+func dl_collect_chans(kids) {
+    for _, si := range kids {
+        n := nodes[si]
+        k := n.kind
+        if k == K_ASSIGN {
+            if n.s2 == ":=" { if nodes[n.a].kind == K_MAKECHAN { if dl_sidx(g_scan_chans, n.s) < 0 { g_scan_chans = append(g_scan_chans, n.s) } } }
+        } else { if k == K_IF {
+            dl_collect_chans(n.kids)  dl_collect_chans(n.kids2)
+        } else { if k == K_WHILE {
+            dl_collect_chans(n.kids)
+        } else { if k == K_RANGE {
+            dl_collect_chans(n.kids)
+        } else { if k == K_ARENA {
+            dl_collect_chans(n.kids)
+        } else { if k == K_SELECT {
+            for _, ci := range n.kids { dl_collect_chans(nodes[ci].kids) }
+            dl_collect_chans(n.kids2)
+        }}}}}}
+    }
+}
+
+// dl_scan_call: classify a call's channel args (close feeds; a callee feeds a param;
+// an unknown callee conservatively feeds).
+func dl_scan_call(callidx) {
+    c := nodes[callidx]
+    if c.s == "close" {
+        if len(c.kids) == 1 {
+            an := nodes[c.kids[0]]
+            if an.kind == K_ID { if dl_is_chan(an.s) == 1 { dl_mark_fed(an.s)  return } }
+        }
+    }
+    known := 0
+    if func_root(c.s) >= 0 { known = 1 }
+    j := 0
+    for j < len(c.kids) {
+        an := nodes[c.kids[j]]
+        if an.kind == K_ID && dl_is_chan(an.s) == 1 {
+            if known == 0 { dl_mark_fed(an.s) } else { if dl_feeds(c.s, j) == 1 { dl_mark_fed(an.s) } }
+        } else {
+            dl_scan_expr(c.kids[j])
+        }
+        j = j + 1
+    }
+}
+
+// dl_scan_expr: escape-aware — a bare channel Ident here escaped into an unanalyzed
+// position, so (to stay sound) it counts as a possible feed.
+func dl_scan_expr(idx) {
+    if idx < 0 { return }
+    n := nodes[idx]
+    k := n.kind
+    if k == K_ID {
+        if dl_is_chan(n.s) == 1 { dl_mark_fed(n.s) }
+    } else { if k == K_RECV {
+        cn := nodes[n.a]
+        if cn.kind == K_ID && dl_is_chan(cn.s) == 1 { dl_mark_recv(cn.s) } else { dl_scan_expr(n.a) }
+    } else { if k == K_CALL {
+        dl_scan_call(idx)
+    } else { if k == K_BIN {
+        dl_scan_expr(n.a)  dl_scan_expr(n.b)
+    } else { if k == K_UNARY {
+        dl_scan_expr(n.a)
+    } else { if k == K_INDEX {
+        dl_scan_expr(n.a)  dl_scan_expr(n.b)
+    } else { if k == K_FIELD {
+        dl_scan_expr(n.a)
+    } else { if k == K_SLICE {
+        for _, e := range n.kids { dl_scan_expr(e) }
+    } else { if k == K_STRUCT {
+        for _, e := range n.kids { dl_scan_expr(e) }
+    }}}}}}}}}
+}
+
+// dl_scan_stmts: classify uses of the tracked channel vars over a body.
+func dl_scan_stmts(kids) {
+    for _, si := range kids {
+        n := nodes[si]
+        k := n.kind
+        if k == K_SEND {
+            cn := nodes[n.a]
+            if cn.kind == K_ID && dl_is_chan(cn.s) == 1 { dl_mark_fed(cn.s) } else { dl_scan_expr(n.a) }
+            dl_scan_expr(n.b)
+        } else { if k == K_EXPRSTMT {
+            if nodes[n.a].kind == K_CALL { dl_scan_call(n.a) } else { dl_scan_expr(n.a) }
+        } else { if k == K_GO {
+            dl_scan_call(n.a)
+        } else { if k == K_ASSIGN {
+            if nodes[n.a].kind == K_MAKECHAN {
+                // the declaration itself — no channel use
+            } else { if nodes[n.a].kind == K_ID && dl_is_chan(nodes[n.a].s) == 1 {
+                dl_mark_fed(nodes[n.a].s)   // aliased into another var — an escape
+            } else { if nodes[n.a].kind == K_CALL {
+                dl_scan_call(n.a)
+            } else {
+                dl_scan_expr(n.a)
+            }}}
+        } else { if k == K_MULTI {
+            for _, r := range n.kids {
+                rn := nodes[r]
+                if rn.kind == K_RECV && nodes[rn.a].kind == K_ID && dl_is_chan(nodes[rn.a].s) == 1 { dl_mark_recv(nodes[rn.a].s) } else { dl_scan_expr(r) }
+            }
+        } else { if k == K_RETURN {
+            for _, v := range n.kids { dl_scan_expr(v) }
+        } else { if k == K_IF {
+            dl_scan_expr(n.a)  dl_scan_stmts(n.kids)  dl_scan_stmts(n.kids2)
+        } else { if k == K_WHILE {
+            dl_scan_expr(n.a)  dl_scan_stmts(n.kids)
+        } else { if k == K_RANGE {
+            xn := nodes[n.a]
+            if xn.kind == K_ID && dl_is_chan(xn.s) == 1 { dl_mark_recv(xn.s) } else { dl_scan_expr(n.a) }
+            dl_scan_stmts(n.kids)
+        } else { if k == K_ARENA {
+            dl_scan_stmts(n.kids)
+        } else { if k == K_SELECT {
+            for _, ci := range n.kids {
+                sc := nodes[ci]
+                cn := nodes[sc.a]
+                if sc.ival == 0 {
+                    if cn.kind == K_ID && dl_is_chan(cn.s) == 1 { dl_mark_recv(cn.s) } else { dl_scan_expr(sc.a) }
+                } else {
+                    if cn.kind == K_ID && dl_is_chan(cn.s) == 1 { dl_mark_fed(cn.s) } else { dl_scan_expr(sc.a) }
+                    dl_scan_expr(sc.b)
+                }
+                dl_scan_stmts(sc.kids)
+            }
+            dl_scan_stmts(n.kids2)
+        }}}}}}}}}}}
+    }
+}
+
+// detect_deadlocks: fill g_dl_fn / g_dl_ch with DL001 findings.
+func detect_deadlocks() {
+    dl_compute_feeds()
+    fi := 0
+    for fi < len(g_func_names) {
+        fr := g_func_roots[fi]
+        g_scan_chans = []string{}
+        dl_collect_chans(nodes[fr].kids)
+        if len(g_scan_chans) > 0 {
+            g_scan_recv = []string{}
+            g_scan_fed = []string{}
+            dl_scan_stmts(nodes[fr].kids)
+            ci := 0
+            for ci < len(g_scan_chans) {
+                v := g_scan_chans[ci]
+                if dl_sidx(g_scan_recv, v) >= 0 && dl_sidx(g_scan_fed, v) < 0 {
+                    g_dl_fn = append(g_dl_fn, g_func_names[fi])
+                    g_dl_ch = append(g_dl_ch, v)
+                }
+                ci = ci + 1
+            }
+        }
+        fi = fi + 1
+    }
+}
+
+// dl_insert_at: insert v into an int slice at position pos.
+func dl_insert_at(arr, pos, v) (out) {
+    out = []int{}
+    i := 0
+    for i < len(arr) {
+        if i == pos { out = append(out, v) }
+        out = append(out, arr[i])
+        i = i + 1
+    }
+    if pos >= len(arr) { out = append(out, v) }
+}
+
+// dl_dump: findings sorted by (fn, chan), one hex line `fn|DL001|chan|prop` — the oracle
+// format `machin deadlocktest --program` emits (byte-diffed by verify-deadlock-selfhost.sh).
+func dl_dump() (out) {
+    order := []int{}
+    k := 0
+    for k < len(g_dl_fn) {
+        pos := len(order)
+        j := 0
+        for j < len(order) {
+            oj := order[j]
+            less := 0
+            if g_dl_fn[k] < g_dl_fn[oj] { less = 1 }
+            if g_dl_fn[k] == g_dl_fn[oj] { if g_dl_ch[k] < g_dl_ch[oj] { less = 1 } }
+            if less == 1 { pos = j  break }
+            j = j + 1
+        }
+        order = dl_insert_at(order, pos, k)
+        k = k + 1
+    }
+    out = ""
+    m := 0
+    for m < len(order) {
+        e := order[m]
+        prop := "receive on channel `" + g_dl_ch[e] + "` that is never sent to or closed — a guaranteed deadlock"
+        out = out + to_hex(bytes(g_dl_fn[e])) + "|" + to_hex(bytes("DL001")) + "|" + to_hex(bytes(g_dl_ch[e])) + "|" + to_hex(bytes(prop)) + "\n"
+        m = m + 1
+    }
+}

--- a/selfhost/deadlockmain.src
+++ b/selfhost/deadlockmain.src
@@ -1,0 +1,98 @@
+// selfhost/deadlockmain.src — `machin deadlocktest --program <file.mfl>` for the self-hosted
+// compile-time deadlock finder. Runs the same parse -> check pipeline as falsifymain, then
+// the deadlock analysis, dumping DL001 findings in the canonical hex form the Go oracle emits.
+
+func main() {
+    a := args()
+    if len(a) < 3 { write(2, "usage: deadlocktest --program <file.mfl>\n")  exit(2) }
+    if a[1] != "--program" { write(2, "only --program is supported\n")  exit(2) }
+    data := read_file(a[2])
+    lines := split(data, "\n")
+
+    // pass 1: seed struct names so T{...} parses
+    for _, ln := range lines {
+        reset(ln)
+        i := 0
+        while i + 1 < len(T) {
+            if T[i].val == "type" || T[i].val == "cstruct" {
+                if T[i + 1].kind == 1 { g_structs = append(g_structs, T[i + 1].val) }
+            }
+            i = i + 1
+        }
+    }
+    // pass 1b: register struct field names/types + extern cstructs/fns
+    for _, ln := range lines {
+        if has_prefix(ln, "type ") {
+            reset(ln)
+            tidx := parse_type_decl()
+            if g_err == 0 { register_struct(nodes[tidx].s, nodes[tidx].names, nodes[tidx].names2) }
+        }
+        if has_prefix(ln, "extern ") {
+            reset(ln)
+            eidx := parse_extern_decl()
+            if g_err == 0 {
+                for _, ci := range nodes[eidx].kids {
+                    cn := nodes[ci]
+                    register_struct(cn.s, cn.names, cn.names2)
+                }
+                for _, fi := range nodes[eidx].kids2 {
+                    fnn := nodes[fi]
+                    register_extfn(fnn.s, fnn.names, fnn.s2)
+                }
+            }
+        }
+    }
+
+    // pass 2: parse every function + global into the shared nodes array
+    nodes = []Node{}
+    global_names := []string{}
+    global_inits := []int{}
+    for _, ln := range lines {
+        if has_prefix(ln, "func ") || has_prefix(ln, "export func ") {
+            lex_only(ln)
+            r := parse_func_decl()
+            if g_err == 1 || pk().kind != 0 { write(1, "(parse-error)\n")  return }
+            g_func_names = append(g_func_names, nodes[r].s)
+            g_func_roots = append(g_func_roots, r)
+        }
+        if has_prefix(ln, "var ") {
+            lex_only(ln)
+            r := parse_global()
+            if g_err == 0 && pk().kind == 0 {
+                global_names = append(global_names, nodes[r].s)
+                global_inits = append(global_inits, nodes[r].a)
+            }
+        }
+    }
+
+    has_main := 0
+    if func_root("main") >= 0 { has_main = 1 }
+    exported := []string{}
+    i := 0
+    for i < len(g_func_names) {
+        if nodes[g_func_roots[i]].ival == 1 { exported = append(exported, g_func_names[i]) }
+        i = i + 1
+    }
+    if has_main == 0 && len(exported) == 0 { write(1, "(check-error)\n")  return }
+
+    init_consts()
+    gi := 0
+    for gi < len(global_names) {
+        vs := gen_expr(global_inits[gi])
+        gslot := new_slot(0)
+        add_pair(gslot, vs)
+        register_global(global_names[gi], gslot)
+        gi = gi + 1
+    }
+    if has_main == 1 { instantiate("main") }
+    for _, en := range exported { instantiate(en) }
+    if g_unsupported == 1 { write(1, "(unsupported)\n")  return }
+    solve()
+    resolve_deferred()
+    finalize()
+    if g_terr == 1 || g_check_err == 1 { write(1, "(check-error)\n")  return }
+
+    // the deadlock pass
+    detect_deadlocks()
+    write(1, dl_dump())
+}

--- a/selfhost/verify-deadlock-selfhost.sh
+++ b/selfhost/verify-deadlock-selfhost.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Oracle-diff gate for the SELF-HOSTED deadlock finder (selfhost/deadlock.src): its DL001
+# findings must be byte-identical to the Go reference `machin deadlocktest --program`.
+# (Distinct from the repo-root verify-deadlock.sh, which behaviorally tests the runtime
+# detector. This one proves the MFL port reproduces the Go compile-time oracle exactly.)
+set -u
+N="nice -n 15"
+MACHIN=./bin/machin
+T=$(mktemp -d)
+pass=0; fail=0
+
+echo "building Go machin (oracle) + MFL deadlock pass…"
+GOMAXPROCS=4 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
+$N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+    selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src \
+    selfhost/deadlock.src selfhost/deadlockmain.src > "$T/sh.mfl" || { echo "encode failed"; exit 1; }
+$N "$MACHIN" build "$T/sh.mfl" -o selfhost/mfl-deadlock || { echo "build failed"; exit 1; }
+echo "built selfhost/mfl-deadlock"
+
+run() { # file label
+  $N "$MACHIN" deadlocktest --program "$1" > "$T/o.txt" 2>/dev/null
+  $N ./selfhost/mfl-deadlock --program "$1" > "$T/m.txt" 2>/dev/null
+  if diff -q "$T/o.txt" "$T/m.txt" >/dev/null; then pass=$((pass+1)); echo "ok   $2"; else
+    fail=$((fail+1)); echo "MISMATCH: $2"; echo " oracle:"; cat "$T/o.txt"; echo " mfl:"; cat "$T/m.txt"; fi
+}
+
+# DL001 findings (a receive on a never-fed channel).
+printf 'func main(){ch:=make(chan int) v:=<-ch println(str(v))}\n' > "$T/d1"; run "$T/d1" "main recv nobody sends (DL001)"
+printf 'func worker(c){}\nfunc main(){ch:=make(chan int) go worker(ch) v:=<-ch println(str(v))}\n' > "$T/d2"; run "$T/d2" "goroutine never sends (DL001)"
+printf 'func main(){ch:=make(chan int) s:=0 for v:=range ch{s=s+v} println(str(s))}\n' > "$T/d3"; run "$T/d3" "range over never-fed (DL001)"
+printf 'func main(){a:=make(chan int) b:=make(chan int) x:=<-a y:=<-b println(str(x+y))}\n' > "$T/d4"; run "$T/d4" "two unfed channels (2x DL001)"
+
+# clean: fed by send / close / goroutine / indirect call chain / select send.
+printf 'func send(c){c<-7}\nfunc main(){ch:=make(chan int) go send(ch) v:=<-ch println(str(v))}\n' > "$T/c1"; run "$T/c1" "goroutine sends (clean)"
+printf 'func prod(c){i:=0 for i<3{c<-i i=i+1} close(c)}\nfunc main(){ch:=make(chan int) go prod(ch) s:=0 for v:=range ch{s=s+v} println(str(s))}\n' > "$T/c2"; run "$T/c2" "producer closes (clean)"
+printf 'func inner(c){c<-42}\nfunc outer(c){inner(c)}\nfunc main(){ch:=make(chan int) go outer(ch) v:=<-ch println(str(v))}\n' > "$T/c3"; run "$T/c3" "indirect feed via call chain (clean)"
+printf 'func a(x,y){v:=<-x y<-v}\nfunc main(){p:=make(chan int) q:=make(chan int) go a(p,q) r:=<-q p<-r println("done")}\n' > "$T/c4"; run "$T/c4" "mutual wait — both fed, runtime-only (clean)"
+printf 'func feed(c){c<-1}\nfunc main(){a:=make(chan int) b:=make(chan int) go feed(a) go feed(b) select{case v:=<-a: println(str(v)) case b<-9: println("s")}}\n' > "$T/c5"; run "$T/c5" "select recv+send (clean)"
+printf 'func feed(c){c<-1 close(c)}\nfunc main(){ch:=make(chan int) go feed(ch) n:=0 while n<1{arena{v,ok:=<-ch if ok{println(str(v))}} n=n+1}}\n' > "$T/c6"; run "$T/c6" "comma-ok recv under arena/while/if (clean)"
+
+echo
+echo "self-hosted deadlock oracle-diff: $pass pass, $fail fail"
+rm -rf "$T"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## DL001 self-host port

Ports the compile-time deadlock finder to the self-hosted compiler — the analogue of the Falsifier's Phase 2 — so `machin check`'s DL001 warning is produced **identically** whether the Go-hosted or the self-hosted compiler ran the analysis.

- **`selfhost/deadlock.src`** — the analysis reimplemented over the self-hosted `nodes[]` AST: the per-function **feed fixpoint** (which channel params a function sends to / closes, directly or through a callee) and the **escape-aware scan** (received-from vs fed, any unaccounted use conservatively a feed). Same false-positive-free logic as `deadlock_check.go`.
- **`selfhost/deadlockmain.src`** — `deadlocktest --program` driver (same parse→typecheck pipeline as `falsifymain`, then `detect_deadlocks` + `dl_dump`, sorted + hex-encoded).
- **`deadlocktest.go`** — the Go oracle `machin deadlocktest --program`.
- **`selfhost/verify-deadlock-selfhost.sh`** — the oracle-diff gate.

`detectDeadlocks` now **sorts** its output (its per-function channel set is a map, so the order was nondeterministic); the oracle relies on that.

### Gates
- `selfhost/verify-deadlock-selfhost.sh` → **10/10 byte-identical** (Go vs self-hosted): 4 DL001-producing + 6 clean, covering send / close / goroutine / indirect-call-chain / select / comma-ok-under-arena.
- `go test .` → ok (incl. a `deadlocktest`-command test restoring the coverage floor)

With this, the deadlock-freedom arc is fully self-hosted — the entire concurrency-safety stack (race-freedom, deadlock detection, replay) reproduces itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `deadlocktest` command for analyzing programs and reporting DL001 deadlock findings.
  * Added a self-hosted deadlock detector with deterministic, canonical output.
  * Added validation for missing, invalid, or malformed program inputs.

* **Bug Fixes**
  * Deadlock results are now returned in a consistent, predictable order.

* **Tests**
  * Added coverage for detected deadlocks, clean programs, and command-line error cases.
  * Added an oracle comparison check for self-hosted analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->