### PR TITLE
fix(codegen): json() O(n) instead of O(n²) via a string builder (#520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## v0.114.0
+
+- **`json()` is no longer O(n²)** — the generated serializers built their result
+  with chained `mfl_cat`, each of which recopied the entire accumulated prefix,
+  and every intermediate prefix stayed in the (never-collected) arena as
+  permanent garbage. Serializing a 4,000-element `[]struct` (~2 MB of output)
+  took ~5 s and **8.2 GB** peak RSS; 40k was effectively a hang. The serializers
+  now append into a growable string builder (`mfl_sb`, doubling, malloc-backed,
+  copied once into the arena at the end), so serialization is O(total output) in
+  both time and memory: the same 4k case is now ~0.01 s / ~12 MB, and 40k is
+  ~0.07 s / ~110 MB. Output bytes are unchanged. Fixes #520.
+
 ## v0.113.0
 
 - **`arena_reset()` builtin** — frees the current goroutine's value-arena chain

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.113.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.114.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.113.0
+Version 0.114.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/codegen.go
+++ b/codegen.go
@@ -833,6 +833,21 @@ static char* mfl_cat(const char* a, const char* b) {
     memcpy(r, a, la); memcpy(r + la, b, lb); r[la + lb] = 0;
     return r;
 }
+/* growable string builder: append in amortized O(1) so building N pieces is
+   O(total bytes), not the O(N^2) that chained mfl_cat produced (each mfl_cat
+   recopied the entire accumulated prefix, and every intermediate prefix stayed
+   in the arena as permanent garbage — a 2 MB json() output cost ~8 GB RSS). The
+   scratch buffer is plain malloc (doubling); mfl_sb_done copies the final bytes
+   once into the arena and frees the scratch, so no intermediate is arena garbage.
+   Used by the json() serializers. (#520) */
+typedef struct { char* buf; size_t len; size_t cap; } mfl_sb;
+static void mfl_sb_init(mfl_sb* sb) { sb->cap = 64; sb->len = 0; sb->buf = malloc(sb->cap); sb->buf[0] = 0; }
+static void mfl_sb_puts(mfl_sb* sb, const char* s) {
+    s = mfl_s(s); size_t n = strlen(s);
+    if (sb->len + n + 1 > sb->cap) { while (sb->len + n + 1 > sb->cap) sb->cap *= 2; sb->buf = realloc(sb->buf, sb->cap); }
+    memcpy(sb->buf + sb->len, s, n); sb->len += n; sb->buf[sb->len] = 0;
+}
+static char* mfl_sb_done(mfl_sb* sb) { char* r = mfl_alloc(sb->len + 1); memcpy(r, sb->buf, sb->len + 1); free(sb->buf); return r; }
 static char* mfl_str_i(int64_t v) { char* b = mfl_alloc(24); snprintf(b, 24, "%lld", (long long)v); return b; }
 static char* mfl_str_d(double v)  { char* b = mfl_alloc(32); snprintf(b, 32, "%g", v); return b; }
 /* reinterpret a double's IEEE-754 bits as an int64 and back — the byte-level access
@@ -5338,12 +5353,13 @@ func (g *cgen) jsonSerializer(typeStr string) (string, error) {
 			return "", err
 		}
 		ect := cTypeName(elem)
-		body = fmt.Sprintf(`char* out = mfl_dup("[");
+		body = fmt.Sprintf(`mfl_sb sb; mfl_sb_init(&sb); mfl_sb_puts(&sb, "[");
     for (int64_t i = 0; i < v.len; i++) {
-        if (i) out = mfl_cat(out, ",");
-        out = mfl_cat(out, %s(((%s*)v.data)[i]));
+        if (i) mfl_sb_puts(&sb, ",");
+        mfl_sb_puts(&sb, %s(((%s*)v.data)[i]));
     }
-    return mfl_cat(out, "]");`, es, ect)
+    mfl_sb_puts(&sb, "]");
+    return mfl_sb_done(&sb);`, es, ect)
 	case strings.HasPrefix(typeStr, "map["):
 		kt, vt, err := splitMapType(typeStr)
 		if err != nil {
@@ -5363,23 +5379,24 @@ func (g *cgen) jsonSerializer(typeStr string) (string, error) {
 			getCall = "mfl_map_get(v, _k, NULL, &_val);"
 		}
 		body = fmt.Sprintf(`mfl_slice _ks = mfl_map_keys(v);
-    char* out = mfl_dup("{");
+    mfl_sb sb; mfl_sb_init(&sb); mfl_sb_puts(&sb, "{");
     for (int64_t i = 0; i < _ks.len; i++) {
-        if (i) out = mfl_cat(out, ",");
+        if (i) mfl_sb_puts(&sb, ",");
         %s _k = ((%s*)_ks.data)[i];
         %s _val; %s
-        out = mfl_cat(out, %s);
-        out = mfl_cat(out, ":");
-        out = mfl_cat(out, %s(_val));
+        mfl_sb_puts(&sb, %s);
+        mfl_sb_puts(&sb, ":");
+        mfl_sb_puts(&sb, %s(_val));
     }
-    return mfl_cat(out, "}");`, kct, kct, vct, getCall, keyJSON, vs)
+    mfl_sb_puts(&sb, "}");
+    return mfl_sb_done(&sb);`, kct, kct, vct, getCall, keyJSON, vs)
 	default:
 		td, ok := g.c.StructTypes()[typeStr]
 		if !ok {
 			return "", fmt.Errorf("json: cannot serialize type %q", typeStr)
 		}
 		var b strings.Builder
-		b.WriteString(`char* out = mfl_dup("{");` + "\n")
+		b.WriteString(`mfl_sb sb; mfl_sb_init(&sb); mfl_sb_puts(&sb, "{");` + "\n")
 		for i, f := range td.Fields {
 			fs, err := g.jsonSerializer(f.Type)
 			if err != nil {
@@ -5389,10 +5406,11 @@ func (g *cgen) jsonSerializer(typeStr string) (string, error) {
 			if i > 0 {
 				prefix = `",\"` + f.Name + `\":"`
 			}
-			fmt.Fprintf(&b, "    out = mfl_cat(out, %s);\n", prefix)
-			fmt.Fprintf(&b, "    out = mfl_cat(out, %s(v.f_%s));\n", fs, f.Name)
+			fmt.Fprintf(&b, "    mfl_sb_puts(&sb, %s);\n", prefix)
+			fmt.Fprintf(&b, "    mfl_sb_puts(&sb, %s(v.f_%s));\n", fs, f.Name)
 		}
-		b.WriteString(`    return mfl_cat(out, "}");`)
+		b.WriteString(`    mfl_sb_puts(&sb, "}");` + "\n")
+		b.WriteString(`    return mfl_sb_done(&sb);`)
 		body = b.String()
 	}
 

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.113.0"
+const machinVersion = "0.114.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/json_scale_test.go
+++ b/json_scale_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// #520: json() built its result with chained mfl_cat (each recopied the whole
+// accumulated prefix), so serializing a large []struct was O(n^2) time and left
+// O(n^2) arena garbage — a 2 MB output cost ~5 s and 8.2 GB RSS. The serializers
+// now use a growable string builder (mfl_sb), so it's O(total output). These
+// tests lock in exact-byte correctness through the rewrite and exercise the
+// large-slice path that used to blow up.
+
+func TestJSONExactBytesNested(t *testing.T) {
+	inner := `type Inner struct { a int  b bool }`
+	outer := `type Outer struct { name string  tags []string  scores map[string]int  kid Inner }`
+	main := `func main() {
+	tg := []string{}
+	tg = append(tg, "p")
+	tg = append(tg, "q")
+	sc := make(map[string]int)
+	sc["z"] = 3
+	o := Outer{ name: "hi\"x", tags: tg, scores: sc, kid: Inner{a: 0 - 7, b: true} }
+	println(json(o))
+}`
+	out := strings.TrimSpace(buildRunResetProg(t, inner, outer, main))
+	want := `{"name":"hi\"x","tags":["p","q"],"scores":{"z":3},"kid":{"a":-7,"b":true}}`
+	if out != want {
+		t.Fatalf("json bytes changed:\n got %q\nwant %q", out, want)
+	}
+}
+
+// A large []struct must serialize to the correct total length (and, implicitly,
+// complete quickly / in bounded memory — before the fix this was a multi-second,
+// multi-gigabyte O(n^2) blowup).
+func TestJSONLargeSliceScale(t *testing.T) {
+	typ := `type C struct { id int  text string }`
+	main := `func main() {
+	xs := []C{}
+	i := 0
+	while i < 20000 { xs = append(xs, C{id: i, text: "payload"})  i = i + 1 }
+	s := json(xs)
+	println(str(len(s)))
+}`
+	out := strings.TrimSpace(buildRunResetProg(t, typ, main))
+	// Each element: {"id":<i>,"text":"payload"} ; digits of i vary. Compute expected.
+	// fixed per element besides the id digits: `{"id":,"text":"payload"}` = 24 chars
+	// plus commas between elements (n-1) plus the surrounding [].
+	n := 20000
+	total := 2 + (n - 1) // [] + commas
+	for i := 0; i < n; i++ {
+		total += 24 + len(itoa(i))
+	}
+	if out != itoa(total) {
+		t.Fatalf("large-slice json length wrong: got %s want %d", out, total)
+	}
+}


### PR DESCRIPTION
Closes #520.

## Problem
The generated `json()` serializers (`jsonSerializer` in codegen.go) built their result with chained `out = mfl_cat(out, …)`. `mfl_cat` allocates a fresh buffer and **recopies the entire accumulated prefix** every call, so a loop over N elements is **O(N²)** copies — and because machin's arena is never collected, every intermediate prefix stays resident as permanent garbage.

Reported (glane dogfood): a 4,000-element `[]struct` (~2 MB output) took **~5 s and 8.2 GB peak RSS**; 40k was effectively a hang/OOM.

## Fix
Append into a growable string builder instead:

```
typedef struct { char* buf; size_t len; size_t cap; } mfl_sb;
// doubling, malloc-backed scratch; mfl_sb_done copies the final bytes once
// into the arena and frees the scratch — no intermediate becomes arena garbage.
```

Each nested serializer **still returns `char*`**, so the two channel-deepcopy call sites and the `json()` builtin call site are all untouched. The parent appends a child's finished string in amortized O(1), making the whole (recursive) serialization **O(total output)** in time *and* memory.

## Measured (issue's exact repro)
| case | before | after |
|---|---|---|
| 4,000 elements (~2 MB) | ~5 s / 8.2 GB | **~0.01 s / ~12 MB** |
| 40,000 elements (~20 MB) | hang / OOM | **~0.07 s / ~110 MB** |

Output bytes are **unchanged** (verified byte-exact on a nested struct/slice/map/negative-int case).

## Changes
- **runtime** (`codegen.go`): `mfl_sb` string builder (`mfl_sb_init`/`mfl_sb_puts`/`mfl_sb_done`) next to `mfl_cat`
- **serializers** (`codegen.go`): `[]`, `map[`, and struct bodies build into a local `mfl_sb`
- **tests** (`json_scale_test.go`): exact-byte nested output + 20k-element scale length check

Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)