### PR TITLE
feat(crypto): RSA PKCS#1 SHA-256 sign/verify + JWK RS256 verify (#484)

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -2854,6 +2854,9 @@ const cryptoRuntime = `#include <openssl/evp.h>
 #include <openssl/ec.h>
 #include <openssl/ecdsa.h>
 #include <openssl/obj_mac.h>
+#include <openssl/rsa.h>
+#include <openssl/pem.h>
+#include <openssl/bn.h>
 #include <string.h>
 
 static mfl_bytes mfl_crypto_buf(int64_t n) {
@@ -2956,6 +2959,111 @@ static int mfl_crypto_ed25519_verify(mfl_bytes pub, mfl_bytes msg, mfl_bytes sig
         if (c) EVP_MD_CTX_free(c);
         EVP_PKEY_free(pk);
     }
+    return ok;
+}
+
+/* RSA PKCS#1 v1.5 signatures over SHA-256 (RS256). Unblocks local RS256 JWT
+   verification (verify an IdP's id_token against its JWKS n/e) and SAML SP keys
+   — the gap identified in issue #484. PEM keys are parsed via a memory BIO; the
+   JWKS path builds the public key straight from the raw big-endian modulus (n)
+   and exponent (e) bytes a JWKS exposes as base64url. */
+typedef struct { mfl_bytes priv; mfl_bytes pub; } mfl_crypto_rsa_keypair;
+
+/* Generate an RSA keypair; returns PEM (PKCS#8 private, SubjectPublicKeyInfo
+   public), both empty on failure. Keygen draws from the CSPRNG internally and —
+   like the ECDSA nonce in secp256k1_sign_recoverable — is NOT captured by
+   record/replay, so a program that mints a key at runtime is best-effort for
+   replay (generate once at setup, not on a hot replayed path). */
+static mfl_crypto_rsa_keypair mfl_crypto_rsa_generate(int64_t bits) {
+    mfl_crypto_rsa_keypair kp;
+    kp.priv = mfl_crypto_buf(1); kp.priv.len = 0;
+    kp.pub  = mfl_crypto_buf(1); kp.pub.len  = 0;
+    int nbits = (int)(bits >= 512 ? bits : 2048);
+    EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+    EVP_PKEY* pk = NULL;
+    if (ctx && EVP_PKEY_keygen_init(ctx) > 0 &&
+        EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, nbits) > 0 &&
+        EVP_PKEY_keygen(ctx, &pk) > 0) {
+        BIO* b1 = BIO_new(BIO_s_mem());
+        if (b1 && PEM_write_bio_PrivateKey(b1, pk, NULL, NULL, 0, NULL, NULL)) {
+            char* p = NULL; long n = BIO_get_mem_data(b1, &p);
+            if (n > 0) { mfl_bytes o = mfl_crypto_buf(n); memcpy(o.data, p, (size_t)n); o.len = n; kp.priv = o; }
+        }
+        if (b1) BIO_free(b1);
+        BIO* b2 = BIO_new(BIO_s_mem());
+        if (b2 && PEM_write_bio_PUBKEY(b2, pk)) {
+            char* p = NULL; long n = BIO_get_mem_data(b2, &p);
+            if (n > 0) { mfl_bytes o = mfl_crypto_buf(n); memcpy(o.data, p, (size_t)n); o.len = n; kp.pub = o; }
+        }
+        if (b2) BIO_free(b2);
+    }
+    if (pk) EVP_PKEY_free(pk);
+    if (ctx) EVP_PKEY_CTX_free(ctx);
+    return kp;
+}
+static int mfl_crypto_rsa_verify_evp(EVP_PKEY* pk, mfl_bytes msg, mfl_bytes sig) {
+    int ok = 0;
+    EVP_MD_CTX* c = EVP_MD_CTX_new();
+    if (c && EVP_DigestVerifyInit(c, NULL, EVP_sha256(), NULL, pk) > 0)
+        ok = EVP_DigestVerify(c, sig.data, (size_t)sig.len, msg.data, (size_t)msg.len) == 1;
+    if (c) EVP_MD_CTX_free(c);
+    return ok;
+}
+/* Sign msg with a PEM private key -> PKCS#1 v1.5 signature (empty on failure). */
+static mfl_bytes mfl_crypto_rsa_sign_pkcs1_sha256(mfl_bytes priv_pem, mfl_bytes msg) {
+    mfl_bytes out = mfl_crypto_buf(1); out.len = 0;
+    BIO* bio = BIO_new_mem_buf(priv_pem.data, (int)priv_pem.len);
+    if (!bio) return out;
+    EVP_PKEY* pk = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+    BIO_free(bio);
+    if (!pk) return out;
+    EVP_MD_CTX* c = EVP_MD_CTX_new();
+    if (c && EVP_DigestSignInit(c, NULL, EVP_sha256(), NULL, pk) > 0) {
+        size_t l = 0;
+        if (EVP_DigestSign(c, NULL, &l, msg.data, (size_t)msg.len) > 0 && l > 0) {
+            mfl_bytes sig = mfl_crypto_buf((int64_t)l);
+            if (EVP_DigestSign(c, sig.data, &l, msg.data, (size_t)msg.len) > 0) { sig.len = (int64_t)l; out = sig; }
+        }
+    }
+    if (c) EVP_MD_CTX_free(c);
+    EVP_PKEY_free(pk);
+    return out;
+}
+/* Verify sig over msg with a PEM public key (SubjectPublicKeyInfo). */
+static int mfl_crypto_rsa_verify_pkcs1_sha256(mfl_bytes pub_pem, mfl_bytes msg, mfl_bytes sig) {
+    BIO* bio = BIO_new_mem_buf(pub_pem.data, (int)pub_pem.len);
+    if (!bio) return 0;
+    EVP_PKEY* pk = PEM_read_bio_PUBKEY(bio, NULL, NULL, NULL);
+    BIO_free(bio);
+    if (!pk) return 0;
+    int ok = mfl_crypto_rsa_verify_evp(pk, msg, sig);
+    EVP_PKEY_free(pk);
+    return ok;
+}
+/* Build an RSA public key straight from raw modulus/exponent bytes (a JWKS's
+   base64url-decoded n and e), then verify. This is the RS256 JWT path: no PEM,
+   no X.509 — just the two JWKS numbers. */
+static int mfl_crypto_rsa_verify_jwk_sha256(mfl_bytes n, mfl_bytes e, mfl_bytes msg, mfl_bytes sig) {
+    BIGNUM* bn = BN_bin2bn(n.data, (int)n.len, NULL);
+    BIGNUM* be = BN_bin2bn(e.data, (int)e.len, NULL);
+    int ok = 0;
+    if (bn && be) {
+        RSA* rsa = RSA_new();
+        if (rsa && RSA_set0_key(rsa, bn, be, NULL) == 1) {
+            bn = NULL; be = NULL; /* ownership moved into rsa */
+            EVP_PKEY* pk = EVP_PKEY_new();
+            if (pk && EVP_PKEY_assign_RSA(pk, rsa) == 1) {
+                ok = mfl_crypto_rsa_verify_evp(pk, msg, sig);
+                EVP_PKEY_free(pk); /* frees rsa too */
+                rsa = NULL;
+            } else {
+                if (pk) EVP_PKEY_free(pk);
+            }
+        }
+        if (rsa) RSA_free(rsa);
+    }
+    if (bn) BN_free(bn);
+    if (be) BN_free(be);
     return ok;
 }
 static mfl_bytes mfl_crypto_aes_gcm_enc(mfl_bytes key, mfl_bytes iv, mfl_bytes pt, mfl_bytes aad) {
@@ -4031,6 +4139,8 @@ func multiRetBuiltinC(name string) (cfn, ctype string, fields []string, needsTLS
 		return "mfl_exec", "mfl_exec_result", []string{"code", "out", "err"}, false, true
 	case "mmap_file":
 		return "mfl_mmap_file", "mfl_mmap_result", []string{"ptr", "len"}, false, true
+	case "rsa_generate":
+		return "mfl_crypto_rsa_generate", "mfl_crypto_rsa_keypair", []string{"priv", "pub"}, false, true
 	}
 	return "", "", nil, false, false
 }
@@ -4198,6 +4308,9 @@ func (g *cgen) multiAssign(st *MultiAssign, depth int) error {
 			if cfn, ctype, fields, needsTLS, ok := multiRetBuiltinC(call.Callee); ok {
 				if needsTLS {
 					g.usesTLS = true
+				}
+				if strings.HasPrefix(cfn, "mfl_crypto_") {
+					g.usesCrypto = true
 				}
 				args := make([]string, len(call.Args))
 				for i, a := range call.Args {
@@ -5465,6 +5578,15 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "secp256k1_recover":
 		g.usesCrypto = true
 		return fmt.Sprintf("mfl_crypto_secp256k1_recover(%s, %s)", args[0], args[1]), nil
+	case "rsa_sign_pkcs1_sha256":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_rsa_sign_pkcs1_sha256(%s, %s)", args[0], args[1]), nil
+	case "rsa_verify_pkcs1_sha256":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_rsa_verify_pkcs1_sha256(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "rsa_verify_jwk_sha256":
+		g.usesCrypto = true
+		return fmt.Sprintf("mfl_crypto_rsa_verify_jwk_sha256(%s, %s, %s, %s)", args[0], args[1], args[2], args[3]), nil
 	case "has":
 		ik, sk := g.mapKeyArgs(ex.Args[0], args[1])
 		return fmt.Sprintf("mfl_map_has(%s, %s, %s)", args[0], ik, sk), nil

--- a/guide.go
+++ b/guide.go
@@ -332,6 +332,10 @@ func machinGuide() guideCatalog {
 			{"secp256k1_pubkey", "(bytes) -> bytes", "secp256k1 public key from a 32-byte private key -> 65-byte uncompressed point (0x04||X||Y); an Ethereum address is the last 20 bytes of keccak256(pub[1:])", "crypto"},
 			{"secp256k1_sign_recoverable", "(bytes, bytes) -> bytes", "secp256k1 ECDSA sign (priv32, hash32) -> 65-byte r||s||v (EIP-2 canonical low-S; v is 27/28) — the primitive behind eth_sign/EIP-712/raw tx signing", "crypto"},
 			{"secp256k1_recover", "(bytes, bytes) -> bytes", "secp256k1 ECDSA recover (hash32, sig65 r||s||v) -> the 65-byte uncompressed public key (empty bytes if invalid) — same math Solidity's ecrecover uses, for self-checking a signature before broadcasting it", "crypto"},
+			{"rsa_generate", "(int) -> (bytes, bytes)", "generate an RSA keypair of `bits` (>=512, default 2048) -> (private PEM, public PEM). MULTI-ASSIGN ONLY: priv, pub := rsa_generate(2048). For SAML SP keys / minting an RS256 signing key. Keygen uses the CSPRNG and is NOT captured by record/replay (generate at setup, not on a replayed path)", "crypto"},
+			{"rsa_sign_pkcs1_sha256", "(bytes, bytes) -> bytes", "RSA PKCS#1 v1.5 sign (private PEM, msg) -> signature over SHA-256 (RS256; empty bytes on failure)", "crypto"},
+			{"rsa_verify_pkcs1_sha256", "(bytes, bytes, bytes) -> bool", "RSA PKCS#1 v1.5 verify (public PEM SubjectPublicKeyInfo, msg, sig) over SHA-256 (RS256)", "crypto"},
+			{"rsa_verify_jwk_sha256", "(bytes, bytes, bytes, bytes) -> bool", "RS256 JWT verify straight from a JWKS: (n, e, msg, sig) where n and e are the base64url-decoded modulus & exponent bytes from the IdP's JWKS. Builds the RSA public key from n/e (no PEM/X.509 needed) and verifies PKCS#1 v1.5 over SHA-256 — the OIDC id_token verification path (issue #484)", "crypto"},
 			// sqlite (libsqlite3, linked only when used)
 			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
 			{"sqlite_exec", "(int, string[, []string]) -> int", "run SQL with no result; optional []string binds the ? params (injection-safe); 0 ok", "db"},

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// rsa_generate + rsa_sign_pkcs1_sha256 + rsa_verify_pkcs1_sha256 form a
+// self-contained round trip in pure MFL: mint a keypair, sign a message, verify
+// it holds, and confirm a tampered message fails. This is the RS256 primitive
+// that issue #484 asks for (unblocks local JWT signing/verification + SAML SP
+// keys) without any PEM/X.509 handling on the MFL side.
+func TestRSASignVerifyRoundTrip(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    priv, pub := rsa_generate(2048)
+    println("privpem=" + str(len(priv) > 0))
+    println("pubpem=" + str(len(pub) > 0))
+
+    msg := bytes("the quick brown fox jumps over the lazy dog")
+    sig := rsa_sign_pkcs1_sha256(priv, msg)
+    println("siglen=" + str(len(sig) == 256))
+
+    ok := rsa_verify_pkcs1_sha256(pub, msg, sig)
+    println("verify=" + str(ok))
+
+    bad := rsa_verify_pkcs1_sha256(pub, bytes("tampered payload"), sig)
+    println("tampered=" + str(bad))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"privpem=true", "pubpem=true", "siglen=true",
+		"verify=true", "tampered=false",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// rsa_verify_jwk_sha256 is THE RS256 JWT path: verify a signature straight from
+// a JWKS's raw modulus (n) and exponent (e) — no PEM, no X.509. We build a real
+// RS256 vector in Go (the same crypto/rsa an IdP uses), feed n/e/msg/sig into an
+// MFL program as hex, and assert the MFL builtin agrees: valid sig -> true, a
+// flipped signature byte -> false. This mirrors verifying an IdP id_token
+// against its published JWKS.
+func TestRSAVerifyJWK(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	msg := []byte("id_token.signing.input.example")
+	digest := sha256.Sum256(msg)
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// JWKS exposes n and e as base64url of the big-endian bytes; we pass the raw
+	// bytes (hex here) — the builtin base64url-decodes on the MFL caller's side.
+	nBytes := key.N.Bytes()
+	eBytes := key.PublicKey.E // int; encode big-endian, trimming leading zeros
+	eb := []byte{byte(eBytes >> 16), byte(eBytes >> 8), byte(eBytes)}
+	for len(eb) > 1 && eb[0] == 0 {
+		eb = eb[1:]
+	}
+
+	badSig := make([]byte, len(sig))
+	copy(badSig, sig)
+	badSig[0] ^= 0xff
+
+	src := fmt.Sprintf(`
+func main() {
+    n := from_hex("%s")
+    e := from_hex("%s")
+    msg := from_hex("%s")
+    sig := from_hex("%s")
+    bad := from_hex("%s")
+    println("valid=" + str(rsa_verify_jwk_sha256(n, e, msg, sig)))
+    println("invalid=" + str(rsa_verify_jwk_sha256(n, e, msg, bad)))
+}`,
+		hex.EncodeToString(nBytes),
+		hex.EncodeToString(eb),
+		hex.EncodeToString(msg),
+		hex.EncodeToString(sig),
+		hex.EncodeToString(badSig),
+	)
+
+	prog := progFromSrc(t, src)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"valid=true", "invalid=false"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// Cross-key negative: a signature made by one key must NOT verify against a
+// different key's public PEM. Guards against a builtin that ignores the key.
+func TestRSAWrongKeyFails(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    privA, _ := rsa_generate(2048)
+    _, pubB := rsa_generate(2048)
+    msg := bytes("cross key check")
+    sig := rsa_sign_pkcs1_sha256(privA, msg)
+    println("wrongkey=" + str(rsa_verify_pkcs1_sha256(pubB, msg, sig)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out, "wrongkey=false") {
+		t.Fatalf("expected wrongkey=false in:\n%s", out)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -2497,6 +2497,8 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		return 0, fmt.Errorf("exec returns 3 values; use: code, out, err := exec(cmd)")
 	case "mmap_file":
 		return 0, fmt.Errorf("mmap_file returns 2 values; use: ptr, size := mmap_file(path)")
+	case "rsa_generate":
+		return 0, fmt.Errorf("rsa_generate returns 2 values; use: priv, pub := rsa_generate(bits)")
 	case "wss_open":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("wss_open: 1 arg (url string)")

--- a/types.go
+++ b/types.go
@@ -1520,6 +1520,8 @@ func (c *Checker) multiRetBuiltin(name string) (args []int, rets []int, ok bool)
 		return []int{c.cString}, []int{c.cInt, c.cString, c.cString}, true
 	case "mmap_file":
 		return []int{c.cString}, []int{c.cInt, c.cInt}, true
+	case "rsa_generate":
+		return []int{c.cInt}, []int{c.cBytes, c.cBytes}, true
 	}
 	return nil, nil, false
 }
@@ -1842,6 +1844,29 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 	case "ed25519_verify":
 		if len(argSlots) != 3 {
 			return 0, fmt.Errorf("ed25519_verify: 3 args (pub, msg, sig — all bytes)")
+		}
+		for _, sl := range argSlots {
+			c.addPair(sl, c.cBytes)
+		}
+		return c.cBool, nil
+	case "rsa_sign_pkcs1_sha256":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("rsa_sign_pkcs1_sha256: 2 args (priv_pem, msg — both bytes)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cBytes)
+		return c.cBytes, nil
+	case "rsa_verify_pkcs1_sha256":
+		if len(argSlots) != 3 {
+			return 0, fmt.Errorf("rsa_verify_pkcs1_sha256: 3 args (pub_pem, msg, sig — all bytes)")
+		}
+		for _, sl := range argSlots {
+			c.addPair(sl, c.cBytes)
+		}
+		return c.cBool, nil
+	case "rsa_verify_jwk_sha256":
+		if len(argSlots) != 4 {
+			return 0, fmt.Errorf("rsa_verify_jwk_sha256: 4 args (n, e, msg, sig — all bytes)")
 		}
 		for _, sl := range argSlots {
 			c.addPair(sl, c.cBytes)


### PR DESCRIPTION
## Summary

Recovers the RSA Phase-1 work from AM run `e06217` (which was interrupted before commit) and adds native RSA PKCS#1 v1.5 SHA-256 crypto builtins to machin.

## New builtins

- `rsa_generate(bits) -> (bytes priv_pem, bytes pub_pem)`
- `rsa_sign_pkcs1_sha256(priv_pem, msg) -> bytes sig`
- `rsa_verify_pkcs1_sha256(pub_pem, msg, sig) -> bool`
- `rsa_verify_jwk_sha256(n, e, msg, sig) -> bool`

`rsa_verify_jwk_sha256` builds the public key directly from the raw JWKS `n`/`e` bytes, enabling local RS256 JWT id_token verification (OIDC) without PEM or X.509.

## Files changed

- `codegen.go` — OpenSSL EVP/PEM/RSA C runtime and builtin wiring
- `types.go` — type checker registrations
- `guide.go` — builtin catalog entries
- `rsa_test.go` — round-trip, JWKS n/e, and cross-key negative tests

## Test plan

- [x] `go test -run 'TestRSA' -v` passes (3/3)

Closes #484 (RSA slice; X.509 + XML-c14n still deferred).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RSA key generation with PEM-encoded private and public keys.
  * Added RS256 signing using a PEM private key.
  * Added RS256 signature verification using PEM public keys.
  * Added JWKS-based RS256 verification using modulus and exponent values.
  * Added the new RSA cryptography builtins to the feature catalog.

* **Tests**
  * Added coverage for valid signatures, tampered messages, invalid signatures, and mismatched keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->