### PR TITLE
fix(#508): escape '?' in emitted C string literals to defeat trigraphs

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -3573,6 +3573,20 @@ func cZero(k Kind) string {
 	}
 }
 
+// cStringLit renders an MFL string value as a C string literal. Beyond the
+// standard Go quoting, each '?' is escaped as '\?' so that adjacent question
+// marks cannot form ANSI C trigraphs (e.g. "??'" -> '^'), which some C
+// toolchains still honor and would otherwise silently corrupt the string (#508).
+func cStringLit(s string) string {
+	q := strconv.Quote(s)
+	if !strings.Contains(q, "?") {
+		return q
+	}
+	// strconv.Quote never emits '?' as part of an escape sequence, so every
+	// '?' in the output is a literal question mark from the source string.
+	return strings.ReplaceAll(q, "?", "\\?")
+}
+
 func (g *cgen) program(p *Program) (string, error) {
 	// record package-global names so varRef renders them as mfl_g_<name> (this must
 	// be set before any function body is emitted, since bodies may reference them).
@@ -4737,7 +4751,7 @@ func (g *cgen) expr(e Expr) (string, error) {
 		}
 		return s, nil
 	case *StringLit:
-		return strconv.Quote(ex.Val), nil
+		return cStringLit(ex.Val), nil
 	case *BoolLit:
 		if ex.Val {
 			return "1", nil

--- a/trigraph_test.go
+++ b/trigraph_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// C trigraphs (e.g. "??'" -> '^') must not survive into the generated C, or the
+// toolchain silently corrupts string literals containing "??" (#508).
+func TestCStringLitEscapesTrigraphs(t *testing.T) {
+	got := cStringLit("A??'B ??( ??) ??= END")
+	if strings.Contains(got, "??") {
+		t.Fatalf("cStringLit left an unescaped trigraph sequence: %q", got)
+	}
+	if !strings.Contains(got, "\\?\\?") {
+		t.Fatalf("cStringLit did not escape '?' as '\\?': %q", got)
+	}
+}
+
+// Strings without question marks must be quoted exactly as before.
+func TestCStringLitLeavesPlainStrings(t *testing.T) {
+	got := cStringLit("hello world")
+	if got != `"hello world"` {
+		t.Fatalf("cStringLit(\"hello world\") = %q, want %q", got, `"hello world"`)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #508: "string literals silently corrupted by C trigraph processing (\"??'\" becomes \"^\")")

ISSUE DESCRIPTION:
Found while building vigie's globe artifact — a JS string `'??'` inside an MFL string literal reached the browser as `'^'`, producing `SyntaxError: Invalid regular expression flags` at runtime. Took a node-based bisect of the emitted JS to find, because the corruption is **silent**: encode passes, build passes, the binary runs, and the string is just… different.

Repro (machin v0.107.0):

```go
func main() {
    println("A??'B ??( ??) ??= END")
}
```

```
$ machin build tri.mfl -o tri && ./tri
A^B [ ] # END
```

Every ANSI C trigraph is live in MFL string literals: `??'`→`^`, `??(`→`[`, `??)`→`]`, `??=`→`#`, `??/`→`\`, `??<`→`{`, `??>`→`}`, `??!`→`|`, `??-`→`~`.

Cause: the MFL→C emitter writes string literals verbatim into the generated C, and the C toolchain applies trigraph replacement (the system cc here still honors them at this std level). Any MFL program embedding user-facing text, JS, or SQL containing `??` is affected — e.g. JS's null-coalescing operator `??` inside any web-serving MFL app.

Fix suggestion: escape `?` as `\?` when emitting C string literals (the standard C idiom to defeat trigraphs), or split adjacent `??` into `"?" "?"` concatenations. Either is purely mechanical in the emitter.

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#508): <brief description>
5. The PR body MUST include 'Fixes #508' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-tid9cq`

**Diff:**
```
codegen.go       | 16 +++++++++++++++-
 trigraph_test.go | 26 ++++++++++++++++++++++++++
 2 files changed, 41 insertions(+), 1 deletion(-)
```
