### PR TITLE
feat(io): fsync builtin — the missing half of durability

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -1877,6 +1877,29 @@ static int64_t mfl_read_file_raw(const char* path, int64_t ptr, int64_t nbytes) 
 }
 /* delete a file (0 on success, -1 on error) — e.g. removing a stored upload. */
 static int64_t mfl_remove_file(const char* path) { return remove(path) == 0 ? 0 : -1; }
+/* fsync a path — the missing half of durability. write_file returns when the
+   data is in the page cache, so a power loss can still lose it; fsync returns
+   only once the storage device has it.
+
+   Works on a DIRECTORY too, which is not a detail: creating or renaming a file
+   is a directory modification, so a fully-synced file can still vanish after a
+   crash if its directory entry never reached the disk. The durable-write recipe
+   is therefore write -> fsync(file) -> fsync(dirname). A directory must be
+   opened read-only (O_RDONLY); opening it for write fails with EISDIR.
+
+   Returns 0 on success, -1 on error. EINVAL is reported as success: some
+   filesystems reject fsync on a directory fd, and there the directory entry is
+   not the thing at risk. */
+static int64_t mfl_fsync(const char* path) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) return -1;
+    int r = fsync(fd);
+    int e = errno;
+    close(fd);
+    if (r == 0) return 0;
+    if (e == EINVAL) return 0;
+    return -1;
+}
 /* read a file's raw bytes (NUL-safe, unlike read_file which returns a C string).
    Empty bytes if the file can't be opened. */
 static mfl_bytes mfl_read_file_bytes(const char* path) {
@@ -6291,6 +6314,8 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_system(%s)", args[0]), nil
 	case "mkdir":
 		return fmt.Sprintf("mfl_mkdir(%s)", args[0]), nil
+	case "fsync":
+		return fmt.Sprintf("mfl_fsync(%s)", args[0]), nil
 	case "https_get":
 		g.usesTLS = true
 		return fmt.Sprintf("mfl_https_get(%s)", args[0]), nil

--- a/fsync_test.go
+++ b/fsync_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fsync is the missing half of durability: write_file returns once the data is
+// in the page cache, so a power loss can still lose a "written" file. These
+// tests cover the three cases a durable-write recipe depends on — a file, a
+// DIRECTORY (creating a file is a directory change; without syncing it a fully
+// synced file can still vanish), and a path that does not exist.
+func TestFsyncFileDirAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "d")
+	src := `func main() {
+    mkdir(` + `"` + sub + `"` + `)
+    write_file(` + `"` + filepath.Join(sub, "a.txt") + `"` + `, "durable")
+    println("file=" + str(fsync(` + `"` + filepath.Join(sub, "a.txt") + `"` + `)))
+    println("dir=" + str(fsync(` + `"` + sub + `"` + `)))
+    println("missing=" + str(fsync(` + `"` + filepath.Join(dir, "nope") + `"` + `)))
+}`
+	out := runNative(t, src)
+	for _, want := range []string{"file=0", "dir=0", "missing=-1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("fsync output = %q, want it to contain %q", out, want)
+		}
+	}
+}
+
+// The durable-write recipe must round-trip: the point of fsync is that the file
+// is still readable and correct afterwards, not merely that it returns 0.
+func TestFsyncPreservesContent(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "chunk.grg")
+	src := `func main() {
+    write_file(` + `"` + p + `"` + `, "record|1\nrecord|2")
+    fsync(` + `"` + p + `"` + `)
+    fsync(` + `"` + dir + `"` + `)
+    println(read_file(` + `"` + p + `"` + `))
+}`
+	if out := runNative(t, src); !strings.Contains(out, "record|1") || !strings.Contains(out, "record|2") {
+		t.Fatalf("content after fsync = %q, want both records", out)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil || string(b) != "record|1\nrecord|2" {
+		t.Fatalf("on-disk content = %q err=%v", b, err)
+	}
+}

--- a/guide.go
+++ b/guide.go
@@ -219,6 +219,7 @@ func machinGuide() guideCatalog {
 			{"remove", "(string) -> int", "delete a file (0 ok; -1 error)", "io"},
 			{"list_dir", "(string) -> []string", "directory entries (excludes . / ..)", "io"},
 			{"mkdir", "(string) -> int", "create a directory (0 ok; -1 error)", "io"},
+			{"fsync", "(string) -> int", "flush a file (or a DIRECTORY) to the storage device (0 ok; -1 error). write_file returns when the data is only in the page cache, so a power loss can still lose it. Durable write = write_file -> fsync(file) -> fsync(dir), because creating the file is a directory change that must be synced too", "io"},
 			// cli / process
 			{"args", "() -> []string", "command-line args (args()[0] is program path)", "cli"},
 			{"env", "(string) -> string", "environment variable (\"\" if unset)", "cli"},

--- a/types.go
+++ b/types.go
@@ -2440,6 +2440,12 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cString)
 		return newSliceSlot(c, c.cString), nil
+	case "fsync":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("fsync: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cInt, nil
 	case "mkdir":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("mkdir: 1 arg (path)")


### PR DESCRIPTION
MFL had no way to make a write durable. `write_file` returns once the data is in the page cache, so a program that wrote a file and reported success could still lose it to a power cut or a kernel panic.

This surfaced building [grange](https://github.com/javimosch/grange), whose crash harness only ever proved **process**-crash safety (`kill -9`) — which the page cache survives on its own. A database cannot claim crash safety without this.

## `fsync(path) -> int` (0 ok, -1 error)

It accepts a **directory** as well as a file, which is the part that is easy to miss: creating a file is a modification of its directory, so a fully-synced file can still vanish after a crash if the directory entry never reached the disk. The durable-write recipe is:

```
write_file(p, data)
fsync(p)        // content is durable
fsync(dir)      // the file's EXISTENCE is durable
```

A directory must be opened `O_RDONLY` (opening it for write fails with `EISDIR`), which is why this is a builtin rather than something a caller can express. `EINVAL` is reported as success: some filesystems reject fsync on a directory fd, and there the directory entry is not what is at risk.

## Verification

- New `fsync_test.go`: file, directory, missing path, and a content round-trip.
- Checked with `strace` that both calls reach the kernel as real `fsync(2)` on the right fds — a builtin that returned 0 without syncing would pass any behavioural test.
- `go test -short` suite green.

Consumer: grange now fsyncs each chunk and then its directory before acknowledging a commit, and asserts that ordering at the syscall level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `fsync` built-in for flushing file and directory changes to durable storage.
  * Supports syncing files and directories, returning success or failure status.
  * Added `fsync` to the built-in capability guide with usage and return-type details.
* **Tests**
  * Added coverage for syncing files, directories, missing paths, and preserving written content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->