### PR TITLE
feat(sso): pure-MFL RS256 id_token/JWT verification (part of #484)

### DIFF
--- a/framework/sso.src
+++ b/framework/sso.src
@@ -104,3 +104,73 @@ func sso_complete(p, secret, req) (profile, ok) {
     if tok == 0 { return }
     profile, ok = sso_userinfo(p, token)
 }
+
+// --- RS256 id_token verification (issue #484) -------------------------------
+// The flow above trusts the TLS token endpoint, so it needs no JWT signature
+// check. When you DO hold an RS256-signed JWT (an OIDC id_token, or an API token
+// from an IdP that publishes a JWKS), sso_verify_rs256 checks it in pure MFL on
+// top of the rsa_verify_jwk_sha256 builtin — no PEM/X.509, just the JWKS n/e.
+
+// JWK is one RSA key from a provider's JWKS ("keys":[...]). Unknown members
+// (use, x5c, x5t, …) are ignored by parse. n and e are base64url big-endian.
+type JWK struct {
+    kty string
+    kid string
+    alg string
+    n   string   // modulus  (base64url)
+    e   string   // exponent (base64url)
+}
+
+type JWKS struct {
+    keys []JWK
+}
+
+// sso_verify_rs256 verifies an RS256-signed JWT against a provider's JWKS JSON.
+// Returns (claims_json, ok). ok is 0 unless the signature is valid AND the header
+// alg is exactly "RS256" — an alg of "none" or "HS256" is rejected outright, so a
+// forged unsigned/symmetric token can never pass (the classic JWT alg-confusion
+// bug). If the header carries a "kid", only the matching JWKS key is trusted;
+// otherwise the sole RSA key is used. On ok the caller MUST still validate the
+// claims it cares about (exp, iss, aud) via json_get(claims, ".exp") etc.
+func sso_verify_rs256(token, jwks_json) (claims, ok) {
+    claims = ""
+    ok = 0
+    parts := split(token, ".")
+    if len(parts) != 3 { return }                  // not header.payload.signature
+
+    // Header: pin alg to RS256 before touching any key material.
+    hdr := base64_decode(parts[0])
+    alg, ae := json_get(hdr, ".alg")
+    if ae != "" { return }
+    if alg != "\"RS256\"" { return }               // reject none / HS256 confusion
+    kidq, _ := json_get(hdr, ".kid")
+    kid := json_unq(kidq)                           // "" if the header omits kid
+
+    // Select the signing key from the JWKS.
+    keys_json, ke := json_get(jwks_json, ".keys")
+    if ke != "" { return }
+    ks := parse(keys_json, []JWK{})
+    n64 := ""
+    e64 := ""
+    for _, k := range ks {
+        if k.kty == "RSA" {
+            if kid == "" || k.kid == kid {
+                if n64 == "" {                      // first match wins
+                    n64 = k.n
+                    e64 = k.e
+                }
+            }
+        }
+    }
+    if n64 == "" { return }                         // no key (wrong/absent kid)
+
+    // Verify PKCS#1 v1.5 over SHA-256 of the "header.payload" signing input.
+    signing_input := bytes(parts[0] + "." + parts[1])
+    sig := base64_decode_bytes(parts[2])
+    n := base64_decode_bytes(n64)
+    e := base64_decode_bytes(e64)
+    if rsa_verify_jwk_sha256(n, e, signing_input, sig) {
+        claims = base64_decode(parts[1])            // decoded payload JSON
+        ok = 1
+    }
+}

--- a/jwt_rs256_test.go
+++ b/jwt_rs256_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+)
+
+// b64url is JWT/JWKS base64url without padding (RFC 7515).
+func b64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+// mintRS256 builds a real RS256 JWT: base64url(headerJSON).base64url(payloadJSON)
+// signed with PKCS#1 v1.5 over SHA-256 — exactly what an IdP emits for an
+// id_token. Returns the compact token string.
+func mintRS256(t *testing.T, key *rsa.PrivateKey, headerJSON, payloadJSON string) string {
+	t.Helper()
+	signingInput := b64url([]byte(headerJSON)) + "." + b64url([]byte(payloadJSON))
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signingInput + "." + b64url(sig)
+}
+
+// TestJWTVerifyRS256 exercises the pure-MFL RS256 id_token verifier
+// (sso_verify_rs256 in framework/sso.src), the "RS256 JWT verification" half of
+// issue #484. We mint a genuine RS256 JWT + JWKS in Go (the same crypto/rsa an
+// IdP uses) and assert the MFL helper: (1) accepts a valid token and returns its
+// claims, (2) rejects a tampered payload, (3) rejects alg-confusion (an HS256 /
+// unsigned header — the classic JWT attack), and (4) rejects a token whose kid
+// is absent from the JWKS.
+func TestJWTVerifyRS256(t *testing.T) {
+	mw, err := os.ReadFile("framework/machweb.src")
+	if err != nil {
+		t.Skip("framework/machweb.src not found")
+	}
+	sso, err := os.ReadFile("framework/sso.src")
+	if err != nil {
+		t.Skip("framework/sso.src not found")
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	// JWKS exposes n/e as base64url big-endian bytes.
+	nB64 := b64url(key.N.Bytes())
+	eBytes := []byte{byte(key.E >> 16), byte(key.E >> 8), byte(key.E)}
+	for len(eBytes) > 1 && eBytes[0] == 0 {
+		eBytes = eBytes[1:]
+	}
+	eB64 := b64url(eBytes)
+	jwks := `{"keys":[{"kty":"RSA","use":"sig","alg":"RS256","kid":"k1","n":"` +
+		nB64 + `","e":"` + eB64 + `"}]}`
+
+	payload := `{"sub":"u1","email":"ada@x.com","iss":"https://idp.example","exp":9999999999}`
+	valid := mintRS256(t, key, `{"alg":"RS256","typ":"JWT","kid":"k1"}`, payload)
+
+	// Tampered: swap in a different payload but keep the original signature.
+	vparts := strings.Split(valid, ".")
+	tampered := vparts[0] + "." + b64url([]byte(`{"sub":"admin","email":"evil@x.com"}`)) + "." + vparts[2]
+
+	// alg confusion: a header claiming HS256 must be refused before any key use.
+	hs256 := mintRS256(t, key, `{"alg":"HS256","typ":"JWT","kid":"k1"}`, payload)
+
+	// Correctly signed, but its kid is not in the JWKS.
+	wrongKid := mintRS256(t, key, `{"alg":"RS256","typ":"JWT","kid":"k2"}`, payload)
+
+	// MFL string literals escape only the double quote; our JSON has no backslashes.
+	esc := func(s string) string { return strings.ReplaceAll(s, `"`, `\"`) }
+
+	app := "\n" +
+		"func main() {\n" +
+		"    jwks := \"" + esc(jwks) + "\"\n" +
+		"    claims, ok := sso_verify_rs256(\"" + valid + "\", jwks)\n" +
+		"    email, _ := json_get(claims, \".email\")\n" +
+		"    println(\"valid=\" + str(ok) + \" email=\" + email)\n" +
+		"    _, bad := sso_verify_rs256(\"" + tampered + "\", jwks)\n" +
+		"    println(\"tampered=\" + str(bad))\n" +
+		"    _, alg := sso_verify_rs256(\"" + hs256 + "\", jwks)\n" +
+		"    println(\"algconf=\" + str(alg))\n" +
+		"    _, wk := sso_verify_rs256(\"" + wrongKid + "\", jwks)\n" +
+		"    println(\"wrongkid=\" + str(wk))\n" +
+		"}\n"
+
+	prog, perr := progFromSrcErr(string(mw) + string(sso) + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		`valid=1 email="ada@x.com"`, // valid signature -> claims returned
+		"tampered=0",                // altered payload -> signature fails
+		"algconf=0",                 // HS256 header -> rejected outright
+		"wrongkid=0",                // kid absent from JWKS -> no key -> rejected
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Issue #484: Implement RSA + X.509 crypto primitives for machin to enable pure-MFL SAML SSO and RS256 JWT verification. Prioritize RSA sign/verify/generate and X.509 certificate parse/mint; keep the diff minimal, tested, and safe.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #511 (am/am-7b5889-tideg2): fix(#507): explain function-scoping when := collides in disjoint branches
    touches: guide.go, mismatch_identifier_test.go, types.go


**Branch:** `am/am-7b5889-tidewr`

**Diff:**
```
framework/sso.src |  70 ++++++++++++++++++++++++++++++++++
 jwt_rs256_test.go | 110 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 180 insertions(+)
```
