### PR TITLE
feat(crypto): x509_pubkey — extract RSA n/e from a DER X.509 cert (SAML arm of #484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## v0.116.0
+
+- **`x509_pubkey(cert_der) -> (n, e)` — the X.509 arm of pure-MFL SAML SSO**
+  (issue #484). Extracts an RSA public key (raw big-endian modulus `n` and
+  exponent `e`) from a DER-encoded X.509 certificate — the base64-decoded bytes of
+  a SAML metadata `<ds:X509Certificate>`. The output plugs straight into
+  `rsa_verify_jwk_sha256(n, e, msg, sig)`, so an RSA-SHA256 signature can be
+  verified against the IdP's embedded cert with no JWKS. Non-RSA (EC/Ed25519)
+  certs return two empty buffers so a caller can detect "not an RSA cert". A new
+  pure-MFL helper `sso_x509_rsa_verify(cert_b64, signed, sig_b64)` in
+  `framework/sso.src` wraps the extract-and-verify flow (XML whitespace tolerated).
+  Verified end-to-end against genuine `crypto/x509` certs + `crypto/rsa`
+  signatures. XML Exclusive Canonicalization (c14n) + `<ds:Signature>` parsing —
+  the rest of SAML — remain open under #484.
+
 ## v0.115.0
 
 - **Windows cross-compile target (`--target windows`), Phase 0** — `machin build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.115.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.116.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.115.0
+Version 0.116.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/codegen.go
+++ b/codegen.go
@@ -3063,6 +3063,7 @@ const cryptoRuntime = `#include <openssl/evp.h>
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
 #include <openssl/bn.h>
+#include <openssl/x509.h>
 #include <string.h>
 
 static mfl_bytes mfl_crypto_buf(int64_t n) {
@@ -3174,6 +3175,39 @@ static int mfl_crypto_ed25519_verify(mfl_bytes pub, mfl_bytes msg, mfl_bytes sig
    JWKS path builds the public key straight from the raw big-endian modulus (n)
    and exponent (e) bytes a JWKS exposes as base64url. */
 typedef struct { mfl_bytes priv; mfl_bytes pub; } mfl_crypto_rsa_keypair;
+/* x509_pubkey result: the RSA public key's modulus (n) and exponent (e) as raw
+   big-endian bytes — the exact shape rsa_verify_jwk_sha256 consumes (BN_bin2bn),
+   so a SAML <ds:X509Certificate> plugs straight into the RS256/RSA-SHA256 verify
+   path with no JWKS. Both empty on any parse/type failure. #484 */
+typedef struct { mfl_bytes n; mfl_bytes e; } mfl_crypto_x509_pubkey;
+/* Extract the RSA public key (n, e) from a DER-encoded X.509 certificate — the
+   base64-decoded bytes of a SAML metadata <ds:X509Certificate>. Non-RSA keys
+   (EC/Ed25519) yield two empty buffers (caller checks len). */
+static mfl_crypto_x509_pubkey mfl_crypto_x509_pubkey_ne(mfl_bytes der) {
+    mfl_crypto_x509_pubkey r;
+    r.n = mfl_crypto_buf(1); r.n.len = 0;
+    r.e = mfl_crypto_buf(1); r.e.len = 0;
+    const unsigned char* p = der.data;
+    X509* cert = d2i_X509(NULL, &p, (long)der.len);
+    if (!cert) return r;
+    EVP_PKEY* pk = X509_get_pubkey(cert);
+    if (pk) {
+        RSA* rsa = EVP_PKEY_get1_RSA(pk);
+        if (rsa) {
+            const BIGNUM* bn = NULL; const BIGNUM* be = NULL;
+            RSA_get0_key(rsa, &bn, &be, NULL);
+            if (bn && be) {
+                int ln = BN_num_bytes(bn), le = BN_num_bytes(be);
+                if (ln > 0) { mfl_bytes o = mfl_crypto_buf(ln); o.len = BN_bn2bin(bn, o.data); r.n = o; }
+                if (le > 0) { mfl_bytes o = mfl_crypto_buf(le); o.len = BN_bn2bin(be, o.data); r.e = o; }
+            }
+            RSA_free(rsa);
+        }
+        EVP_PKEY_free(pk);
+    }
+    X509_free(cert);
+    return r;
+}
 
 /* Generate an RSA keypair; returns PEM (PKCS#8 private, SubjectPublicKeyInfo
    public), both empty on failure. Keygen draws from the CSPRNG internally and —
@@ -4368,6 +4402,8 @@ func multiRetBuiltinC(name string) (cfn, ctype string, fields []string, needsTLS
 		return "mfl_mmap_file", "mfl_mmap_result", []string{"ptr", "len"}, false, true
 	case "rsa_generate":
 		return "mfl_crypto_rsa_generate", "mfl_crypto_rsa_keypair", []string{"priv", "pub"}, false, true
+	case "x509_pubkey":
+		return "mfl_crypto_x509_pubkey_ne", "mfl_crypto_x509_pubkey", []string{"n", "e"}, false, true
 	}
 	return "", "", nil, false, false
 }

--- a/framework/sso.src
+++ b/framework/sso.src
@@ -174,3 +174,30 @@ func sso_verify_rs256(token, jwks_json) (claims, ok) {
         ok = 1
     }
 }
+
+// --- SAML / X.509 signature verification (issue #484) -----------------------
+// SAML metadata embeds the IdP's signing cert as a base64 DER X.509 inside a
+// <ds:X509Certificate>. sso_x509_rsa_verify pulls that cert's RSA public key out
+// with x509_pubkey and verifies an RSA-SHA256 (PKCS#1 v1.5) signature over
+// `signed` — the bytes an XML-DSig <ds:SignatureValue> covers (the canonicalized
+// <Assertion>/<SignedInfo>). Returns ok=1 only when the signature is valid.
+// This is the X.509/RSA key-extraction + verify ARM of pure-MFL SAML; XML
+// Exclusive Canonicalization (c14n) and <ds:Signature> reference parsing are the
+// remaining pieces of the full flow.
+//   cert_b64: the <ds:X509Certificate> text — standard base64 of the DER cert,
+//             XML indentation/newlines tolerated (stripped here).
+//   signed:   the exact signed bytes (already canonicalized by the caller).
+//   sig_b64:  the <ds:SignatureValue> — standard base64 of the signature bytes.
+func sso_x509_rsa_verify(cert_b64, signed, sig_b64) (ok) {
+    ok = 0
+    c := replace(cert_b64, "\n", "")
+    c = replace(c, "\r", "")
+    c = replace(c, "\t", "")
+    c = replace(c, " ", "")
+    cert_der := base64_decode_bytes(c)
+    if len(cert_der) == 0 { return }                // not decodable
+    n, e := x509_pubkey(cert_der)
+    if len(n) == 0 { return }                       // cert has no RSA key (EC/EdDSA)
+    sig := base64_decode_bytes(sig_b64)
+    if rsa_verify_jwk_sha256(n, e, signed, sig) { ok = 1 }
+}

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.115.0"
+const machinVersion = "0.116.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -340,6 +340,7 @@ func machinGuide() guideCatalog {
 			{"rsa_sign_pkcs1_sha256", "(bytes, bytes) -> bytes", "RSA PKCS#1 v1.5 sign (private PEM, msg) -> signature over SHA-256 (RS256; empty bytes on failure)", "crypto"},
 			{"rsa_verify_pkcs1_sha256", "(bytes, bytes, bytes) -> bool", "RSA PKCS#1 v1.5 verify (public PEM SubjectPublicKeyInfo, msg, sig) over SHA-256 (RS256)", "crypto"},
 			{"rsa_verify_jwk_sha256", "(bytes, bytes, bytes, bytes) -> bool", "RS256 JWT verify straight from a JWKS: (n, e, msg, sig) where n and e are the base64url-decoded modulus & exponent bytes from the IdP's JWKS. Builds the RSA public key from n/e (no PEM/X.509 needed) and verifies PKCS#1 v1.5 over SHA-256 — the OIDC id_token verification path (issue #484)", "crypto"},
+			{"x509_pubkey", "(bytes) -> (bytes, bytes)", "extract the RSA public key from a DER-encoded X.509 certificate -> (n, e) as raw big-endian modulus & exponent bytes. MULTI-ASSIGN ONLY: n, e := x509_pubkey(cert_der). The cert_der is the base64-DECODED bytes of a SAML metadata <ds:X509Certificate>. Output plugs straight into rsa_verify_jwk_sha256(n, e, msg, sig) — so a SAML/XML-DSig RSA-SHA256 signature can be verified against the IdP's embedded cert with no JWKS. Non-RSA (EC/Ed25519) certs return two EMPTY buffers (check len). The X.509 arm of pure-MFL SAML SSO (issue #484); XML c14n + <ds:Signature> parsing are the remaining pieces", "crypto"},
 			// sqlite (libsqlite3, linked only when used)
 			{"sqlite_open", "(string) -> int", "open/create a SQLite db file -> handle (0 on fail); \":memory:\" for in-memory", "db"},
 			{"sqlite_exec", "(int, string[, []string]) -> int", "run SQL with no result; optional []string binds the ? params (injection-safe); 0 ok", "db"},

--- a/types.go
+++ b/types.go
@@ -1590,6 +1590,8 @@ func (c *Checker) multiRetBuiltin(name string) (args []int, rets []int, ok bool)
 		return []int{c.cString}, []int{c.cInt, c.cInt}, true
 	case "rsa_generate":
 		return []int{c.cInt}, []int{c.cBytes, c.cBytes}, true
+	case "x509_pubkey":
+		return []int{c.cBytes}, []int{c.cBytes, c.cBytes}, true
 	}
 	return nil, nil, false
 }
@@ -2570,6 +2572,8 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		return 0, fmt.Errorf("mmap_file returns 2 values; use: ptr, size := mmap_file(path)")
 	case "rsa_generate":
 		return 0, fmt.Errorf("rsa_generate returns 2 values; use: priv, pub := rsa_generate(bits)")
+	case "x509_pubkey":
+		return 0, fmt.Errorf("x509_pubkey returns 2 values; use: n, e := x509_pubkey(cert_der)")
 	case "wss_open":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("wss_open: 1 arg (url string)")

--- a/x509_pubkey_test.go
+++ b/x509_pubkey_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestX509PubkeyVerify exercises the X.509 arm of pure-MFL SAML SSO (issue #484):
+// the x509_pubkey builtin (extract an RSA n/e from a DER cert) and the
+// sso_x509_rsa_verify helper (framework/sso.src). We mint a genuine self-signed
+// RSA cert + an RSA-SHA256 signature in Go — exactly what a SAML IdP's
+// <ds:X509Certificate> / <ds:SignatureValue> carry — and assert the MFL path:
+// (1) verifies a valid signature against the cert's embedded key, and
+// (2) rejects a tampered message.
+func TestX509PubkeyVerify(t *testing.T) {
+	sso, err := os.ReadFile("framework/sso.src")
+	if err != nil {
+		t.Skip("framework/sso.src not found")
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	// A self-signed cert, like an IdP signing cert published in SAML metadata.
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "idp.example.com"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+	certB64 := base64.StdEncoding.EncodeToString(der) // <ds:X509Certificate> body
+
+	msg := "the-canonicalized-assertion-bytes"
+	digest := sha256.Sum256([]byte(msg))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sigB64 := base64.StdEncoding.EncodeToString(sig) // <ds:SignatureValue> body
+
+	app := "\n" +
+		"func main() {\n" +
+		"    cert := \"" + certB64 + "\"\n" +
+		"    sig := \"" + sigB64 + "\"\n" +
+		"    n, e := x509_pubkey(base64_decode_bytes(cert))\n" +
+		"    println(\"nlen=\" + str(len(n)) + \" elen=\" + str(len(e)))\n" +
+		"    good := sso_x509_rsa_verify(cert, bytes(\"" + msg + "\"), sig)\n" +
+		"    println(\"valid=\" + str(good))\n" +
+		"    bad := sso_x509_rsa_verify(cert, bytes(\"" + msg + "X\"), sig)\n" +
+		"    println(\"tampered=\" + str(bad))\n" +
+		"}\n"
+
+	prog, perr := progFromSrcErr(string(sso) + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"nlen=256 elen=3", // 2048-bit modulus + 65537 exponent, extracted from the DER cert
+		"valid=1",         // genuine RSA-SHA256 signature verifies against the cert key
+		"tampered=0",      // altered message -> signature fails
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// A non-RSA (here EC) certificate must yield an empty n/e — so a caller can
+// detect "not an RSA cert" (and sso_x509_rsa_verify returns ok=0) rather than
+// crash. Locks in the documented contract of x509_pubkey.
+func TestX509PubkeyNonRSAEmpty(t *testing.T) {
+	sso, err := os.ReadFile("framework/sso.src")
+	if err != nil {
+		t.Skip("framework/sso.src not found")
+	}
+	eckey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("eckey: %v", err)
+	}
+	tmpl := x509.Certificate{SerialNumber: big.NewInt(2), Subject: pkix.Name{CommonName: "ec.example.com"}}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &eckey.PublicKey, eckey)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+	certB64 := base64.StdEncoding.EncodeToString(der)
+
+	app := "\n" +
+		"func main() {\n" +
+		"    n, e := x509_pubkey(base64_decode_bytes(\"" + certB64 + "\"))\n" +
+		"    println(\"nlen=\" + str(len(n)) + \" elen=\" + str(len(e)))\n" +
+		"    ok := sso_x509_rsa_verify(\"" + certB64 + "\", bytes(\"whatever\"), \"AAAA\")\n" +
+		"    println(\"ok=\" + str(ok))\n" +
+		"}\n"
+	prog, perr := progFromSrcErr(string(sso) + app)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"nlen=0 elen=0", "ok=0"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Advances #484 (pure-MFL SAML SSO). The **RSA slice** (#498) unblocked RS256 JWT verification from a JWKS; this adds the **X.509 arm** — SAML embeds the IdP's signing key as a base64 DER X.509 cert in a `<ds:X509Certificate>`, not as JWKS `n`/`e`.

## New builtin
`x509_pubkey(cert_der bytes) -> (n bytes, e bytes)` — parse a DER X.509 certificate (OpenSSL `d2i_X509` → `X509_get_pubkey` → `RSA_get0_key` → `BN_bn2bin`) and return the RSA modulus + exponent as **raw big-endian bytes** — the exact shape `rsa_verify_jwk_sha256(n, e, msg, sig)` already consumes. So a SAML/XML-DSig RSA-SHA256 signature verifies against the cert's embedded key with **no JWKS**.

Non-RSA (EC/Ed25519) certs return two **empty** buffers, so a caller detects "not an RSA cert" rather than crashing.

## Pure-MFL helper
`framework/sso.src` gains `sso_x509_rsa_verify(cert_b64, signed, sig_b64)` — decode + extract + verify in pure MFL (XML whitespace in the cert body tolerated), mirroring the existing `sso_verify_rs256`.

## Consistency
Follows #498's OpenSSL-backed `rsa_*` builtins: it's a `mfl_crypto_*` function, so it sets `usesCrypto` (links libcrypto only when used) and is rejected on the `--target windows` build like the other crypto (an OpenSSL-Windows link is a later #517 phase).

## Verified
End-to-end against genuine `crypto/x509` self-signed certs + `crypto/rsa` RSA-SHA256 signatures:
- valid signature → `x509_pubkey` yields n=256 / e=3, `rsa_verify_jwk_sha256` returns true
- tampered message → rejected
- EC cert → empty `n`/`e`, helper returns `ok=0`

## Out of scope (stay open under #484)
XML Exclusive Canonicalization (c14n) and `<ds:Signature>` reference parsing — the remaining, harder SAML pieces.

Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)