### PR TITLE
[needs work] fix(#537): add zlib_compress and zlib_decompress builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ bin/machin guide  --text                 # print the full feature catalog for ag
 - **Web:** [`machweb`](framework/) HTTP framework (router, cookies, SSO, SSE streaming, file uploads, proxy hardening) + reactive wasm frontend
 - **CLI:** [`flags.src`](framework/flags.src) — a composable flag parser (short/long flags, bools, `=`/space values)
 - **Crypto:** SHA-256, HMAC, HKDF, Ed25519, X25519, AES-GCM/CBC — binary and text paths
+- **Binary/wire:** NUL-safe `bytes`, hex, base64, zlib compress/decompress — for blob storage and protocols
 - **C FFI:** `extern` blocks, by-value structs, opaque handles — real raylib 3D games
 
 Full surface and grammar: [`SPEC.md`](SPEC.md). Runnable programs: [`examples/`](examples/).

--- a/SPEC.md
+++ b/SPEC.md
@@ -317,6 +317,8 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 | `byte_at` | `(bytes, int) -> int` | byte value 0–255 at an index (`-1` if out of range) |
 | `bytes_sub` | `(bytes, int, int) -> bytes` | sub-range `[start, end)` |
 | `bytes_concat` | `(bytes, bytes) -> bytes` | concatenate two `bytes` values |
+| `zlib_compress` | `(bytes, int) -> bytes` | zlib-compress raw bytes; level `0`–`9` (`-1` = default) |
+| `zlib_decompress` | `(bytes) -> bytes` | zlib-decompress raw bytes |
 | `rand_bytes` | `(int) -> bytes` | `n` cryptographically-random bytes (CSPRNG) |
 | `sha256_bytes` | `(bytes) -> bytes` | SHA-256 of binary → 32-byte digest (binary-safe) |
 | `hmac_sha256_bytes` | `(bytes, bytes) -> bytes` | HMAC-SHA256(key, msg) → 32 bytes |

--- a/build.go
+++ b/build.go
@@ -102,6 +102,7 @@ func BuildBinaryStatic(prog *Program, outPath string, safe, static bool) error {
 	usesTLS := strings.Contains(csrc, "mfl_tls_dial")
 	usesCrypto := strings.Contains(csrc, "mfl_crypto_")
 	usesSodium := strings.Contains(csrc, "mfl_xeddsa_")
+	usesZlib := strings.Contains(csrc, "mfl_zlib_")
 	bundleSqlite := static && usesSqlite
 
 	// foreign linkage: extern cflags go before the source; -l libs after it
@@ -208,6 +209,9 @@ func BuildBinaryStatic(prog *Program, outPath string, safe, static bool) error {
 	// Requires libsodium-dev (provides libsodium.so) on the build host.
 	if usesSodium {
 		libs = append(libs, "-lsodium", "-lcrypto")
+	}
+	if usesZlib {
+		libs = append(libs, "-lz")
 	}
 	args = append(args, "-o", outPath, tmp.Name())
 	args = append(args, srcs...)

--- a/codegen.go
+++ b/codegen.go
@@ -60,6 +60,7 @@ func windowsUnsupported(g *cgen) error {
 		{g.usesXEdDSA, "XEdDSA (xeddsa_* — needs libsodium for Windows, not yet wired)"},
 		{g.usesSQLite, "SQLite (sqlite_*)"},
 		{g.usesRegex, "regex (regex_*)"},
+		{g.usesZlib, "zlib (zlib_*)"},
 	} {
 		if u.used {
 			return fmt.Errorf("the windows target does not yet support %s — see issue #517 (supported: the stdio/compute core, TCP sockets, and HTTPS/TLS+crypto via a user-supplied OpenSSL)", u.what)
@@ -119,6 +120,7 @@ type cgen struct {
 	usesSelect   bool            // program uses `select` (now record/replay-gated; kept for diagnostics)
 	usesXEdDSA   bool            // program calls xeddsa_* -> emit XEdDSA runtime + link -lsodium -lcrypto
 	usesMath     bool            // program calls math builtins (sin/cos/sqrt/...) -> emit math runtime + link -lm
+	usesZlib     bool            // program calls zlib_* -> emit zlib runtime + link -lz
 	usesNoise    bool            // program calls noise2/noise3 -> emit Perlin noise runtime + link -lm
 	usesNet      bool            // program calls dial/listen/accept/read/write/close(fd) -> emit POSIX socket runtime
 	usesTTY      bool            // program calls raw_mode/read_key -> emit termios/select runtime
@@ -3879,6 +3881,59 @@ static int mfl_xeddsa_verify(mfl_bytes pub, mfl_bytes msg, mfl_bytes sig) {
 }
 `
 
+// zlibRuntime implements raw zlib compress/decompress over the bytes type.
+// Emitted and linked -lz only when a program calls zlib_*. Level follows zlib
+// semantics (0-9, -1 default); both functions return empty bytes on failure.
+const zlibRuntime = `#include <zlib.h>
+
+static mfl_bytes mfl_zlib_compress(mfl_bytes src, int64_t level) {
+    mfl_bytes r; r.len = 0; r.data = NULL;
+    if (src.len < 0) return r;
+    uLong bound = compressBound((uLong)src.len);
+    r.data = (uint8_t*)mfl_alloc(bound ? bound : 1);
+    uLongf outLen = (uLongf)bound;
+    int lvl = (int)level;
+    if (lvl < -1) lvl = -1;
+    if (lvl > 9) lvl = 9;
+    int ret = compress2(r.data, &outLen, src.data, (uLong)src.len, lvl);
+    if (ret != Z_OK) { r.len = 0; return r; }
+    r.len = (int64_t)outLen;
+    return r;
+}
+
+static mfl_bytes mfl_zlib_decompress(mfl_bytes src) {
+    mfl_bytes r; r.len = 0; r.data = NULL;
+    if (src.len < 0) return r;
+    z_stream s; memset(&s, 0, sizeof(s));
+    s.next_in = (Bytef*)src.data;
+    s.avail_in = (uInt)src.len;
+    if (inflateInit(&s) != Z_OK) return r;
+    size_t cap = (size_t)src.len * 2;
+    if (cap < 256) cap = 256;
+    uint8_t* out = (uint8_t*)mfl_alloc(cap);
+    s.next_out = (Bytef*)out;
+    s.avail_out = (uInt)cap;
+    int ret;
+    while ((ret = inflate(&s, Z_NO_FLUSH)) == Z_OK) {
+        if (s.avail_out == 0) {
+            size_t done = (size_t)s.total_out;
+            cap *= 2;
+            out = (uint8_t*)mfl_realloc(out, cap);
+            s.next_out = (Bytef*)(out + done);
+            s.avail_out = (uInt)(cap - done);
+        }
+    }
+    if (ret != Z_STREAM_END) {
+        inflateEnd(&s);
+        return r;
+    }
+    r.data = out;
+    r.len = (int64_t)s.total_out;
+    inflateEnd(&s);
+    return r;
+}
+`
+
 // isFFIScalar reports whether t is an FFI scalar type name (vs a cstruct name).
 func isFFIScalar(t string) bool {
 	switch t {
@@ -4121,6 +4176,10 @@ func (g *cgen) program(p *Program) (string, error) {
 		}
 		if g.usesXEdDSA {
 			out.WriteString(xeddsaRuntime)
+			out.WriteByte('\n')
+		}
+		if g.usesZlib {
+			out.WriteString(zlibRuntime)
 			out.WriteByte('\n')
 		}
 	}
@@ -6015,6 +6074,12 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_bytes_index(%s, %s, %s)", args[0], args[1], args[2]), nil
 	case "bytes_concat":
 		return fmt.Sprintf("mfl_bytes_concat(%s, %s)", args[0], args[1]), nil
+	case "zlib_compress":
+		g.usesZlib = true
+		return fmt.Sprintf("mfl_zlib_compress(%s, %s)", args[0], args[1]), nil
+	case "zlib_decompress":
+		g.usesZlib = true
+		return fmt.Sprintf("mfl_zlib_decompress(%s)", args[0]), nil
 	case "rand_bytes":
 		g.usesCrypto = true
 		return fmt.Sprintf("mfl_crypto_rand(%s)", args[0]), nil

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -451,6 +451,8 @@ first := users[0]                                // value copy
 | `byte_at(b, i)`             | byte value 0–255 at index `i` (−1 if out of range) |
 | `bytes_sub(b, start, end)`  | sub-range `[start, end)` of a `bytes` value  |
 | `bytes_concat(a, b)`        | concatenate two `bytes` values               |
+| `zlib_compress(b, level)`   | zlib-compress raw `bytes`; `level` 0–9 (`-1` = default) |
+| `zlib_decompress(b)`        | zlib-decompress raw `bytes`                  |
 | `bytes_index(b, needle, from)` | find `needle` in `b` at/after index `from`, NUL-safe (`-1` if absent); for binary protocols / multipart boundaries |
 | `alloc(n)` / `free(p)`      | allocate/free `n` zeroed raw bytes on the heap → pointer (an `int`); for building C buffers/structs to pass over FFI |
 | `poke_f32(p, off, v)` / `peek_f32(p, off)` | write/read a 4-byte float at byte offset `off` from pointer `p` |

--- a/examples/complex/zlib.mfl
+++ b/examples/complex/zlib.mfl
@@ -1,0 +1,1 @@
+func main(){b:=from_hex("48656c6c6f2c207a6c696221")c:=zlib_compress(b,6)d:=zlib_decompress(c)println(str(len(b))+" "+str(len(c))+" "+str(len(d)))}

--- a/guide.go
+++ b/guide.go
@@ -320,6 +320,8 @@ func machinGuide() guideCatalog {
 			{"bytes_sub", "(bytes, int, int) -> bytes", "sub-range [start, end) of a bytes value", "bytes"},
 			{"bytes_index", "(bytes, bytes, int) -> int", "find a needle in bytes at/after an offset, NUL-safe (-1 if absent); for binary protocols / multipart boundaries", "bytes"},
 			{"bytes_concat", "(bytes, bytes) -> bytes", "concatenate two bytes values", "bytes"},
+			{"zlib_compress", "(bytes, int) -> bytes", "zlib-compress raw bytes; level 0-9 (-1 default/6). Returns empty bytes on failure", "bytes"},
+			{"zlib_decompress", "(bytes) -> bytes", "zlib-decompress raw bytes. Returns empty bytes on failure", "bytes"},
 			// crypto over bytes (OpenSSL libcrypto, linked only when used)
 			{"rand_bytes", "(int) -> bytes", "n cryptographically-random bytes (CSPRNG)", "crypto"},
 			{"sha256_bytes", "(bytes) -> bytes", "SHA-256 of binary -> 32-byte digest (binary-safe, unlike sha256)", "crypto"},

--- a/types.go
+++ b/types.go
@@ -1892,6 +1892,19 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cBytes)
 		c.addPair(argSlots[1], c.cBytes)
 		return c.cBytes, nil
+	case "zlib_compress":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("zlib_compress: 2 args (bytes, level)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cBytes, nil
+	case "zlib_decompress":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("zlib_decompress: 1 arg (bytes)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		return c.cBytes, nil
 	case "rand_bytes":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("rand_bytes: 1 arg (count)")

--- a/zlib_test.go
+++ b/zlib_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/hex"
+	"io"
+	"strings"
+	"testing"
+)
+
+// zlib_compress/zlib_decompress are the raw zlib codec the market-data collector
+// needs for its SQLite BLOBs. We verify both round-trip and interoperability
+// with Go's compress/zlib (which is the downstream consumer's format).
+func TestZlibRoundTripAndGoInterop(t *testing.T) {
+	original := bytes.Repeat([]byte("The quick brown fox jumps over the lazy dog. "), 20)
+	wantHex := hex.EncodeToString(original)
+
+	prog := progFromSrc(t, `
+func main() {
+	b := from_hex("`+wantHex+`")
+	c := zlib_compress(b, 6)
+	d := zlib_decompress(c)
+	println("comp=" + to_hex(c))
+	println("orig=" + to_hex(b))
+	println("decomp=" + to_hex(d))
+	println("lens=" + str(len(c)) + " " + str(len(d)))
+}`)
+
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	m := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if p := strings.Index(line, "="); p >= 0 {
+			m[line[:p]] = line[p+1:]
+		}
+	}
+
+	if m["orig"] != wantHex {
+		t.Fatalf("original mismatch: got %q, want %q", m["orig"], wantHex)
+	}
+	if m["decomp"] != wantHex {
+		t.Fatalf("decompress mismatch: got %q, want %q", m["decomp"], wantHex)
+	}
+
+	compRaw, err := hex.DecodeString(m["comp"])
+	if err != nil {
+		t.Fatalf("decode comp hex: %v", err)
+	}
+	if len(compRaw) >= len(original) {
+		t.Fatalf("compressed length %d should be smaller than original %d", len(compRaw), len(original))
+	}
+
+	// Go's compress/zlib must be able to decompress what MFL produced.
+	r, err := zlib.NewReader(bytes.NewReader(compRaw))
+	if err != nil {
+		t.Fatalf("zlib.NewReader on MFL output: %v", err)
+	}
+	goOut, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("zlib read: %v", err)
+	}
+	r.Close()
+	if !bytes.Equal(goOut, original) {
+		t.Fatalf("Go zlib decompression of MFL output differs: got %q, want %q", goOut, original)
+	}
+
+	// And MFL must decompress what Go produced.
+	var goCompressed bytes.Buffer
+	w, err := zlib.NewWriterLevel(&goCompressed, 6)
+	if err != nil {
+		t.Fatalf("zlib.NewWriterLevel: %v", err)
+	}
+	w.Write(original)
+	w.Close()
+
+	goCompHex := hex.EncodeToString(goCompressed.Bytes())
+	prog2 := progFromSrc(t, `
+func main() {
+	b := from_hex("`+goCompHex+`")
+	println(to_hex(zlib_decompress(b)))
+}`)
+	out2, err := RunCaptured(prog2)
+	if err != nil {
+		t.Fatalf("run MFL decompress of Go zlib: %v", err)
+	}
+	if got := strings.TrimSpace(out2); got != wantHex {
+		t.Fatalf("MFL decompress of Go zlib: got %q, want %q", got, wantHex)
+	}
+}
+
+// Empty input round-trips, and bad data yields empty bytes.
+func TestZlibEdgeCases(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+	empty := bytes("")
+	c := zlib_compress(empty, 6)
+	d := zlib_decompress(c)
+	bad := zlib_decompress(from_hex("deadbeef"))
+	println(str(len(c)) + " " + str(len(d)) + " " + str(len(bad)))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(out), " 0 0") {
+		t.Fatalf("expected some compressed length, 0 decompressed, 0 bad; got %q", out)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #537: "Add zlib compress/decompress builtins (blocks a WebSocket + SQLite collector port)")

ISSUE DESCRIPTION:
## Gap

There is no compression primitive in MFL. Checked against `machin guide`: **0 of 172 builtins** match `zlib|deflate|inflate|gzip|compress|zstd|lz4|brotli`. The `bytes_*` family is `bytes_concat`, `bytes_index`, `bytes_str`, `bytes_sub` — no codec.

## Why it blocks a real port

Evaluating MFL for a market-data collector (`javika-multi-scraper`, currently Go). Everything else the collector needs is already there and looks good:

- `wss_open` / `wss_send` / `wss_recv` / `wss_send_bin` / `wss_recv_bin` / `wss_close` — a complete WebSocket client with auto ping/pong
- goroutines + channels, with compile-time race detection (`RACE001/002/004`) that Go doesn't give
- native SQLite, `--static` for a `FROM scratch` binary
- `arena_reset()` + `malloc_trim(0)` for a long-running daemon that must keep RSS flat

The blocker is storage format. Orderbook snapshots are persisted as **zlib-compressed JSON blobs** (`compress/zlib`, level 6) in a SQLite BLOB column. That format is fixed by downstream consumers — an offloader, a distiller, a parquet featurestore builder and a backtest runner all read those blobs today. A port cannot change it without rewriting the whole chain.

Measured on live production data (500 blobs sampled): orderbook books average **36.9 levels** (min 5, max 63), and a compressed blob pair is ~437 B/row. Uncompressed JSON would be several times that, on ~17k rows/day/market — so "just store raw JSON" is not a viable workaround at this volume.

## Proposed

A minimal codec pair over `bytes`, matching the existing `bytes_*` style:

```
zlib_compress(data bytes, level int) -> bytes
zlib_decompress(data bytes) -> bytes
```

zlib specifically (not gzip) — that is the wire format already on disk. `level` matters: the existing data is written at level 6, and round-trip compatibility is the point.

If a wider surface is preferred, `gzip_*` and a raw `deflate_*` variant would cover most other uses (HTTP `Content-Encoding`, `.gz` log reading), but **zlib is the one that unblocks this**.

## Alternatives considered

- **C FFI to libz** — presumably possible, but a codec this common feels like it belongs in the stdlib rather than in every caller's FFI glue. Happy to be told otherwise if FFI is the intended path.
- **`exec()` to `gzip`** — a process spawn per blob, at ~17k blobs/day/market. Not viable.
- **Change the storage format** — breaks four downstream consumers and the existing historical archive.

## Not urgent

This is a "would unlock a future port", not a blocker on anything shipping. Filing it so the gap is recorded with a concrete use case attached. Happy to test a branch against the real blobs — I have production data to round-trip against, which would be a decent correctness check (compress in MFL, decompress in Go's `compress/zlib` and vice versa).


APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#537): <brief description>
5. The PR body MUST include 'Fixes #537' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-dkdq5h25ohof-abbfd77e`

> ⚠️ **Verification failed** — this PR is a draft. Last output:
```
TEST_SUMMARY passed=1 failed=0
TEST_SUMMARY passed=1 failed=0
0 root=0 kind=int
1 root=1 kind=func fsig=|0
err=0
0 root=0 kind=var
1 root=1 kind=num
2 root=2 kind=int
3 root=3 kind=float
4 root=4 kind=bool
5 root=5 kind=string
6 root=6 kind=void
7 root=7 kind=bytes
8 root=8 kind=slice elem=2
9 root=9 kind=chan elem=2
10 root=10 kind=struct sname=Bar
11 root=11 kind=map mkey=0 mval=1
12 root=12 kind=func fsig=0,1|2
err=1
0 root=0 kind=int
1 root=1 kind=string
err=1
err=0
--- FAIL: TestWindowsNetCompiles (0.24s)
    windows_target_test.go:120: BuildWindows (net): zig failed: exit status 1
        /tmp/mfl-3158433387.c:1741:13: error: call to undeclared function 'fsync'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
         1741 |     int r = fsync(fd);
              |             ^
        1 error generated.
--- FAIL: TestWindowsBuildsPE (0.24s)
    windows_target_test.go:202: BuildWindows: zig failed: exit status 1
        /tmp/mfl-2592047219.c:1741:13: error: call to undeclared function 'fsync'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
         1741 |     int r = fsync(fd);
              |             ^
        1 error generated.
--- FAIL: TestReadBytesLoopReassemblesLargePayload (319.67s)
    wire_test.go:105: run: signal: terminated
FAIL
FAIL	machin	446.949s
FAIL
[verify environment problem — the command can't run in the worktree; not auto-fixable]
```

**Diff:**
```
README.md                 |   1 +
 SPEC.md                   |   2 +
 build.go                  |   4 ++
 codegen.go                |  65 +++++++++++++++++++++++++++
 docs/LANGUAGE.md          |   2 +
 examples/complex/zlib.mfl |   1 +
 guide.go                  |   2 +
 types.go                  |  13 ++++++
 zlib_test.go              | 112 ++++++++++++++++++++++++++++++++++++++++++++++
 9 files changed, 202 insertions(+)
```
