### PR TITLE
fix(runtime): arena_reset() returns freed pages to the OS via malloc_trim (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## v0.118.0
+
+- **`arena_reset()` now returns freed pages to the OS** (issue #529). It already
+  freed the arena chain, but plain `free()` leaves the pages on glibc's heap
+  free-list, so process RSS stayed pinned at the peak (e.g. a poche single-actor
+  server plateaued at ~168 MB for an ~16 MB working set). `arena_reset()` now
+  also calls `malloc_trim(0)` on glibc, releasing that free heap back to the
+  kernel. Measured: a churn that peaks at ~825 MB drops to ~1.8 MB after reset
+  (was: no change). The trim runs only in `arena_reset()`, at the caller's
+  quiescent reset point — NOT in the per-goroutine-exit reclaim path, which stays
+  a cheap `free()`-only fast path. No-op on musl/macOS (their allocators already
+  release freed spans) and on the wasm/windows targets. No API change.
+
 ## v0.117.0
 
 - **Pure-MFL SAML / XML-DSig signature verification** (`framework/xml.src`) —

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.117.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.118.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.117.0
+Version 0.118.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one
@@ -492,7 +492,10 @@ id(42); id("hi"); id(3.14)   // → three native functions
   flat. Unlike an `arena { }` block, it is **unchecked** — the caller asserts
   that no arena-allocated value is still reachable at the reset point; any
   survivor dangles. Keep cross-reset state in malloc-backed maps/channels or on
-  disk. Prefer `arena { }` when the lifetime is a lexical scope.
+  disk. Prefer `arena { }` when the lifetime is a lexical scope. On glibc it also
+  runs `malloc_trim(0)`, returning the freed pages to the OS so RSS actually drops
+  (plain `free` keeps them on the C heap's free-list); it is a no-op on
+  musl/macOS, whose allocators already release freed spans.
 - By default, integer overflow wraps (two's complement) and division by zero /
   out-of-bounds slice access are undefined (they follow the generated C).
 - Building with **`--safe`** inserts runtime checks: a slice index out of range,

--- a/arena_trim_test.go
+++ b/arena_trim_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// #529: arena_reset() frees the arena chain, but plain free() leaves the pages
+// on glibc's heap free-list, so RSS stayed pinned at the peak. arena_reset() now
+// calls malloc_trim(0) (glibc) to return those pages to the OS. This test churns
+// to a multi-hundred-MB high-water mark, then asserts RSS collapses after a
+// reset. glibc/Linux only — malloc_trim is a no-op elsewhere (and the RSS probe
+// reads /proc), so the test skips on other platforms.
+func TestArenaResetReturnsRSSToOS(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("RSS-return check is glibc/Linux-specific (malloc_trim)")
+	}
+	rssFn := `func rss_kb() (r) {
+	code, out, err := exec("grep VmRSS /proc/$PPID/status | grep -o '[0-9]*'")
+	r = parse_int(trim(out))
+}`
+	churnFn := `func churn(n) (acc) {
+	acc = 0
+	i := 0
+	while i < n {
+		s := "row-" + str(i) + "-payload-" + str(i * 7) + "-" + str(i * 13)
+		acc = acc + len(s)
+		i = i + 1
+	}
+}`
+	mainFn := `func main() {
+	a := churn(500000)
+	peak := rss_kb()
+	arena_reset()
+	after := rss_kb()
+	println(str(peak) + " " + str(after) + " " + str(a))
+}`
+
+	p, err := ParseProgram([]string{normalize(rssFn), normalize(churnFn), normalize(mainFn)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bin, err := os.CreateTemp("", "mfl-trim-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	if err := BuildBinary(p, bin.Name(), false); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	out, err := exec.Command(bin.Name()).Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 2 {
+		t.Fatalf("unexpected output %q", out)
+	}
+	peak, _ := strconv.Atoi(fields[0])
+	after, _ := strconv.Atoi(fields[1])
+	if peak == 0 || after == 0 {
+		t.Skipf("RSS probe unavailable in this environment (peak=%d after=%d)", peak, after)
+	}
+	// The churn allocates well over 100 MB into the arena; if the fix works,
+	// after-reset RSS collapses to a small fraction of the peak.
+	if peak < 100_000 {
+		t.Fatalf("churn did not build the expected high-water RSS (peak=%d KB)", peak)
+	}
+	if after > peak/4 {
+		t.Fatalf("arena_reset did not return memory to the OS: peak=%d KB, after=%d KB (want after <= peak/4)", peak, after)
+	}
+}

--- a/codegen.go
+++ b/codegen.go
@@ -190,6 +190,9 @@ const cRuntime = `#define _GNU_SOURCE
 #ifndef __wasm__
 #include <signal.h>     /* mingw-w64 ships signal.h; SIGPIPE just doesn't exist there (guarded at use) */
 #endif
+#ifdef __GLIBC__
+#include <malloc.h>     /* malloc_trim — arena_reset() returns freed heap pages to the OS (#529) */
+#endif
 
 #ifdef _WIN32
 /* Windows portability shims (#517). mingw-w64's headers don't declare the POSIX
@@ -269,10 +272,22 @@ static void mfl_arena_free(mfl_arena* a) {
    caller to ensure NO arena-allocated value is still reachable — any survivor
    dangles. Live cross-reset state must sit in malloc-backed maps/channels or on
    disk. Safe on both the main and spawned arenas; a later goroutine exit re-runs
-   mfl_arena_free on the now-empty head (a no-op). See issue #523. */
+   mfl_arena_free on the now-empty head (a no-op). See issue #523.
+
+   After freeing, it also asks the allocator to return the now-free pages to the
+   OS (malloc_trim on glibc): plain free() keeps the pages in the C heap's
+   free-list, so RSS would otherwise stay pinned at the peak (#529). This runs
+   only here, at the caller's quiescent reset point — NOT in mfl_arena_free, which
+   also fires on every goroutine exit and must stay a cheap free()-only path.
+   malloc_trim is glibc-specific and a no-op elsewhere (musl/macOS allocators
+   already release freed spans); it can only reclaim the free top of the heap, so
+   a live malloc-backed structure near the top may cap how much is returned. */
 static int64_t mfl_arena_reset(void) {
     if (!mfl_arena_cur) mfl_arena_cur = &mfl_main_arena;
     mfl_arena_free(mfl_arena_cur);
+#ifdef __GLIBC__
+    malloc_trim(0);
+#endif
     return 0;
 }
 

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.117.0"
+const machinVersion = "0.118.0"
 
 // ---- the source-of-truth feature catalog ----
 //
@@ -258,7 +258,7 @@ func machinGuide() guideCatalog {
 			{"noise2", "(number, number) -> float", "Perlin gradient noise (2D), deterministic, ~[-1,1], smooth. Layer it (fbm) by summing octaves at scaled freq/amp", "math"},
 			{"noise3", "(number, number, number) -> float", "Perlin gradient noise (3D) — animate 2D noise over time, or volumetric", "math"},
 			// raw memory (pointers are ints) — build C buffers/structs for the FFI
-			{"arena_reset", "() -> int", "free the CURRENT goroutine's value-arena chain in place, without ending the goroutine — hands all strings/slice-backings/closure-envs allocated so far back to the OS. The escape hatch for a long-running SINGLE-ACTOR server (one that can't run each request in its own goroutine, e.g. a non-thread-safe store): the main goroutine's arena otherwise grows forever, so call arena_reset() at a quiescent point to keep RSS flat. UNCHECKED, unlike an `arena { }` block (whose escape analysis PROVES nothing escapes): you assert NO arena-allocated value is still reachable — a survivor dangles. Keep any cross-reset state in malloc-backed maps/channels or on disk. Prefer `arena { }` when the lifetime is a lexical scope; reach for arena_reset() only across the request loop of a persistent single-actor server. Returns 0", "memory"},
+			{"arena_reset", "() -> int", "free the CURRENT goroutine's value-arena chain in place, without ending the goroutine — hands all strings/slice-backings/closure-envs allocated so far back to the OS. The escape hatch for a long-running SINGLE-ACTOR server (one that can't run each request in its own goroutine, e.g. a non-thread-safe store): the main goroutine's arena otherwise grows forever, so call arena_reset() at a quiescent point to keep RSS flat. UNCHECKED, unlike an `arena { }` block (whose escape analysis PROVES nothing escapes): you assert NO arena-allocated value is still reachable — a survivor dangles. Keep any cross-reset state in malloc-backed maps/channels or on disk. Prefer `arena { }` when the lifetime is a lexical scope; reach for arena_reset() only across the request loop of a persistent single-actor server. On glibc it also runs malloc_trim(0) so the freed pages are RETURNED TO THE OS (RSS actually drops, not just the C heap free-list); no-op on musl/macOS (their allocators already release freed spans). Returns 0", "memory"},
 			{"alloc", "(int) -> int", "allocate n zeroed bytes; returns a pointer (as int). For C buffers/structs to hand to an extern fn", "memory"},
 			{"free", "(int) ->", "free a pointer returned by alloc", "memory"},
 			{"madvise_free", "(int, int) ->", "drop resident pages of an mmap region (MADV_DONTNEED); re-faults lazily on next access", "memory"},


### PR DESCRIPTION
Closes #529 (follow-up to #523's `arena_reset()`).

## Problem
`arena_reset()` frees the arena chain, but plain `free()` leaves the pages on glibc's heap free-list — the memory is reusable but never handed back to the kernel, so process **RSS stays pinned at the peak**. A poche single-actor server plateaued at ~168 MB for an ~16 MB working set.

## Fix
`arena_reset()` now also calls `malloc_trim(0)` on glibc, releasing the free heap back to the OS.

**Measured** (2M-iteration string churn, RSS read from `/proc`):

| | peak RSS | after `arena_reset()` |
|---|---|---|
| before this fix | ~825 MB | **~825 MB** (unchanged) |
| with the fix | ~825 MB | **~1.8 MB** |

## Why scoped to `arena_reset()` (not `mfl_arena_free`)
The trim runs **only** in `arena_reset()`, at the caller's quiescent reset point. It is deliberately **not** added to `mfl_arena_free`, which also fires on **every goroutine exit** — a concurrent server (one goroutine per request) would otherwise `malloc_trim` on every request completion, a syscall + heap walk in the hot path. This keeps the per-goroutine reclaim a cheap `free()`-only path (chosen over the issue's Option A, which trimmed in `mfl_arena_free`).

Guarded by `#ifdef __GLIBC__`: a no-op on musl/macOS (their allocators already release freed spans) and on the wasm/windows targets. **No API change** — existing `arena_reset()` callers (poche) get RSS back for free.

## Changes
- `codegen.go`: guarded `#include <malloc.h>` + `malloc_trim(0)` in `mfl_arena_reset`
- `arena_trim_test.go`: churn to a >100 MB high-water, assert RSS collapses to `<= peak/4` after reset (glibc/Linux-gated; skips elsewhere)
- `guide.go` / `SPEC.md`: document the RSS-return behavior

Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `arena_reset()` now returns freed memory to the operating system on glibc-based Linux systems, helping reduce memory usage after heavy allocation churn.
  * Behavior remains unchanged on musl, macOS, WebAssembly, and Windows.

* **Documentation**
  * Updated the project and language specification versions to 0.118.0.
  * Clarified platform-specific `arena_reset()` behavior in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->