### PR TITLE
fix(codegen): NULL-string segfault on len()/charat of a parse() missing field

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -188,6 +188,7 @@ static void* mfl_realloc(void* old, size_t sz) {
 static _Thread_local const char* mfl_strlen_cache_s = NULL;
 static _Thread_local int64_t mfl_strlen_cache_n = 0;
 static inline int64_t mfl_strlen_cached(const char* s) {
+    if (s == NULL) return 0; /* NULL string (e.g. parse() missing field) is length 0, not a crash */
     if (s == mfl_strlen_cache_s) return mfl_strlen_cache_n;
     int64_t n = (int64_t)strlen(s);
     mfl_strlen_cache_s = s; mfl_strlen_cache_n = n;
@@ -1356,7 +1357,7 @@ static int64_t mfl_index(const char* s, const char* sub) { const char* f = strst
 static int mfl_contains(const char* s, const char* sub) { return strstr(s, sub) != NULL; }
 static int mfl_has_prefix(const char* s, const char* p) { return strncmp(s, p, strlen(p)) == 0; }
 static int mfl_has_suffix(const char* s, const char* p) { size_t ls = strlen(s), lp = strlen(p); return lp <= ls && strcmp(s + ls - lp, p) == 0; }
-static char* mfl_charat(const char* s, int64_t i) { int64_t n = strlen(s); if (i < 0 || i >= n) return mfl_dup(""); char* r = mfl_alloc(2); r[0] = s[i]; r[1] = 0; return r; }
+static char* mfl_charat(const char* s, int64_t i) { int64_t n = mfl_strlen_cached(s); if (i < 0 || i >= n) return mfl_dup(""); char* r = mfl_alloc(2); r[0] = s[i]; r[1] = 0; return r; }
 static char* mfl_to_upper(const char* s) { size_t n = strlen(s); char* r = mfl_alloc(n + 1); for (size_t i = 0; i < n; i++) r[i] = toupper((unsigned char)s[i]); r[n] = 0; return r; }
 static char* mfl_to_lower(const char* s) { size_t n = strlen(s); char* r = mfl_alloc(n + 1); for (size_t i = 0; i < n; i++) r[i] = tolower((unsigned char)s[i]); r[n] = 0; return r; }
 static char* mfl_trim(const char* s) {
@@ -5518,7 +5519,7 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		case KMap:
 			return fmt.Sprintf("mfl_map_len(%s)", args[0]), nil
 		}
-		return fmt.Sprintf("((int64_t)strlen(%s))", args[0]), nil
+		return fmt.Sprintf("((int64_t)strlen(mfl_s(%s)))", args[0]), nil
 	case "bytes":
 		return fmt.Sprintf("mfl_bytes_from_str(%s)", args[0]), nil
 	case "bytes_str":

--- a/nullstring_test.go
+++ b/nullstring_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// buildRunProg builds a full program (types + funcs) and returns its stdout.
+func buildRunProg(t *testing.T, decls ...string) string {
+	t.Helper()
+	nd := make([]string, len(decls))
+	for i, d := range decls {
+		nd[i] = normalize(d)
+	}
+	prog, err := ParseProgram(nd)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bin, err := os.CreateTemp("", "mfl-null-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(prog, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	out, err := exec.Command(bin.Name()).Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return string(out)
+}
+
+// parse() zero-initializes structs with {0}, so a missing string field is NULL
+// (char*), not "". len()/charat took strlen(s) directly, and strlen(NULL) is UB
+// (segfault). len() on a string must route through mfl_s() so len(NULL) == 0.
+func TestLenOnNullStringFromParse(t *testing.T) {
+	out := buildRunProg(t,
+		`type U struct { name string  age int }`,
+		`func main() { u := parse("{\"age\":5}", U{})  println(str(len(u.name)))  println(u.name + "!") }`,
+	)
+	// name absent -> NULL, normalized to "": len 0, and concatenation yields "!"
+	if strings.TrimSpace(out) != "0\n!" {
+		t.Fatalf("len/concat on a NULL parsed string = %q, want \"0\\n!\"", out)
+	}
+}


### PR DESCRIPTION
Extracts the still-valuable, non-overlapping fix from **#515** onto current `main`. (#515 is based on pre-v0.109.0 main and can't be merged — it would revert arena analysis, superopt, and the v0.109.0 release; its int-literal-overflow and `keys()` UAF fixes already shipped in **v0.109.0** via #513.)

## NULL-string segfault fix (cherry-picked a5bf2ee)
`parse()` zero-initializes structs with `{0}`, so a missing string field is `NULL` (`char*`), not `""`. `len()`/`charat` called `strlen(s)` directly — and `strlen(NULL)` is UB (segfault). `len()` on a string now routes through `mfl_s()` (which normalizes `NULL`→`""`); `mfl_charat` uses the NULL-guarded `mfl_strlen_cached`. Found building grange, where a missing JSON field crashed on `len()`.

`TestLenOnNullStringFromParse` covers it (was a crash; now `len == 0`, concatenation yields `""`).

## Note on the Phase 1-6 coverage fixtures
I initially also extracted #515's coverage-push test files, but they **hang on CI** against current main (`build_args_test.go` wedged to the 10-minute timeout — a CLI behavior changed since they were written on old main). Dropped them; only the clean NULL-string fix remains here.

Supersedes #515 (which will be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)