### PR TITLE
feat(io): stat / is_dir / file_size / is_symlink — the metadata half of file I/O

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -1942,6 +1942,51 @@ static int64_t mfl_mkdir(const char* path) {
     if (r < 0 && errno == EEXIST) return 0;
     return r;
 }
+/* stat / is_dir / file_size / is_symlink — the metadata half of file I/O.
+
+   MFL could list a directory (list_dir) and read a file, but could not ask what
+   an entry IS. That made a recursive walk impossible to write safely: every
+   list_dir() entry may be a subdirectory, and read_file_bytes on a directory is
+   not a meaningful read. Any tool that walks a tree — a scanner, a bundler, a
+   size auditor — needs this before it needs anything else.
+
+   stat() answers all three questions in ONE syscall and follows symlinks, like
+   Go's os.Stat. kind: 0 missing, 1 regular file, 2 directory, 3 other (device,
+   socket, fifo). size is -1 when the path cannot be stat'd, so a caller that
+   ignores kind still sees failure. mtime is Unix seconds.
+
+   is_symlink() is the exception: it uses lstat, because a walker that follows
+   links needs to detect them to avoid an infinite cycle (a/link -> a). Without
+   it the other three are not enough to write a terminating walk. */
+typedef struct { int64_t kind; int64_t size; int64_t mtime; } mfl_stat_result;
+static mfl_stat_result mfl_stat(const char* path) {
+    mfl_stat_result R; R.kind = 0; R.size = -1; R.mtime = 0;
+    struct stat st;
+    if (stat(path, &st) != 0) return R;
+    if (S_ISDIR(st.st_mode)) R.kind = 2;
+    else if (S_ISREG(st.st_mode)) R.kind = 1;
+    else R.kind = 3;
+    R.size = (int64_t)st.st_size;
+    R.mtime = (int64_t)st.st_mtime;
+    return R;
+}
+/* is_dir reuses the existing mfl_is_dir helper defined above (the guard that
+   keeps read_file from fopen'ing a directory) — same semantics, one definition. */
+static int64_t mfl_file_size(const char* path) {
+    struct stat st;
+    if (stat(path, &st) != 0) return -1;
+    return (int64_t)st.st_size;
+}
+static int mfl_is_symlink(const char* path) {
+#if defined(_WIN32) || !defined(S_ISLNK)
+    /* Windows has no lstat/S_ISLNK; report "not a symlink" rather than fail so a
+       walk still terminates (it just cannot detect a junction). */
+    (void)path; return 0;
+#else
+    struct stat st;
+    return (lstat(path, &st) == 0 && S_ISLNK(st.st_mode)) ? 1 : 0;
+#endif
+}
 #ifndef __wasm__
 /* run a shell command, return its exit code (-1 if it could not be launched). For
    process orchestration — e.g. spawning a detached daemon with a trailing "&". */
@@ -4581,6 +4626,8 @@ func multiRetBuiltinC(name string) (cfn, ctype string, fields []string, needsTLS
 		return "mfl_exec", "mfl_exec_result", []string{"code", "out", "err"}, false, true
 	case "mmap_file":
 		return "mfl_mmap_file", "mfl_mmap_result", []string{"ptr", "len"}, false, true
+	case "stat":
+		return "mfl_stat", "mfl_stat_result", []string{"kind", "size", "mtime"}, false, true
 	case "rsa_generate":
 		return "mfl_crypto_rsa_generate", "mfl_crypto_rsa_keypair", []string{"priv", "pub"}, false, true
 	case "x509_pubkey":
@@ -6314,6 +6361,12 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_system(%s)", args[0]), nil
 	case "mkdir":
 		return fmt.Sprintf("mfl_mkdir(%s)", args[0]), nil
+	case "is_dir":
+		return fmt.Sprintf("mfl_is_dir(%s)", args[0]), nil
+	case "file_size":
+		return fmt.Sprintf("mfl_file_size(%s)", args[0]), nil
+	case "is_symlink":
+		return fmt.Sprintf("mfl_is_symlink(%s)", args[0]), nil
 	case "fsync":
 		return fmt.Sprintf("mfl_fsync(%s)", args[0]), nil
 	case "https_get":

--- a/guide.go
+++ b/guide.go
@@ -218,6 +218,10 @@ func machinGuide() guideCatalog {
 			{"read_file_raw", "(string, int, int) -> int", "read a file into a raw memory region (ptr, nbytes) in one fread; returns bytes read, -1 on open error", "io"},
 			{"remove", "(string) -> int", "delete a file (0 ok; -1 error)", "io"},
 			{"list_dir", "(string) -> []string", "directory entries (excludes . / ..)", "io"},
+			{"stat", "(string) -> (int, int, int)", "file metadata in ONE syscall -> (kind, size, mtime). MULTI-ASSIGN ONLY: kind, size, mtime := stat(path). kind: 0 missing, 1 file, 2 directory, 3 other; size -1 and mtime 0 when the path cannot be stat'd; mtime is Unix seconds. Follows symlinks (like Go's os.Stat). This is what makes a recursive walk writable: every list_dir() entry may be a subdirectory", "io"},
+			{"is_dir", "(string) -> bool", "true if the path is a directory (follows symlinks); false if missing", "io"},
+			{"file_size", "(string) -> int", "size in bytes, or -1 if the path cannot be stat'd — the cheap way to skip a huge file without reading it", "io"},
+			{"is_symlink", "(string) -> bool", "true if the path itself is a symlink (lstat — does NOT follow). The cycle guard for a recursive walk: a link back up the tree makes a following walk loop forever. Always false on Windows (no lstat)", "io"},
 			{"mkdir", "(string) -> int", "create a directory (0 ok; -1 error)", "io"},
 			{"fsync", "(string) -> int", "flush a file (or a DIRECTORY) to the storage device (0 ok; -1 error). write_file returns when the data is only in the page cache, so a power loss can still lose it. Durable write = write_file -> fsync(file) -> fsync(dir), because creating the file is a directory change that must be synced too", "io"},
 			// cli / process

--- a/stat_test.go
+++ b/stat_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stat/is_dir/file_size/is_symlink are the metadata half of file I/O. MFL could
+// list a directory and read a file, but could not ask what an entry IS -- which
+// made a recursive walk impossible to write safely, since every list_dir() entry
+// may be a subdirectory.
+func TestStatKindSizeAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	q := func(p string) string { return `"` + filepath.Join(dir, p) + `"` }
+	src := `func main() {
+    k := 0
+    sz := 0
+    mt := 0
+    k, sz, mt = stat(` + q("f.txt") + `)
+    println("file=" + str(k) + "," + str(sz) + "," + str(mt > 0))
+    k, sz, mt = stat(` + q("sub") + `)
+    println("dir=" + str(k))
+    k, sz, mt = stat(` + q("nope") + `)
+    println("missing=" + str(k) + "," + str(sz))
+}`
+	out := runNative(t, src)
+	for _, want := range []string{"file=1,6,true", "dir=2", "missing=0,-1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stat output = %q, want it to contain %q", out, want)
+		}
+	}
+}
+
+func TestIsDirAndFileSize(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	q := func(p string) string { return `"` + filepath.Join(dir, p) + `"` }
+	src := `func main() {
+    println("d_dir=" + str(is_dir(` + q("sub") + `)))
+    println("f_dir=" + str(is_dir(` + q("f.txt") + `)))
+    println("x_dir=" + str(is_dir(` + q("nope") + `)))
+    println("size=" + str(file_size(` + q("f.txt") + `)))
+    println("nosize=" + str(file_size(` + q("nope") + `)))
+}`
+	out := runNative(t, src)
+	for _, want := range []string{"d_dir=true", "f_dir=false", "x_dir=false", "size=6", "nosize=-1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("is_dir/file_size output = %q, want it to contain %q", out, want)
+		}
+	}
+}
+
+// The distinction that makes a walk terminate: a symlink TO a directory is
+// is_dir (stat follows) AND is_symlink (lstat does not). A walker that only had
+// is_dir would recurse into a link pointing back up the tree, forever.
+func TestIsSymlinkDistinguishesLinkToDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "sub"), filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	q := func(p string) string { return `"` + filepath.Join(dir, p) + `"` }
+	src := `func main() {
+    println("link_isdir=" + str(is_dir(` + q("link") + `)))
+    println("link_islink=" + str(is_symlink(` + q("link") + `)))
+    println("sub_islink=" + str(is_symlink(` + q("sub") + `)))
+}`
+	out := runNative(t, src)
+	for _, want := range []string{"link_isdir=true", "link_islink=true", "sub_islink=false"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("is_symlink output = %q, want it to contain %q", out, want)
+		}
+	}
+}
+
+// End-to-end: the motivating program. A recursive walk over a tree containing a
+// symlink cycle must terminate and report the same totals as the real files.
+func TestRecursiveWalkTerminatesOverSymlinkCycle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "b.txt"), []byte("678"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// a link pointing back at the root: a following walk never terminates
+	if err := os.Symlink(dir, filepath.Join(dir, "sub", "cycle")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	walkFn := `func walk(d) (n, b) {
+    entries := list_dir(d)
+    i := 0
+    for i < len(entries) {
+        p := d + "/" + entries[i]
+        if !is_symlink(p) {
+            if is_dir(p) {
+                sn := 0
+                sb := 0
+                sn, sb = walk(p)
+                n = n + sn
+                b = b + sb
+            } else {
+                n = n + 1
+                b = b + file_size(p)
+            }
+        }
+        i = i + 1
+    }
+}`
+	mainFn := `func main() {
+    f := 0
+    t := 0
+    f, t = walk("` + dir + `")
+    println("files=" + str(f) + " bytes=" + str(t))
+}`
+	out := runNative(t, walkFn, mainFn)
+	if !strings.Contains(out, "files=2 bytes=8") {
+		t.Fatalf("walk output = %q, want it to contain %q", out, "files=2 bytes=8")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1588,6 +1588,8 @@ func (c *Checker) multiRetBuiltin(name string) (args []int, rets []int, ok bool)
 		return []int{c.cString}, []int{c.cInt, c.cString, c.cString}, true
 	case "mmap_file":
 		return []int{c.cString}, []int{c.cInt, c.cInt}, true
+	case "stat":
+		return []int{c.cString}, []int{c.cInt, c.cInt, c.cInt}, true
 	case "rsa_generate":
 		return []int{c.cInt}, []int{c.cBytes, c.cBytes}, true
 	case "x509_pubkey":
@@ -2452,6 +2454,24 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		}
 		c.addPair(argSlots[0], c.cString)
 		return c.cInt, nil
+	case "is_dir":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("is_dir: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cBool, nil
+	case "file_size":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("file_size: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cInt, nil
+	case "is_symlink":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("is_symlink: 1 arg (path)")
+		}
+		c.addPair(argSlots[0], c.cString)
+		return c.cBool, nil
 	case "system":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("system: 1 arg (command string)")
@@ -2582,6 +2602,8 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		return 0, fmt.Errorf("exec returns 3 values; use: code, out, err := exec(cmd)")
 	case "mmap_file":
 		return 0, fmt.Errorf("mmap_file returns 2 values; use: ptr, size := mmap_file(path)")
+	case "stat":
+		return 0, fmt.Errorf("stat returns 3 values; use: kind, size, mtime := stat(path)")
 	case "rsa_generate":
 		return 0, fmt.Errorf("rsa_generate returns 2 values; use: priv, pub := rsa_generate(bits)")
 	case "x509_pubkey":


### PR DESCRIPTION
MFL could list a directory and read a file, but could not ask what an entry **is**. That made a recursive tree walk impossible to write safely — every `list_dir()` entry may be a subdirectory, and there was no way to test for one.

The runtime already knew: `mfl_is_dir` exists as the guard stopping `read_file` from `fopen`'ing a directory, and its own comment calls that "a real, easy-to-hit path, not a contrived one". The language just never exposed it.

### Where it surfaced

Porting `token-optimizer-cli`'s repo scanner to MFL. It walks a tree, skips vendor directories, and skips files over 10 MB. **None of those three steps was expressible**, so the port stalled — the dogfood loop working as intended.

### API

```go
stat(path) -> (kind, size, mtime)   // MULTI-ASSIGN: kind, size, mtime := stat(p)
is_dir(path) -> bool
file_size(path) -> int              // -1 when the path cannot be stat'd
is_symlink(path) -> bool
```

`stat` answers all three questions in **one syscall** and follows symlinks, like Go's `os.Stat`. `kind` is `0` missing / `1` file / `2` directory / `3` other; `size` is `-1` on failure, so a caller that ignores `kind` still sees the error.

### Why `is_symlink` is not optional

It's the one that's easy to leave out and must not be. It uses `lstat`, because a symlink **to** a directory is `is_dir=true` (stat follows) — so a walker with only `is_dir` recurses into a link pointing back up the tree, forever. Without it the other three are **not sufficient to write a terminating walk**, which is the whole motivating use case.

Always `false` on Windows (no `lstat`): a walk there still terminates, it just cannot detect a junction.

`is_dir` reuses the existing `mfl_is_dir` helper rather than redefining it.

### Tests

`stat_test.go` covers kind/size/mtime, the missing path, the link-to-dir distinction, and end-to-end: a recursive walk over a tree containing a symlink cycle back to its own root, asserted to **terminate** and to total the same bytes as the real files.

Full suite passes (`go test ./...`, 162 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filesystem inspection built-ins for retrieving file kind, size, and modification time with `stat`.
  * Added `is_dir` to check whether a path identifies a directory.
  * Added `file_size` to retrieve file sizes, returning `-1` when unavailable.
  * Added `is_symlink` to detect symbolic links, with platform-aware behavior.
  * Directory checks follow symbolic links, while symlink detection remains distinct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->