### PR TITLE
feat(arena): finer per-place taint — closes a struct-field soundness hole

### DIFF
--- a/arena_check.go
+++ b/arena_check.go
@@ -61,6 +61,42 @@ func arenaHeapKind(c *Checker, slot int) bool {
 	return false
 }
 
+// arenaPlaceString encodes an assignable place as a path string: a bare variable is its name,
+// a field access appends ".field", an index appends "#" (all indices of a container share one
+// key). ok=false for a place not rooted in a plain variable. This is the taint key: tracking
+// taint per place (not per whole variable) lets a field-assign of arena memory into an inner
+// struct taint just that field, so escaping the struct is caught while extracting a different,
+// clean field is not.
+func arenaPlaceString(e Expr) (string, bool) {
+	switch t := e.(type) {
+	case *Ident:
+		return t.Name, true
+	case *FieldAccess:
+		if p, ok := arenaPlaceString(t.X); ok {
+			return p + "." + t.Name, true
+		}
+	case *Index:
+		if p, ok := arenaPlaceString(t.X); ok {
+			return p + "#", true
+		}
+	}
+	return "", false
+}
+
+// arenaIsPrefixPath reports whether path a is an ancestor-or-equal of path b — a == b, or b
+// continues a at a place boundary (a ".field" or "#" step). Delimiter-aware so "p" is an
+// ancestor of "p.items" and "p#" but not of "ptr".
+func arenaIsPrefixPath(a, b string) bool {
+	if len(a) > len(b) || b[:len(a)] != a {
+		return false
+	}
+	if len(a) == len(b) {
+		return true
+	}
+	c := b[len(a)]
+	return c == '.' || c == '#'
+}
+
 // detectArenaEscapes returns one finding per arena block from which an allocated value escapes.
 func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 	// Nothing to do (and no summary to compute) unless the program uses an arena.
@@ -82,7 +118,33 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 		}
 		arenaFindEach(f.Body, func(a *ArenaStmt) {
 			inner := arenaInnerDeclared(a.Body)
+			// taint is keyed by PLACE path ("p", "p.items", "p#"), not by whole variable, so a
+			// field/element holding arena memory is tracked at that granularity.
 			tainted := map[string]bool{}
+			// placeCarries: does any tainted place lie on the same chain as `path`? A tainted
+			// ancestor means the whole value is arena (reading a sub-part carries); a tainted
+			// descendant means some part is arena (reading the whole value carries).
+			placeCarries := func(path string) bool {
+				for k := range tainted {
+					if arenaIsPrefixPath(k, path) || arenaIsPrefixPath(path, k) {
+						return true
+					}
+				}
+				return false
+			}
+			// setPlace assigns `path` wholesale: drop `path` and every descendant (they are
+			// replaced), then re-taint `path` if the new value carries arena memory. Ancestors and
+			// siblings are untouched (assigning p.a says nothing about p.b or p as a whole).
+			setPlace := func(path string, tv bool) {
+				for k := range tainted {
+					if arenaIsPrefixPath(path, k) {
+						delete(tainted, k)
+					}
+				}
+				if tv {
+					tainted[path] = true
+				}
+			}
 
 			var carriesArena func(e Expr) bool
 			carriesArena = func(e Expr) bool {
@@ -92,7 +154,7 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 				}
 				switch t := e.(type) {
 				case *Ident:
-					return tainted[t.Name] // params/outer/globals are pre-existing, never tainted
+					return placeCarries(t.Name) // params/outer/globals are pre-existing, never tainted
 				case *Binary:
 					return true // a heap-kind binary is a string concatenation — allocated here
 				case *Call:
@@ -120,7 +182,7 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 					// so calling the closure after the block reads freed arena memory. (The
 					// closure's own env is stable; it is the captured VALUE that dangles.)
 					for _, cap := range t.Captures {
-						if tainted[cap] {
+						if placeCarries(cap) {
 							return true
 						}
 					}
@@ -133,8 +195,14 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 					}
 					return false
 				case *Index:
+					if p, ok := arenaPlaceString(t); ok {
+						return placeCarries(p)
+					}
 					return carriesArena(t.X)
 				case *FieldAccess:
+					if p, ok := arenaPlaceString(t); ok {
+						return placeCarries(p)
+					}
 					return carriesArena(t.X)
 				case *Unary:
 					return carriesArena(t.X)
@@ -156,7 +224,7 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 					case *AssignStmt:
 						tv := carriesArena(st.Val)
 						if inner[st.Name] {
-							tainted[st.Name] = tv // propagate within the block
+							setPlace(st.Name, tv) // propagate within the block
 						} else if tv {
 							flag("ARENA001", "`"+st.Name+"` outlives this arena block but is assigned a value allocated inside it — it dangles after the block's memory is reclaimed")
 						}
@@ -170,7 +238,7 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 							}
 							tv := v != nil && carriesArena(v)
 							if inner[n] {
-								tainted[n] = tv
+								setPlace(n, tv)
 							} else if tv {
 								flag("ARENA001", "`"+n+"` outlives this arena block but is assigned a value allocated inside it — it dangles after the block's memory is reclaimed")
 							}
@@ -183,12 +251,26 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 						// Independent of the returned value; false-positive-free.
 						flag("ARENA002", "a `return` inside this arena block skips the block's cleanup — the block's memory is leaked and the current-arena pointer is left dangling (later allocations corrupt); move the `return` after the arena block")
 					case *IndexAssign:
-						if r, _, ok := placeOf(st.Target); ok && !inner[r] && carriesArena(st.Val) {
-							flag("ARENA001", "`"+r+"` outlives this arena block but is stored an element allocated inside it — it dangles after the block's memory is reclaimed")
+						if r, _, ok := placeOf(st.Target); ok {
+							if inner[r] {
+								// an inner container gains arena memory at this element — taint that
+								// place so escaping the whole container later is caught.
+								if p, ok2 := arenaPlaceString(st.Target); ok2 {
+									setPlace(p, carriesArena(st.Val))
+								}
+							} else if carriesArena(st.Val) {
+								flag("ARENA001", "`"+r+"` outlives this arena block but is stored an element allocated inside it — it dangles after the block's memory is reclaimed")
+							}
 						}
 					case *FieldAssign:
-						if r, _, ok := placeOf(st.Target); ok && !inner[r] && carriesArena(st.Val) {
-							flag("ARENA001", "`"+r+"` outlives this arena block but is stored a field allocated inside it — it dangles after the block's memory is reclaimed")
+						if r, _, ok := placeOf(st.Target); ok {
+							if inner[r] {
+								if p, ok2 := arenaPlaceString(st.Target); ok2 {
+									setPlace(p, carriesArena(st.Val))
+								}
+							} else if carriesArena(st.Val) {
+								flag("ARENA001", "`"+r+"` outlives this arena block but is stored a field allocated inside it — it dangles after the block's memory is reclaimed")
+							}
 						}
 					case *IfStmt:
 						scan(st.Then)

--- a/arena_check_test.go
+++ b/arena_check_test.go
@@ -78,6 +78,47 @@ func TestArenaClosureCaptureClean(t *testing.T) {
 	}
 }
 
+// TestArenaFieldGranularityEscape: assigning arena memory into an INNER container's field/element
+// taints that place, so escaping the whole container is caught (a soundness fix — per-variable
+// taint missed this because the container was built from a pre-existing value and never
+// wholesale-assigned an arena value).
+func TestArenaFieldGranularityEscape(t *testing.T) {
+	cases := []struct {
+		name  string
+		decls []string
+	}{
+		{"field-assign-then-escape-struct", []string{
+			`type Box struct { items []string }`,
+			`func f(seed) (r) { arena { p := Box{seed}  p.items = append(p.items, "x" + str(1))  r = p } }`,
+			`func main() { b := f([]string{})  println(str(len(b.items))) }`}},
+		{"index-assign-then-escape-slice", []string{
+			`func f(seed) (r) { arena { xs := seed  xs[0] = "a" + str(1)  r = xs } }`,
+			`func main() { b := f([]string{"z"})  println(b[0]) }`}},
+		{"extract-the-tainted-field", []string{
+			`type Pair struct { a []string  b []string }`,
+			`func f(s1, s2) (r) { arena { p := Pair{s1, s2}  p.a = append(p.a, "x" + str(1))  r = p.a } }`,
+			`func main() { z := f([]string{}, []string{"ok"})  println(str(len(z))) }`}},
+	}
+	for _, tc := range cases {
+		if fs := arenaEscapes(t, tc.decls...); !hasEscapeIn(fs, "f") {
+			t.Errorf("%s: expected an ARENA001 escape, got none", tc.name)
+		}
+	}
+}
+
+// TestArenaFieldGranularityClean: after tainting ONE field of an inner struct, extracting a
+// DIFFERENT (untouched) field must stay clean — per-place taint does not over-report the way
+// whole-variable taint would.
+func TestArenaFieldGranularityClean(t *testing.T) {
+	fs := arenaEscapes(t,
+		`type Pair struct { a []string  b []string }`,
+		`func f(s1, s2) (r) { arena { p := Pair{s1, s2}  p.a = append(p.a, "x" + str(1))  r = p.b } }`,
+		`func main() { z := f([]string{}, []string{"ok"})  println(z[0]) }`)
+	if hasEscapeIn(fs, "f") {
+		t.Errorf("extracting an untouched clean field must not fire, got %+v", fs)
+	}
+}
+
 // TestArenaEscapeVectors: every way an arena-allocated value can outlive its block must fire.
 func TestArenaEscapeVectors(t *testing.T) {
 	cases := []struct {

--- a/selfhost/arena.src
+++ b/selfhost/arena.src
@@ -314,7 +314,7 @@ var g_af_code = []string{}
 var g_af_detail = []string{}
 var g_af_seen = []string{}   // dedup keys: decl \x00 code \x00 detail
 var g_inner = []string{}     // names declared inside the current arena block
-var g_taint = []string{}     // currently-tainted variable names in the current block
+var g_taint = []string{}     // currently-tainted PLACE paths in the current block ("p", "p.f", "p#")
 
 func arena_flag(decl, code, detail) {
     key := decl + "\x00" + code + "\x00" + detail
@@ -324,18 +324,61 @@ func arena_flag(decl, code, detail) {
     g_af_code = append(g_af_code, code)
     g_af_detail = append(g_af_detail, detail)
 }
-func arena_taint_put(name, tv) {
-    at := arena_sidx(g_taint, name)
-    if tv == 1 { if at < 0 { g_taint = append(g_taint, name) } } else {
-        if at >= 0 {
-            nt := []string{}
-            i := 0
-            for i < len(g_taint) { if g_taint[i] != name { nt = append(nt, g_taint[i]) }  i = i + 1 }
-            g_taint = nt
-        }
+// arena_place_string: encode an assignable place as a path — a variable is its name, a field
+// appends ".field", an index appends "#" (all indices share one key). ok=0 if not var-rooted.
+func arena_place_string(idx) (path, ok) {
+    n := nodes[idx]
+    ok = 0
+    path = ""
+    if n.kind == K_ID { path = n.s  ok = 1  return path, ok }
+    if n.kind == K_FIELD {
+        px, pok := arena_place_string(n.a)
+        if pok == 1 { path = px + "." + n.s  ok = 1 }
+        return path, ok
+    }
+    if n.kind == K_INDEX {
+        px, pok := arena_place_string(n.a)
+        if pok == 1 { path = px + "#"  ok = 1 }
+        return path, ok
     }
 }
-func arena_taint_has(name) (b) { b = 0  if arena_sidx(g_taint, name) >= 0 { b = 1 } }
+// arena_is_prefix_path: is path a an ancestor-or-equal of b (b continues a at a "." or "#" step)?
+func arena_is_prefix_path(a, b) (r) {
+    r = 0
+    la := len(a)
+    lb := len(b)
+    if la > lb { return r }
+    ba := bytes(a)
+    bb := bytes(b)
+    i := 0
+    for i < la { if byte_at(ba, i) != byte_at(bb, i) { return r }  i = i + 1 }
+    if la == lb { r = 1  return r }
+    c := byte_at(bb, la)
+    if c == 46 { r = 1  return r }   // '.'
+    if c == 35 { r = 1 }             // '#'
+}
+// arena_place_carries: does any tainted place share a chain with `path` (an ancestor means the
+// whole value is arena; a descendant means some part is)?
+func arena_place_carries(path) (r) {
+    r = 0
+    i := 0
+    for i < len(g_taint) {
+        if arena_is_prefix_path(g_taint[i], path) == 1 { r = 1  return r }
+        if arena_is_prefix_path(path, g_taint[i]) == 1 { r = 1  return r }
+        i = i + 1
+    }
+}
+// arena_set_place: assign `path` wholesale — drop it and every descendant, then re-taint if tv.
+func arena_set_place(path, tv) {
+    nt := []string{}
+    i := 0
+    for i < len(g_taint) {
+        if arena_is_prefix_path(path, g_taint[i]) == 0 { nt = append(nt, g_taint[i]) }
+        i = i + 1
+    }
+    g_taint = nt
+    if tv == 1 { g_taint = append(g_taint, path) }
+}
 
 // arena_carries: does expression node idx evaluate to a value allocated in this arena block?
 func arena_carries(iid, idx) (r) {
@@ -344,15 +387,23 @@ func arena_carries(iid, idx) (r) {
     if slot >= 0 { if arena_heap_slot(slot) == 0 { return r } }
     n := nodes[idx]
     k := n.kind
-    if k == K_ID { if arena_taint_has(n.s) == 1 { r = 1 }  return r }
+    if k == K_ID { if arena_place_carries(n.s) == 1 { r = 1 }  return r }
     if k == K_BIN { r = 1  return r }
     if k == K_SLICE { r = 1  return r }
     if k == K_STRUCT {
         for _, v := range n.kids { if arena_carries(iid, v) == 1 { r = 1  return r } }
         return r
     }
-    if k == K_INDEX { r = arena_carries(iid, n.a)  return r }
-    if k == K_FIELD { r = arena_carries(iid, n.a)  return r }
+    if k == K_INDEX {
+        px, pok := arena_place_string(idx)
+        if pok == 1 { if arena_place_carries(px) == 1 { r = 1 }  return r }
+        r = arena_carries(iid, n.a)  return r
+    }
+    if k == K_FIELD {
+        px, pok := arena_place_string(idx)
+        if pok == 1 { if arena_place_carries(px) == 1 { r = 1 }  return r }
+        r = arena_carries(iid, n.a)  return r
+    }
     if k == K_UNARY { r = arena_carries(iid, n.a)  return r }
     if k == K_CALL {
         callee := n.s
@@ -403,7 +454,7 @@ func arena_scan(iid, decl, kids) {
         if k == K_ASSIGN {
             tv := arena_carries(iid, n.a)
             if arena_sidx(g_inner, n.s) >= 0 {
-                arena_taint_put(n.s, tv)
+                arena_set_place(n.s, tv)
             } else {
                 if tv == 1 { arena_flag(decl, "ARENA001", "`" + n.s + "` outlives this arena block but is assigned a value allocated inside it — it dangles after the block's memory is reclaimed") }
             }
@@ -416,7 +467,7 @@ func arena_scan(iid, decl, kids) {
                 if vidx >= 0 { tv = arena_carries(iid, vidx) }
                 nm := n.names[ni]
                 if arena_sidx(g_inner, nm) >= 0 {
-                    arena_taint_put(nm, tv)
+                    arena_set_place(nm, tv)
                 } else {
                     if tv == 1 { arena_flag(decl, "ARENA001", "`" + nm + "` outlives this arena block but is assigned a value allocated inside it — it dangles after the block's memory is reclaimed") }
                 }
@@ -426,10 +477,24 @@ func arena_scan(iid, decl, kids) {
             arena_flag(decl, "ARENA002", "a `return` inside this arena block skips the block's cleanup — the block's memory is leaked and the current-arena pointer is left dangling (later allocations corrupt); move the `return` after the arena block")
         } else { if k == K_IDXASSIGN {
             root, ok := arena_place_root(n.a)
-            if ok == 1 { if arena_sidx(g_inner, root) < 0 { if arena_carries(iid, n.b) == 1 { arena_flag(decl, "ARENA001", "`" + root + "` outlives this arena block but is stored an element allocated inside it — it dangles after the block's memory is reclaimed") } } }
+            if ok == 1 {
+                if arena_sidx(g_inner, root) >= 0 {
+                    px, pok := arena_place_string(n.a)
+                    if pok == 1 { arena_set_place(px, arena_carries(iid, n.b)) }
+                } else {
+                    if arena_carries(iid, n.b) == 1 { arena_flag(decl, "ARENA001", "`" + root + "` outlives this arena block but is stored an element allocated inside it — it dangles after the block's memory is reclaimed") }
+                }
+            }
         } else { if k == K_FLDASSIGN {
             root, ok := arena_place_root(n.a)
-            if ok == 1 { if arena_sidx(g_inner, root) < 0 { if arena_carries(iid, n.b) == 1 { arena_flag(decl, "ARENA001", "`" + root + "` outlives this arena block but is stored a field allocated inside it — it dangles after the block's memory is reclaimed") } } }
+            if ok == 1 {
+                if arena_sidx(g_inner, root) >= 0 {
+                    px, pok := arena_place_string(n.a)
+                    if pok == 1 { arena_set_place(px, arena_carries(iid, n.b)) }
+                } else {
+                    if arena_carries(iid, n.b) == 1 { arena_flag(decl, "ARENA001", "`" + root + "` outlives this arena block but is stored a field allocated inside it — it dangles after the block's memory is reclaimed") }
+                }
+            }
         } else { if k == K_IF {
             arena_scan(iid, decl, n.kids)  arena_scan(iid, decl, n.kids2)
         } else { if k == K_WHILE {

--- a/selfhost/verify-arena-selfhost.sh
+++ b/selfhost/verify-arena-selfhost.sh
@@ -41,6 +41,12 @@ printf 'func f(n) (r){arena{s:="x"+str(n) t:=s+"!" println(t)} r="done"}\nfunc m
 printf 'func f(ch){arena{ch<-"msg"+str(1)}}\nfunc main(){ch:=make(chan string) go f(ch) println(<-ch)}\n' > "$T/c4"; run "$T/c4" "channel send is safe (clean)"
 printf 'func f(a) (r){r=a+1}\nfunc main(){println(str(f(2)))}\n' > "$T/c5"; run "$T/c5" "no arena block (clean)"
 
+# finer place-path granularity: arena memory into an inner container's field/element taints that
+# place, so escaping the whole container is caught; extracting a DIFFERENT clean field is not.
+printf 'type Box struct{items []string}\nfunc f(seed) (r){arena{p:=Box{seed} p.items=append(p.items,"x"+str(1)) r=p}}\nfunc main(){b:=f([]string{}) println(str(len(b.items)))}\n' > "$T/sf1"; run "$T/sf1" "field-assign into inner struct then escape (ARENA001)"
+printf 'func f(seed) (r){arena{xs:=seed xs[0]="a"+str(1) r=xs}}\nfunc main(){b:=f([]string{"z"}) println(b[0])}\n' > "$T/sf2"; run "$T/sf2" "index-assign into inner slice then escape (ARENA001)"
+printf 'type Pair struct{a []string  b []string}\nfunc f(s1,s2) (r){arena{p:=Pair{s1,s2} p.a=append(p.a,"x"+str(1)) r=p.b}}\nfunc main(){z:=f([]string{},[]string{"ok"}) println(z[0])}\n' > "$T/sf3"; run "$T/sf3" "extract a different clean field (clean)"
+
 # interprocedural provenance: a pass-through helper must NOT flag; a fresh-allocating one must.
 printf 'func idp(s) (r){r=s}\nfunc f(p) (r){x:="" arena{x=idp(p)} r=x}\nfunc main(){println(f("hi"))}\n' > "$T/i1"; run "$T/i1" "pass-through helper (clean)"
 printf 'func wrap(s) (r){r="["+s+"]"}\nfunc f(p) (r){x:="" arena{x=wrap(p)} r=x}\nfunc main(){println(f("hi"))}\n' > "$T/i2"; run "$T/i2" "fresh-allocating helper (ARENA001)"


### PR DESCRIPTION
## What

Tracks arena taint at **place-path** granularity (`p`, `p.items`, `p#`) instead of per whole variable. This turned out to fix a real **soundness hole**, not just improve precision.

### The hole

Per-variable taint missed this dangle — the struct is built from a pre-existing value (so the variable starts untainted), then arena memory is stored into a *field*, but the variable itself is never wholesale-assigned an arena value:

```
func f(seed) (r) {
    arena {
        p := Box{seed}                          // p untainted (seed pre-exists)
        p.items = append(p.items, "x"+str(1))   // arena into p.items — p stays untainted
        r = p                                    // ESCAPE — previously NOT flagged
    }
}
```

Since the pass is *sound + conservative* (a clean result must **prove** no escape), a missed escape is a hole in the memory-safety guarantee.

### The fix

- **`arenaPlaceString(e)`** encodes an assignable place as a path string; **`arenaIsPrefixPath`** is a delimiter-aware ancestor test (`p` is an ancestor of `p.items`/`p#`, not of `ptr`).
- **`placeCarries(path)`** = any tainted key that is an ancestor-or-equal **or** descendant of `path` (a tainted ancestor ⇒ the whole value is arena; a tainted descendant ⇒ some part is).
- **`setPlace(path, tv)`** drops the path + its descendants (they're replaced), then re-taints if the new value carries arena.
- `carriesArena` resolves `Ident`/`Index`/`FieldAccess` via place lookup; the scan **taints an inner container's field/element** on `IndexAssign`/`FieldAssign`, not only flags outer targets.

### Both sound AND finer

- **Closes the hole**: escaping the mutated struct is now caught.
- **Genuinely finer**: after tainting one field, extracting a **different** untouched field stays clean — no over-report the way whole-variable taint would produce.

## Verification

- Go tests: `TestArenaFieldGranularityEscape` (field/index-assign-then-escape + extract-the-tainted-field) and `TestArenaFieldGranularityClean` (extract a different clean field).
- **Self-host stays oracle-identical**: mirrored byte-for-byte in `selfhost/arena.src`; `verify-arena-selfhost.sh` is **16/16** (added inner-field-escape, inner-index-escape, extract-clean-field fixtures).
- Coverage floor 87.60% (≥ 87.00%); full Go suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arena escape detection for values stored in specific struct fields and slice elements.
  * Prevented false positives when accessing unaffected fields or elements.
  * Continued reporting ARENA001 when arena-allocated data escapes through a container.

* **Tests**
  * Added coverage for field- and element-level escape detection.
  * Expanded self-hosting verification for arena escape scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->