### PR TITLE
release: v0.122.0 — fsync builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+## v0.122.0
+
+- **`fsync(path)` builtin — the missing half of durability** (PR #536). MFL had
+  no way to make a write durable: `write_file` returns once the data is in the
+  page cache, so a program that wrote a file and reported success could still
+  lose it to a power cut or a kernel panic. This surfaced building
+  [grange](https://github.com/javimosch/grange), whose crash harness only ever
+  proved PROCESS-crash safety (`kill -9`) — which the page cache survives on its
+  own, so the harness could not have caught the gap.
+
+  `fsync(path) -> int` (0 ok, -1 error) accepts a **directory** as well as a
+  file, which is the part that is easy to miss: creating a file is a
+  modification of its directory, so a fully-synced file can still vanish after a
+  crash if the directory entry never reached the disk. The durable-write recipe
+  is `write_file(p, data)` then `fsync(p)` (content durable) then `fsync(dir)`
+  (the file's existence durable). A directory must be opened `O_RDONLY`
+  (`O_WRONLY` fails with `EISDIR`), which is why this is a builtin rather than
+  something a caller can express. `EINVAL` is reported as success: some
+  filesystems reject fsync on a directory fd, and there the directory entry is
+  not what is at risk.
+
+  Verified with `strace` that both calls reach the kernel as real `fsync(2)` on
+  the right fds — a builtin that returned 0 without syncing would pass any
+  behavioural test.
+
 ## v0.121.0
 
 - **`parse()`: a JSON `null` no longer silently drops the rest of the object**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.121.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.122.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.121.0"
+const machinVersion = "0.122.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Cuts v0.122.0 for the `fsync` builtin merged in #536.

Version bump matters here beyond bookkeeping: [grange](https://github.com/javimosch/grange) now calls `fsync` on every commit, so it does not compile against v0.121.0.

- `machinVersion` → 0.122.0 (+ README badge, which `TestGuideVersionMatchesReadme` enforces)
- CHANGELOG entry covering the builtin, the directory-sync rationale, and the `EISDIR`/`EINVAL` handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)