### PR TITLE
release: v0.112.0 — ternary/Q2_0 matmul kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## v0.112.0
+
+- **Ternary / Q2_0 quantized matmul kernels** (`dot_q2`, `matmul_q2_batch`) for
+  Prism/anvil Ternary-Bonsai inference: 2-bit packed weights (4×2-bit codes per
+  byte, low bits first) with `w=(q-1)*scale` dequant (`q ∈ {0,1,2}`), activations
+  int8, group scales fp32. Also adds the missing `matmul_q4_batch` (split-nibble
+  int4 weights) referenced by existing Q4 engines — same batched shape as
+  `matmul_q8_batch` (B activations × one weight-row range, weight read once).
+
 ## v0.111.0
 
 - **Pure-MFL RS256 id_token / JWT verification** (`sso_verify_rs256` in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.111.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.112.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.111.0
+Version 0.112.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.111.0"
+const machinVersion = "0.112.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
## Summary
- Bump machinVersion `0.111.0` → `0.112.0` (`guide.go`, README badge, `SPEC.md`)
- CHANGELOG entry for `dot_q2` / `matmul_q2_batch` / `matmul_q4_batch` (#521)

## Test plan
- [ ] CI `test` green
- [ ] After merge: `git tag -a v0.112.0 -m "MFL v0.112.0" && git push origin v0.112.0`
- [ ] Watch release workflow assets land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)