### PR TITLE
release: v0.123.0 — stat/is_dir/file_size/is_symlink builtins (#541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+## v0.123.0
+
+- **`stat` / `is_dir` / `file_size` / `is_symlink` builtins — the metadata half
+  of file I/O** (PR #541). MFL could list a directory and read a file, but could
+  not ask what an entry **is**. That made a recursive tree walk impossible to
+  write safely: every `list_dir()` entry may be a subdirectory, and there was no
+  way to test for one. The runtime already knew — `mfl_is_dir` exists as the
+  guard that stops `read_file` from `fopen`'ing a directory, and its own comment
+  calls that "a real, easy-to-hit path, not a contrived one" — but the language
+  never exposed it.
+
+  It surfaced porting [token-optimizer-cli](https://github.com/javimosch/token-optimizer-cli)'s
+  repo scanner to MFL (now [mfltok](https://github.com/javimosch/mfltok) `scan`):
+  walk the tree, skip vendor directories, skip files over 10 MB. Not one of
+  those three steps was expressible.
+
+  ```go
+  kind, size, mtime := stat(path)   // MULTI-ASSIGN only
+  is_dir(path) -> bool
+  file_size(path) -> int            // -1 when the path cannot be stat'd
+  is_symlink(path) -> bool
+  ```
+
+  `stat` answers all three questions in **one syscall** and follows symlinks,
+  like Go's `os.Stat`. `kind` is `0` missing / `1` file / `2` directory / `3`
+  other; `size` is `-1` on failure, so a caller that ignores `kind` still sees
+  the error; `mtime` is Unix seconds.
+
+  `is_symlink` is the one that is easy to leave out and must not be: it uses
+  `lstat`, because a symlink **to** a directory is `is_dir=true` (stat follows)
+  and would make a walker recurse into a link pointing back up the tree,
+  forever. Without it the other three are **not sufficient to write a
+  terminating walk**, which is the entire motivating use case. Always `false` on
+  Windows, which has no `lstat` — a walk there still terminates, it just cannot
+  detect a junction.
+
+  `is_dir` reuses the existing `mfl_is_dir` helper rather than redefining it.
+  Tests cover kind/size/mtime, the missing path, the link-to-dir distinction,
+  and end-to-end: a recursive walk over a tree containing a symlink cycle back
+  to its own root, asserted to terminate and to total the same bytes as the real
+  files.
+
 ## v0.122.0
 
 - **`fsync(path)` builtin — the missing half of durability** (PR #536). MFL had

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.122.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.123.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.122.0"
+const machinVersion = "0.123.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Cuts v0.123.0 for the file-metadata builtins merged in #541.

- `guide.go`: `machinVersion` 0.122.0 → 0.123.0
- `README.md`: version badge
- `CHANGELOG.md`: v0.123.0 entry

No code change; the builtins themselves landed in #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)