### PR TITLE
fix(parse): a JSON null must be consumed, not silently derail the rest of the object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## v0.121.0
+
+- **`parse()`: a JSON `null` no longer silently drops the rest of the object**
+  (PR #533). `parse("{\"a\":null,\"b\":\"hello\",\"n\":42}", T{})` returned `b=""`
+  and `n=0`. Every `mfl_js_*` value parser returned its zero value **without
+  advancing the cursor** when the value wasn't the shape it expected
+  (`mfl_js_str`: `if (**p != '"') return mfl_dup("");`), so a `null` left the
+  cursor parked on the literal; the enclosing struct's field loop then looked for
+  its separating comma, found `n`, and broke out — losing every remaining field
+  and derailing the enclosing parsers too. Silent data loss, no error, no crash.
+  This bit real APIs hard: OpenAI/OpenRouter return exactly
+  `{"content":null,"tool_calls":[...]}` on a tool call, so `tool_calls` **and** the
+  sibling `usage` block vanished and a tool-calling client saw "no tools
+  requested". New `mfl_js_null()` consumes the literal and is called first in
+  every value parser — `int`, `float`, `bool`, `string`, slice, map, and struct —
+  so a `null` yields the type's zero value *and* leaves the cursor on the comma.
+  `json_get()` was never affected (separate code path). Found while adding
+  declarative tool calling to chatsnip.
+
 ## v0.120.0
 
 - **Windows target — Phase TLS: HTTPS/TLS + OpenSSL crypto** (issue #517). The

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.120.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.121.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/codegen.go
+++ b/codegen.go
@@ -1484,9 +1484,19 @@ static char* mfl_http_body(const char* s) { /* bytes after the blank line of an 
 
 /* JSON parsing: a cursor (const char**) walked by recursive-descent helpers */
 static void mfl_js_ws(const char** p) { while (**p==' '||**p=='\t'||**p=='\n'||**p=='\r') (*p)++; }
-static int64_t mfl_js_int(const char** p) { mfl_js_ws(p); char* e; long long v = strtoll(*p, &e, 10); *p = e; return v; }
-static double mfl_js_float(const char** p) { mfl_js_ws(p); char* e; double v = strtod(*p, &e); *p = e; return v; }
-static int mfl_js_bool(const char** p) { mfl_js_ws(p); if (**p=='t') { *p += 4; return 1; } if (**p=='f') { *p += 5; return 0; } return 0; }
+/* mfl_js_null: consume a JSON null literal if the cursor is on one (-> 1), else
+   leave the cursor untouched (-> 0). EVERY value parser must call this first: a
+   parser that returns its zero value WITHOUT consuming the null leaves the cursor
+   parked on the literal, so the enclosing object's field loop then fails to find
+   its comma and silently drops every REMAINING field ({"a":null,"b":1} lost b). */
+static int mfl_js_null(const char** p) {
+    mfl_js_ws(p);
+    if ((*p)[0]=='n' && (*p)[1]=='u' && (*p)[2]=='l' && (*p)[3]=='l') { *p += 4; return 1; }
+    return 0;
+}
+static int64_t mfl_js_int(const char** p) { if (mfl_js_null(p)) return 0; char* e; long long v = strtoll(*p, &e, 10); *p = e; return v; }
+static double mfl_js_float(const char** p) { if (mfl_js_null(p)) return 0; char* e; double v = strtod(*p, &e); *p = e; return v; }
+static int mfl_js_bool(const char** p) { if (mfl_js_null(p)) return 0; if (**p=='t') { *p += 4; return 1; } if (**p=='f') { *p += 5; return 0; } return 0; }
 /* mfl_hex4: the 4 hex digits at p as an int, or -1 if any of them aren't hex
    (a malformed \u escape -- the caller falls back to treating it literally). */
 static int mfl_hex4(const char* p) {
@@ -1510,7 +1520,7 @@ static size_t mfl_utf8_encode(char* out, int cp) {
     out[0] = (char)(0xF0 | (cp >> 18)); out[1] = (char)(0x80 | ((cp >> 12) & 0x3F)); out[2] = (char)(0x80 | ((cp >> 6) & 0x3F)); out[3] = (char)(0x80 | (cp & 0x3F)); return 4;
 }
 static char* mfl_js_str(const char** p) {
-    mfl_js_ws(p);
+    if (mfl_js_null(p)) return mfl_dup("");
     if (**p != '"') return mfl_dup("");
     (*p)++;
     char* out = mfl_alloc(strlen(*p) + 1); size_t j = 0;
@@ -5637,6 +5647,7 @@ func (g *cgen) jsonParser(typeStr string) (string, error) {
 		}
 		ect := cTypeName(elem)
 		body = fmt.Sprintf(`mfl_slice s = {0};
+    if (mfl_js_null(p)) return s;
     mfl_js_ws(p);
     if (**p == '[') {
         (*p)++; mfl_js_ws(p);
@@ -5666,6 +5677,7 @@ func (g *cgen) jsonParser(typeStr string) (string, error) {
 			keyIsStr, setCall = 1, "mfl_map_set(m, 0, _k, &_val);"
 		}
 		body = fmt.Sprintf(`mfl_map* m = mfl_make_map(%d, sizeof(%s));
+    if (mfl_js_null(p)) return m;
     mfl_js_ws(p);
     if (**p == '{') {
         (*p)++; mfl_js_ws(p);
@@ -5695,7 +5707,8 @@ func (g *cgen) jsonParser(typeStr string) (string, error) {
 		} else {
 			fmt.Fprintf(&b, "%s out = {0};\n", ct)
 		}
-		b.WriteString(`    mfl_js_ws(p);
+		b.WriteString(`    if (mfl_js_null(p)) return out;
+    mfl_js_ws(p);
     if (**p == '{') {
         (*p)++; mfl_js_ws(p);
         if (**p != '}') {

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.120.0"
+const machinVersion = "0.121.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/parse_null_derail_test.go
+++ b/parse_null_derail_test.go
@@ -1,0 +1,79 @@
+package main
+
+import "testing"
+
+// Regression: a JSON `null` VALUE must be consumed by the value parser, not just
+// ignored. Every mfl_js_* parser used to return its zero value WITHOUT advancing
+// the cursor when the value wasn't the shape it expected, so `null` left the
+// cursor parked on the literal. The enclosing object's field loop then looked for
+// its separating comma, found `n`, and broke out — silently dropping every
+// REMAINING field of that object (and derailing the enclosing parsers too).
+//
+// This is a data-loss bug against real APIs: OpenAI/OpenRouter return exactly
+// {"content":null,"tool_calls":[...]} on a tool call, so the tool_calls array
+// (and the sibling usage block) vanished. mfl_js_null() now consumes the literal
+// in every value parser: scalars, strings, slices, maps, and structs.
+
+func TestParseNullDoesNotDropFollowingFields(t *testing.T) {
+	got := runProg(t,
+		`type T struct { a string  b string  n int }`,
+		`func main() {
+			// null in the FIRST field must not eat the ones after it
+			x := parse("{\"a\":null,\"b\":\"hello\",\"n\":42}", T{})
+			println("b=" + x.b)
+			println("n=" + str(x.n))
+			// a null int/bool position likewise
+			y := parse("{\"a\":\"x\",\"n\":null,\"b\":\"tail\"}", T{})
+			println("y.a=" + y.a)
+			println("y.n=" + str(y.n))
+			println("y.b=" + y.b)
+		}`)
+	want := "b=hello\nn=42\ny.a=x\ny.n=0\ny.b=tail\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+// The OpenAI tool-call response shape, verbatim: a null `content` followed by a
+// populated `tool_calls` array of nested structs. Before the fix this parsed as
+// zero tool calls, so a tool-calling client silently saw "no tools requested".
+func TestParseNullContentKeepsToolCallsArray(t *testing.T) {
+	got := runProg(t,
+		`type FnCall struct { name string  arguments string }`,
+		`type ToolCall struct { id string  function FnCall }`,
+		`type RMsg struct { content string  tool_calls []ToolCall }`,
+		`type RChoice struct { message RMsg }`,
+		`type RUsage struct { total_tokens int }`,
+		`type RResp struct { choices []RChoice  usage RUsage }`,
+		`func main() {
+			s := "{\"choices\":[{\"message\":{\"content\":null,\"tool_calls\":[{\"id\":\"call_1\",\"function\":{\"name\":\"calc\",\"arguments\":\"{}\"}}]}}],\"usage\":{\"total_tokens\":7}}"
+			r := parse(s, RResp{})
+			println("tc=" + str(len(r.choices[0].message.tool_calls)))
+			println("id=" + r.choices[0].message.tool_calls[0].id)
+			println("name=" + r.choices[0].message.tool_calls[0].function.name)
+			println("content.len=" + str(len(r.choices[0].message.content)))
+			println("tokens=" + str(r.usage.total_tokens))
+		}`)
+	want := "tc=1\nid=call_1\nname=calc\ncontent.len=0\ntokens=7\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+// A null in place of a whole composite (slice / struct / map) must also be
+// consumed, yielding the empty value and leaving later fields intact.
+func TestParseNullCompositeFields(t *testing.T) {
+	got := runProg(t,
+		`type Inner struct { x string }`,
+		`type C struct { items []string  in Inner  tail string }`,
+		`func main() {
+			a := parse("{\"items\":null,\"tail\":\"kept\"}", C{})
+			println("items=" + str(len(a.items)) + " tail=" + a.tail)
+			b := parse("{\"in\":null,\"tail\":\"kept2\"}", C{})
+			println("in.x.len=" + str(len(b.in.x)) + " tail=" + b.tail)
+		}`)
+	want := "items=0 tail=kept\nin.x.len=0 tail=kept2\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## The bug

`parse()` silently dropped every field **following** a `null` value.

```go
type T struct { a string  b string  n int }
parse("{\"a\":null,\"b\":\"hello\",\"n\":42}", T{})
// before: b="" n=0     after: b="hello" n=42
```

Each `mfl_js_*` value parser returned its zero value **without advancing the cursor** when the value wasn't the shape it expected (`mfl_js_str`: `if (**p != '"') return mfl_dup("");`). So `null` left the cursor parked on the literal. The enclosing struct's field loop then called `mfl_js_more()` looking for its separating comma, found `n`, and broke out — dropping all remaining fields, and leaving the cursor mid-object so the *enclosing* parsers derailed too.

## Why it matters

This is silent data loss against real-world APIs — no error, no crash, just missing data. OpenAI/OpenRouter return exactly this on a tool call:

```json
{"choices":[{"message":{"content":null,"tool_calls":[...]}}],"usage":{"total_tokens":7}}
```

so `tool_calls` **and** the sibling `usage` block vanished, and a tool-calling client saw "no tools requested". Found while adding tool calling to chatsnip.

`json_get()` was unaffected (different code path) — only `parse()`.

## The fix

Adds `mfl_js_null()`, which consumes the literal and reports whether it did, and calls it first in **every** value parser: `int`, `float`, `bool`, `string`, slice, map, and struct. A `null` now yields the type's zero value *and* leaves the cursor on the comma, so parsing continues.

## Testing

- Full suite green (`go test ./...`, 134s, zero failures).
- 3 regression tests in `parse_null_derail_test.go`: scalar-after-null (string + int positions), the verbatim OpenAI `tool_calls` shape, and `null` in place of a whole composite (slice/struct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing of `null` values across scalar and composite fields.
  * Ensured fields following `null` values continue to parse correctly.
  * Preserved subsequent tool-call data when content is `null`.
  * `null` values now produce appropriate empty or zero values without disrupting parsing.

* **Tests**
  * Added coverage for scalar, map, slice, struct-like, and tool-call parsing scenarios involving `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->