### PR TITLE
test(coverage): harden + speed up the coverage-floor guard

### DIFF
--- a/coverage_floor_helpers_test.go
+++ b/coverage_floor_helpers_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+// TestCoverageOutcome pins the hardening decision table: a failed test with a valid profile is a
+// NOTE (coverage still measured), a missing profile is FATAL (build error / crash).
+func TestCoverageOutcome(t *testing.T) {
+	cases := []struct {
+		haveProfile, runFailed bool
+		fatal, note            bool
+	}{
+		{true, false, false, false}, // clean run
+		{true, true, false, true},   // a test failed but coverage is valid → note, NOT fatal (the fix)
+		{false, true, true, false},  // no profile + run failed → build error/crash → fatal
+		{false, false, true, false}, // no profile, no run error → unparseable profile → fatal
+	}
+	for _, c := range cases {
+		fatal, note := coverageOutcome(c.haveProfile, c.runFailed)
+		if fatal != c.fatal || note != c.note {
+			t.Errorf("coverageOutcome(%v,%v) = (fatal=%v,note=%v), want (fatal=%v,note=%v)",
+				c.haveProfile, c.runFailed, fatal, note, c.fatal, c.note)
+		}
+	}
+}
+
+// TestFixtureStatus + TestTailLines cover the small reporting helpers.
+func TestFixtureStatus(t *testing.T) {
+	if fixtureStatus(88.0, 87.0) != "intact" {
+		t.Error("above floor should be intact")
+	}
+	if fixtureStatus(86.0, 87.0) != "REGRESSED" {
+		t.Error("below floor should be REGRESSED")
+	}
+	if fixtureStatus(87.0, 87.0) != "intact" {
+		t.Error("exactly at floor should be intact")
+	}
+}
+
+func TestTailLines(t *testing.T) {
+	if got := tailLines("a\nb\nc\nd", 2); got != "c\nd" {
+		t.Errorf("tailLines = %q, want %q", got, "c\nd")
+	}
+	if got := tailLines("only", 5); got != "only" {
+		t.Errorf("tailLines fewer-than-n = %q", got)
+	}
+}

--- a/coverage_floor_test.go
+++ b/coverage_floor_test.go
@@ -34,12 +34,30 @@ const typesCoverageFloor = 87.0
 // recursively only.
 const coverageReentryEnv = "COVERAGE_FLOOR_REENTRY"
 
+// coverageSkip is a -skip regex for the coverage subprocess: slow runtime
+// INTEGRATION tests that do not drive the front-end (Phase 1-6) coverage this
+// floor guards, so excluding them from the measurement costs ~0.1pp of package
+// total (measured) while cutting the subprocess ~40% (73s -> 45s). Two of them
+// (the ru_maxrss arena-ratio tests) are additionally env-dependent and can flake
+// under the parallel, coverage-instrumented subprocess; dropping them here removes
+// that flake at its source. These tests still run — and gate pass/fail — in the
+// normal `go test .` invocation; only this coverage-MEASUREMENT reentry skips them.
+const coverageSkip = "TestStaticBuildBundlesSqlite|" +
+	"TestDeadlockStrictIO|" +
+	"TestReadBytesLoopReassemblesLargePayload|" +
+	"TestScopedArenaReclaimsInlineAllocations|" +
+	"TestScopedArenaBoundsMemory"
+
 // TestTypesCoverageFloor is the regression guard for the Phase 1-6
-// coverage push. It spawns `go test -short -coverprofile=X .` as a
-// subprocess so the coverage profile includes all of Phase 1-6 +
-// whatever else is in the suite, parses X for the package-total
-// statement coverage via `go tool cover -func`, and asserts that
-// ≥ typesCoverageFloor.
+// coverage push. It spawns `go test -short -skip=<slow-integration>
+// -coverprofile=X .` as a subprocess so the coverage profile includes
+// all of Phase 1-6 + whatever else is in the suite, parses X for the
+// package-total statement coverage via `go tool cover -func`, and
+// asserts that ≥ typesCoverageFloor. The -skip drops a handful of slow
+// runtime integration tests (see coverageSkip) that don't drive this
+// floor — ~40% faster subprocess — and coverage is read from the
+// profile even if a test fails (see coverageOutcome), so a flaky
+// integration test can't turn the floor red.
 //
 // Fires inside the standard `go test ./...` invocation (and so inside
 // the existing CI step) — no separate CI step required. Skips under
@@ -66,18 +84,33 @@ func TestTypesCoverageFloor(t *testing.T) {
 	profilePath := filepath.Join(t.TempDir(), "coverage.out")
 	cmd := exec.Command("go", "test",
 		"-count=1", "-short",
+		"-skip="+coverageSkip,
 		"-coverprofile="+profilePath,
 		".")
 	cmd.Env = append(os.Environ(), coverageReentryEnv+"=1")
-	raw, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("subprocess `go test` failed: %v\n%s", err, raw)
-	}
+	raw, runErr := cmd.CombinedOutput()
 
-	got, err := coverPkgTotal(profilePath)
-	if err != nil {
-		t.Fatalf("coverPkgTotal: %v\nsubprocess tail:\n%s",
-			err, tailLines(string(raw), 15))
+	// Measure coverage from the profile, which `go test` writes even when a test
+	// fails. This test's job is to guard the coverage NUMBER, not to re-adjudicate
+	// the suite's pass/fail — the outer `go test` run already does that. So a flaky
+	// integration test (e.g. an env-dependent ru_maxrss ratio) must not turn the
+	// coverage floor red. Only fail here if the profile is unusable, which means the
+	// subprocess never got far enough to measure coverage (a build error or a panic
+	// that crashed the binary before the profile was written).
+	got, covErr := coverPkgTotal(profilePath)
+	fatal, note := coverageOutcome(covErr == nil, runErr != nil)
+	if fatal {
+		if runErr != nil {
+			t.Fatalf("coverage subprocess produced no usable profile (build error or crash, not a coverage regression): %v\n%s",
+				runErr, tailLines(string(raw), 20))
+		}
+		t.Fatalf("coverPkgTotal: %v\nsubprocess tail:\n%s", covErr, tailLines(string(raw), 15))
+	}
+	if note {
+		// The profile is valid, so coverage is measurable; a test failed but that is
+		// the outer run's concern, not the floor guard's. Surface it as a note.
+		t.Logf("note: a test failed in the coverage subprocess (coverage still measured from the written profile; the main `go test` run is the pass/fail gate):\n%s",
+			tailLines(string(raw), 8))
 	}
 	t.Logf("package total: %.2f%% (floor %.2f%%) — Phase 1-6 fixtures %s",
 		got, floor, fixtureStatus(got, floor))
@@ -96,6 +129,20 @@ func TestTypesCoverageFloor(t *testing.T) {
 			"restore / strengthen the fixture (or, deliberately, bump the floor).",
 			got, floor, got, floor-got)
 	}
+}
+
+// coverageOutcome is the decision table for the coverage subprocess. `haveProfile` is whether a
+// parseable coverage profile was produced; `runFailed` is whether the subprocess `go test`
+// exited non-zero. A missing profile means the subprocess never got far enough to measure
+// coverage (a build error or a crash before the profile flush) → fatal. A valid profile with a
+// run failure means a test failed but coverage is still measurable → not fatal (the outer
+// `go test` is the pass/fail gate); surface it as a note so a flaky integration test can't turn
+// the coverage floor red.
+func coverageOutcome(haveProfile bool, runFailed bool) (fatal, note bool) {
+	if !haveProfile {
+		return true, false
+	}
+	return false, runFailed
 }
 
 // coverPkgTotal parses the canonical `total: (statements) NN.N%` line


### PR DESCRIPTION
The coverage-floor test spawns `go test -short -coverprofile` as a subprocess to measure package coverage, then asserted the subprocess exited zero. That conflated two jobs — **measuring coverage** and **re-adjudicating pass/fail** — so any flaky test in the subprocess (notably the env-dependent `ru_maxrss` arena-ratio tests, which can collapse under the parallel, coverage-instrumented run) turned the coverage floor red even though coverage was fine. Seen red ~half the runs this session.

## 1. Harden
Read coverage from the profile, which `go test` writes even when a test fails. Only fail if the profile is **unusable** (build error / crash before the profile flush); a test failure with a valid profile is a **note**, not fatal. The outer `go test` run stays the pass/fail gate. The decision table is extracted to `coverageOutcome()` and unit-tested.

## 2. Speed + de-flake
Add `-skip` to the coverage subprocess for a few slow runtime **integration** tests (static sqlite bundle ~20s, deadlock strict-IO, large read-bytes reassembly, the two arena `ru_maxrss` ratio tests) that don't drive the Phase 1-6 front-end coverage this floor guards.

| measurement | before | after |
|---|---|---|
| package total | 87.9% | **87.8%** (floor 87.0) |
| coverage subprocess | ~73s | **~45s** (−40%) |
| full `go test .` | ~230s | **~127s** |

These tests still run — and gate pass/fail — in the normal `go test .`; only this coverage-measurement reentry skips them. Skipping the arena ratio tests also removes the flake at its source.

## Tests
`coverage_floor_helpers_test.go` — fast unit tests for `coverageOutcome` (incl. the failed-test-but-valid-profile case that is the whole point), `fixtureStatus`, `tailLines`.

Test-only change (no production code). Floor still 87.0; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)