### PR TITLE
fix(codegen): 64-bit int literals + copy map keys() (two grange bugs)

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -794,7 +794,10 @@ static mfl_slice mfl_map_keys(mfl_map* m) {
     int64_t idx = 0;
     for (int64_t b = 0; b < m->nb; b++)
         for (mfl_ment* e = m->buckets[b]; e; e = e->next) {
-            if (m->sk) ((char**)s.data)[idx] = e->sk; else ((int64_t*)s.data)[idx] = e->ik;
+            /* COPY string keys into arena storage: handing out e->sk aliases
+               the entry's malloc'd key, which mfl_map_del frees — a retained
+               keys() result then reads freed memory. */
+            if (m->sk) { char* cp = mfl_alloc(strlen(e->sk)+1); strcpy(cp, e->sk); ((char**)s.data)[idx] = cp; } else ((int64_t*)s.data)[idx] = e->ik;
             idx++;
         }
     return s;
@@ -4743,7 +4746,10 @@ func (g *cgen) printCall(call *Call, depth int) error {
 func (g *cgen) expr(e Expr) (string, error) {
 	switch ex := e.(type) {
 	case *IntLit:
-		return strconv.FormatInt(ex.Val, 10), nil
+		// Emit with the LL suffix: a bare literal like 86400000 is a C `int`, so
+		// `30 * 86400000` overflows in 32-bit before widening to int64_t (a machin
+		// int is 64-bit, so the C constant must be too).
+		return strconv.FormatInt(ex.Val, 10) + "LL", nil
 	case *FloatLit:
 		s := strconv.FormatFloat(ex.Val, 'g', -1, 64)
 		if !strings.ContainsAny(s, ".eE") {

--- a/intlit_mapkeys_test.go
+++ b/intlit_mapkeys_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A bare integer literal must be emitted as a 64-bit C constant (an `LL` suffix):
+// 30 * 86400000 = 2_592_000_000 exceeds the int32 max, so without the suffix the C
+// multiplication overflowed (int * int) to a negative/garbage value before widening
+// to int64_t. A machin int is 64-bit, so the C constant must be too.
+func TestIntLitNo32BitOverflow(t *testing.T) {
+	out, _ := buildRun(t, `func main() { println(str(30 * 86400000)) }`)
+	if strings.TrimSpace(out) != "2592000000" {
+		t.Fatalf("30 * 86400000 = %q, want 2592000000 (32-bit overflow?)", out)
+	}
+}
+
+// keys() must return COPIES of the string keys: a retained keys() result has to
+// stay valid even after a key is deleted (its entry freed) and the freed slot is
+// reused by later inserts. The old code handed out the entry's own malloc'd key
+// pointer, so a retained slice read freed (then reused) memory. Summing lengths is
+// order-independent, so this is robust to bucket iteration order.
+func TestMapKeysRetainedAfterDelete(t *testing.T) {
+	src := `func main() {
+		m := make(map[string]int)
+		m["alpha"] = 1  m["bravo"] = 2  m["charlie"] = 3
+		ks := keys(m)
+		delete(m, "bravo")
+		m["delta-padding-xx"] = 4  m["echo-padding-yyy"] = 5
+		total := 0
+		i := 0
+		for i < len(ks) { total = total + len(ks[i])  i = i + 1 }
+		println(str(total))
+	}`
+	out, _ := buildRun(t, src)
+	// len("alpha")+len("bravo")+len("charlie") = 5+5+7 = 17
+	if strings.TrimSpace(out) != "17" {
+		t.Fatalf("retained keys() corrupted after delete+reinsert: got %q, want 17", out)
+	}
+}


### PR DESCRIPTION
Two codegen correctness bugs surfaced by the **grange** app.

## 1. IntLit 32-bit overflow
A bare integer literal was emitted as a C `int` (32-bit), so `30 * 86400000` (30 days in ms) **overflowed to a negative value** before widening to `int64_t`. A machin int is 64-bit — emit the constant with an `LL` suffix so the arithmetic happens in 64-bit.

## 2. map `keys()` use-after-free
`mfl_map_keys` handed out the map entry's own `malloc`'d key pointer. A **retained** `keys()` result then aliased memory that `mfl_map_del` frees (and later inserts reuse) — a use-after-free that turned a WAL tombstone id to garbage mid-iteration. Copy each string key into arena storage instead.

## Tests
- `TestIntLitNo32BitOverflow` — `30 * 86400000 == 2592000000` (not a wrapped negative).
- `TestMapKeysRetainedAfterDelete` — a retained `keys()` stays valid after delete + reinsert.

Full suite green; coverage floor holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)