### PR TITLE
release: v0.110.0 — NULL-string segfault fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v0.110.0
+
+- **codegen: NULL-string segfault fix.** `parse()` zero-initializes structs with
+  `{0}`, so a missing string field is `NULL` (`char*`), not `""`. `len()` / `charat`
+  called `strlen(s)` directly, and `strlen(NULL)` is undefined behavior (segfault).
+  `len()` on a string now routes through `mfl_s()` (which normalizes `NULL`→`""`),
+  and `mfl_charat` uses the NULL-guarded `mfl_strlen_cached`, so `len()` /
+  indexing a missing parsed field is `0` / `""` instead of a crash. (Surfaced
+  building grange, where a missing JSON field crashed on `len()`.)
+
 ## v0.109.0 — Evidence: certify, deadlock-freedom, superoptimization, arena safety
 
 The **evidence** release — the binary now comes with machine-checkable proof across

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.109.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.110.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.109.0
+Version 0.110.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.109.0"
+const machinVersion = "0.110.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Version bump for **v0.110.0**.

- `machinVersion` 0.109.0 → 0.110.0 (guide.go), README badge, SPEC.md
- CHANGELOG v0.110.0 entry

Ships the NULL-string segfault fix (#516): `len()`/`charat` on a `parse()` missing string field no longer crashes. Binaries + tag follow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when processing omitted JSON string fields.
  * Improved handling of missing strings during length checks and indexing.

* **Documentation**
  * Added release notes for version 0.110.0.
  * Updated displayed versions across the README, language specification, and built-in feature guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->