### PR TITLE
perf: scoped arenas return pages to the OS; machweb reads a body in linear time

### DIFF
--- a/arena_escape_test.go
+++ b/arena_escape_test.go
@@ -244,3 +244,27 @@ func TestMainArenaMapKeepsFreeingOnDelete(t *testing.T) {
 		t.Fatalf("long-lived map semantics changed: %q", got)
 	}
 }
+
+// A scoped arena that freed a lot should hand the pages back to the OS, not just
+// to the C heap's free-list: glibc raises its mmap threshold once large blocks
+// have been freed, so a server doing heavy scoped work per request otherwise
+// sees RSS climb even though every block is reclaimed correctly. (It can only
+// release the free TOP of the heap — live data allocated above freed pages caps
+// what comes back, which is why this asserts a ratio rather than a fixed floor.)
+func TestScopedArenaReturnsPagesToTheOS(t *testing.T) {
+	prog := func(scoped bool) string {
+		inner := `big := []string{} i := 0 while i < 120000 { big = append(big, "row-" + str(i) + "-payload") i = i + 1 } total = total + len(big)`
+		if scoped {
+			inner = `arena { ` + inner + ` }`
+		}
+		return `func main() { total := 0 n := 0 while n < 6 { ` + inner + ` n = n + 1 } println(total) }`
+	}
+	scopedOut, scopedRSS := buildRun(t, prog(true))
+	unscopedOut, unscopedRSS := buildRun(t, prog(false))
+	if scopedOut != unscopedOut {
+		t.Fatalf("trimming changed output: %q vs %q", scopedOut, unscopedOut)
+	}
+	if scopedRSS*3 > unscopedRSS {
+		t.Fatalf("scoped arena did not return pages: scoped %d kB vs unscoped %d kB", scopedRSS, unscopedRSS)
+	}
+}

--- a/codegen.go
+++ b/codegen.go
@@ -227,7 +227,7 @@ typedef struct { void* fn; void* env; } mfl_closure;
    own goroutine and frees everything it allocated on return. Subsystems that
    free explicitly (channels, maps, goroutine args) use raw malloc/free. */
 typedef struct mfl_blk { struct mfl_blk* next; size_t size; } mfl_blk;
-typedef struct { mfl_blk* head; } mfl_arena;
+typedef struct { mfl_blk* head; size_t bytes; } mfl_arena;
 static mfl_arena mfl_main_arena = { NULL };
 static _Thread_local mfl_arena* mfl_arena_cur = NULL;
 static void* mfl_alloc(size_t sz) {
@@ -235,6 +235,7 @@ static void* mfl_alloc(size_t sz) {
     if (sz == 0) sz = 1;
     mfl_blk* b = malloc(sizeof(mfl_blk) + sz);
     b->size = sz; b->next = mfl_arena_cur->head; mfl_arena_cur->head = b;
+    mfl_arena_cur->bytes += sz;
     return (void*)(b + 1);
 }
 /* mfl_calloc is only ever used to box a local captured by a nested closure
@@ -286,7 +287,28 @@ static void mfl_arena_free(mfl_arena* a) {
     mfl_blk* b = a->head;
     while (b) { mfl_blk* n = b->next; free(b); b = n; }
     a->head = NULL;
+    a->bytes = 0;
     mfl_strlen_cache_s = NULL; /* freed addresses may be reused — drop stale length */
+}
+
+/* Exit path for an arena { } block. free() alone hands the pages to the C heap's
+   free-list, not to the OS, and glibc's mmap threshold adapts upward once large
+   blocks have been freed — so a server doing heavy scoped work per request sees
+   RSS climb monotonically even though every block is correctly reclaimed
+   (measured: ~23 MB per request retained across a bulk-ingest loop, with the
+   arena working exactly as designed). When a block freed a lot, ask the
+   allocator to return the pages; the syscall is worth it at this size and is
+   skipped entirely for the small blocks that dominate hot loops. Same trim
+   arena_reset() has always done, now available to the checked, scoped form. */
+#ifndef MFL_ARENA_TRIM_BYTES
+#define MFL_ARENA_TRIM_BYTES (8u * 1024u * 1024u)
+#endif
+static void mfl_arena_free_scoped(mfl_arena* a) {
+    size_t had = a->bytes;
+    mfl_arena_free(a);
+#ifdef __GLIBC__
+    if (had >= MFL_ARENA_TRIM_BYTES) malloc_trim(0);
+#endif
 }
 /* arena_reset(): free the CURRENT goroutine's arena chain in place, WITHOUT
    ending the goroutine (same reclamation as mfl_arena_free, but on the live
@@ -4510,7 +4532,7 @@ func (g *cgen) stmt(s Stmt, depth int) error {
 		}
 		g.arenaStack = g.arenaStack[:len(g.arenaStack)-1]
 		indentC(&g.buf, depth)
-		fmt.Fprintf(&g.buf, "mfl_arena_cur = _sp%d; mfl_arena_free(&_sa%d); }\n", id, id)
+		fmt.Fprintf(&g.buf, "mfl_arena_cur = _sp%d; mfl_arena_free_scoped(&_sa%d); }\n", id, id)
 	case *GoStmt:
 		return g.goStmt(st)
 	default:

--- a/framework/machweb.src
+++ b/framework/machweb.src
@@ -429,10 +429,20 @@ func read_request(conn) (raw) {
     if sep >= 0 {
         clen := content_length(substr(raw, 0, sep))
         body_start := sep + 4
-        for len(raw) - body_start < clen {
-            chunk := read(conn)
-            if chunk == "" { break }            // connection closed early
-            raw = raw + chunk
+        have := len(raw) - body_start
+        if have < clen {
+            // Collect the chunks and join ONCE. `raw = raw + chunk` in this loop
+            // is quadratic: a 1.5 MB body arriving in 64 kB reads allocates ~24
+            // ever-larger copies (~18 MB), and in a long-lived server that all
+            // stays on the goroutine's arena. join() allocates the result once.
+            parts := []string{raw}
+            while have < clen {
+                chunk := read(conn)
+                if chunk == "" { break }        // connection closed early
+                parts = append(parts, chunk)
+                have = have + len(chunk)
+            }
+            raw = join(parts, "")
         }
     }
 }
@@ -449,10 +459,33 @@ func read_request_bytes(conn) (raw) {
         // (no buffering, no OOM) rather than draining megabytes off the socket.
         if machweb_max_body == 0 || clen <= machweb_max_body {
             body_start := sep + 4
-            for len(raw) - body_start < clen {
-                chunk := read_bytes(conn)
-                if len(chunk) == 0 { break }    // connection closed early (or read timeout)
-                raw = bytes_concat(raw, chunk)
+            // Same quadratic trap as read_request, in bytes: merge the chunks
+            // pairwise (each pass halves the count) so the total copying is
+            // O(n log n) instead of O(n^2). bytes has no join().
+            have := len(raw) - body_start
+            if have < clen {
+                parts := []bytes{}
+                parts = append(parts, raw)
+                while have < clen {
+                    chunk := read_bytes(conn)
+                    if len(chunk) == 0 { break } // connection closed early (or read timeout)
+                    parts = append(parts, chunk)
+                    have = have + len(chunk)
+                }
+                while len(parts) > 1 {
+                    merged := []bytes{}
+                    i := 0
+                    while i < len(parts) {
+                        if i + 1 < len(parts) {
+                            merged = append(merged, bytes_concat(parts[i], parts[i+1]))
+                        } else {
+                            merged = append(merged, parts[i])
+                        }
+                        i = i + 2
+                    }
+                    parts = merged
+                }
+                raw = parts[0]
             }
         }
     }


### PR DESCRIPTION
Two fixes for long-lived machin servers, both found by profiling a bulk-ingest loop in [grange](https://github.com/javimosch/grange) whose RSS climbed ~23 MB per request **even though every arena block was reclaiming correctly**.

### 1. Scoped arenas now trim

`free()` hands pages to the C heap's free-list, and glibc raises its mmap threshold once large blocks have been freed — so a process doing heavy scoped work per request grows monotonically. An `arena { }` block that freed ≥8 MB now asks the allocator to return the pages: the same `malloc_trim` that `arena_reset()` has always done, now available to the **checked** scoped form, and skipped for the small blocks that dominate hot loops.

Measured: six iterations building a 120k-element slice go from climbing to flat (RSS 1 MB).

Honest limit, already documented on `arena_reset`: trim can only release the free **top** of the heap, so live data allocated above freed pages caps what comes back. In the grange case that is exactly what happens — the win there is smaller than the microbenchmark suggests, and the report says so.

### 2. machweb body reads were quadratic

`read_request` and `read_request_bytes` both accumulated with `raw = raw + chunk` in a loop, so a 1.5 MB upload arriving in 64 kB reads allocated ~24 ever-larger copies. `read_request` now collects chunks and `join()`s once; the bytes variant merges pairwise (O(n log n) — bytes has no `join`). This affects every machin web app that accepts large bodies.

### Tests

New reclamation-ratio test for the trim; the existing machweb I/O tests caught a non-empty `[]bytes` literal in my first draft of the bytes path. Full suite green (`-short -skip TestCmdBuildWasm`; the wasm build tests hang on this box with or without the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of large HTTP request bodies, reducing processing time and memory overhead.
  * Scoped temporary allocations can now return unused memory to the operating system more effectively.
* **Bug Fixes**
  * Improved memory behavior after large temporary workloads, helping reduce ongoing process memory usage.
  * Preserved request-body handling when data arrives across multiple reads or connections close early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->