### PR TITLE
release: v0.111.0 — pure-MFL RS256 id_token/JWT verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## v0.111.0
+
+- **Pure-MFL RS256 id_token / JWT verification** (`sso_verify_rs256` in
+  `framework/sso.src`, part of issue #484). Verifies an RS256-signed JWT against a
+  provider's JWKS in pure MFL on top of the `rsa_verify_jwk_sha256` builtin — no
+  PEM/X.509, just the JWKS `n`/`e`. Pins the header `alg` to exactly `RS256`
+  **before** touching any key material, so a forged `none`/`HS256` token is
+  rejected outright (the classic alg-confusion attack); selects the signing key by
+  `kid`; and returns the decoded claims only when the signature verifies. The
+  caller still validates `exp`/`iss`/`aud`. Tested end-to-end against genuine
+  `crypto/rsa`-minted tokens (valid, tampered, alg-confusion, wrong-kid).
+
 ## v0.110.0
 
 - **codegen: NULL-string segfault fix.** `parse()` zero-initializes structs with

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.110.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.111.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.110.0
+Version 0.111.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.110.0"
+const machinVersion = "0.111.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Version bump for **v0.111.0**.

- `machinVersion` 0.110.0 → 0.111.0 (guide.go), README badge, SPEC.md
- CHANGELOG v0.111.0 entry

Ships `sso_verify_rs256` (#512): pure-MFL RS256 JWT verification against a JWKS, alg-confusion-safe, part of #484. Binaries + tag follow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)