### PR TITLE
fix(#537): add zlib_compress and zlib_decompress builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ bin/machin guide  --text                 # print the full feature catalog for ag
 - **Web:** [`machweb`](framework/) HTTP framework (router, cookies, SSO, SSE streaming, file uploads, proxy hardening) + reactive wasm frontend
 - **CLI:** [`flags.src`](framework/flags.src) — a composable flag parser (short/long flags, bools, `=`/space values)
 - **Crypto:** SHA-256, HMAC, HKDF, Ed25519, X25519, AES-GCM/CBC — binary and text paths
+- **Compression:** `zlib_compress` / `zlib_decompress` over raw `bytes`
 - **C FFI:** `extern` blocks, by-value structs, opaque handles — real raylib 3D games
 
 Full surface and grammar: [`SPEC.md`](SPEC.md). Runnable programs: [`examples/`](examples/).

--- a/SPEC.md
+++ b/SPEC.md
@@ -317,6 +317,8 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 | `byte_at` | `(bytes, int) -> int` | byte value 0–255 at an index (`-1` if out of range) |
 | `bytes_sub` | `(bytes, int, int) -> bytes` | sub-range `[start, end)` |
 | `bytes_concat` | `(bytes, bytes) -> bytes` | concatenate two `bytes` values |
+| `zlib_compress` | `(bytes, int) -> bytes` | zlib-compress raw bytes at the given level (`0`-`9`, `-1` for default `6`); links `-lz` only when used |
+| `zlib_decompress` | `(bytes) -> bytes` | zlib-decompress a raw zlib stream back to raw bytes; empty `bytes` on an invalid stream |
 | `rand_bytes` | `(int) -> bytes` | `n` cryptographically-random bytes (CSPRNG) |
 | `sha256_bytes` | `(bytes) -> bytes` | SHA-256 of binary → 32-byte digest (binary-safe) |
 | `hmac_sha256_bytes` | `(bytes, bytes) -> bytes` | HMAC-SHA256(key, msg) → 32 bytes |

--- a/build.go
+++ b/build.go
@@ -102,6 +102,7 @@ func BuildBinaryStatic(prog *Program, outPath string, safe, static bool) error {
 	usesTLS := strings.Contains(csrc, "mfl_tls_dial")
 	usesCrypto := strings.Contains(csrc, "mfl_crypto_")
 	usesSodium := strings.Contains(csrc, "mfl_xeddsa_")
+	usesZlib := strings.Contains(csrc, "mfl_zlib_")
 	bundleSqlite := static && usesSqlite
 
 	// foreign linkage: extern cflags go before the source; -l libs after it
@@ -208,6 +209,10 @@ func BuildBinaryStatic(prog *Program, outPath string, safe, static bool) error {
 	// Requires libsodium-dev (provides libsodium.so) on the build host.
 	if usesSodium {
 		libs = append(libs, "-lsodium", "-lcrypto")
+	}
+	// zlib compression (zlib_compress/zlib_decompress) links libz — only when used.
+	if usesZlib {
+		libs = append(libs, "-lz")
 	}
 	args = append(args, "-o", outPath, tmp.Name())
 	args = append(args, srcs...)

--- a/codegen.go
+++ b/codegen.go
@@ -60,6 +60,7 @@ func windowsUnsupported(g *cgen) error {
 		{g.usesXEdDSA, "XEdDSA (xeddsa_* — needs libsodium for Windows, not yet wired)"},
 		{g.usesSQLite, "SQLite (sqlite_*)"},
 		{g.usesRegex, "regex (regex_*)"},
+		{g.usesZlib, "zlib (zlib_compress/zlib_decompress — needs a mingw libz, not yet wired)"},
 	} {
 		if u.used {
 			return fmt.Errorf("the windows target does not yet support %s — see issue #517 (supported: the stdio/compute core, TCP sockets, and HTTPS/TLS+crypto via a user-supplied OpenSSL)", u.what)
@@ -122,6 +123,7 @@ type cgen struct {
 	usesNoise    bool            // program calls noise2/noise3 -> emit Perlin noise runtime + link -lm
 	usesNet      bool            // program calls dial/listen/accept/read/write/close(fd) -> emit POSIX socket runtime
 	usesTTY      bool            // program calls raw_mode/read_key -> emit termios/select runtime
+	usesZlib     bool            // program calls zlib_* -> emit zlib runtime + link -lz
 	target       string          // "" or "native" (default) -> cc; "wasm" -> zig cc, lean runtime, FFI as imports, exports
 	globals      map[string]bool // package-global names (emitted as C statics, mfl_g_<name>)
 	bodyOnly     bool            // oracle mode: emit only the program-specific C (skip the static runtime blocks)
@@ -2356,6 +2358,74 @@ static char* mfl_read_key(void) {
 }
 `
 
+// zlibRuntime provides zlib compression/decompression over the bytes type.
+// Emitted (and linked, -lz) only when a program calls zlib_compress/zlib_decompress.
+const zlibRuntime = `#include <zlib.h>
+
+/* zlib-compress data at the given level (0-9, -1 for default). Returns the
+   raw zlib stream bytes, or empty bytes if deflate fails. */
+static mfl_bytes mfl_zlib_compress(mfl_bytes in, int64_t level) {
+    mfl_bytes out; out.len = 0; out.data = (uint8_t*)mfl_alloc(1);
+    if (level < -1) level = -1;
+    if (level > 9) level = 9;
+    uLong bound = compressBound((uLong)in.len);
+    if (bound > (uLong)INT64_MAX) return out;
+    uint8_t* buf = (uint8_t*)mfl_alloc(bound ? bound : 1);
+    z_stream z;
+    memset(&z, 0, sizeof(z));
+    z.next_in = in.data;
+    z.avail_in = (uInt)in.len;
+    z.next_out = buf;
+    z.avail_out = (uInt)bound;
+    if (deflateInit2(&z, (int)level, Z_DEFLATED, 15, 8, Z_DEFAULT_STRATEGY) != Z_OK) return out;
+    int rc = deflate(&z, Z_FINISH);
+    if (rc == Z_STREAM_END) {
+        out.len = (int64_t)z.total_out;
+        out.data = (uint8_t*)mfl_alloc(out.len ? out.len : 1);
+        if (out.len) memcpy(out.data, buf, (size_t)out.len);
+    }
+    deflateEnd(&z);
+    return out;
+}
+
+/* zlib-decompress a raw zlib stream. Returns the uncompressed bytes, or empty
+   bytes on any error (invalid data, wrong format, allocation failure). */
+static mfl_bytes mfl_zlib_decompress(mfl_bytes in) {
+    mfl_bytes out; out.len = 0; out.data = (uint8_t*)mfl_alloc(1);
+    if (in.len == 0) return out;
+    size_t cap = (size_t)in.len * 4;
+    if (cap < 256) cap = 256;
+    uint8_t* buf = (uint8_t*)malloc(cap);
+    if (!buf) return out;
+    z_stream z;
+    memset(&z, 0, sizeof(z));
+    z.next_in = in.data;
+    z.avail_in = (uInt)in.len;
+    z.next_out = buf;
+    z.avail_out = (uInt)cap;
+    if (inflateInit2(&z, 15) != Z_OK) { free(buf); return out; }
+    for (;;) {
+        int rc = inflate(&z, Z_NO_FLUSH);
+        if (rc == Z_STREAM_END) break;
+        if (rc != Z_OK) { free(buf); inflateEnd(&z); return out; }
+        size_t have = (size_t)z.total_out;
+        size_t need = cap * 2;
+        uint8_t* nb = (uint8_t*)realloc(buf, need);
+        if (!nb) { free(buf); inflateEnd(&z); return out; }
+        buf = nb; cap = need;
+        z.next_out = buf + have;
+        z.avail_out = (uInt)(cap - have);
+    }
+    size_t have = (size_t)z.total_out;
+    out.len = (int64_t)have;
+    out.data = (uint8_t*)mfl_alloc(out.len ? out.len : 1);
+    if (out.len) memcpy(out.data, buf, (size_t)out.len);
+    free(buf);
+    inflateEnd(&z);
+    return out;
+}
+`
+
 // tlsCoreRuntime holds the shared OpenSSL plumbing (a verified TLS dial) used by
 // both the HTTPS client and the WebSocket client. Emitted whenever a program
 // uses native TLS (https_* or wss_*); linked against -lssl -lcrypto. A single
@@ -4121,6 +4191,10 @@ func (g *cgen) program(p *Program) (string, error) {
 		}
 		if g.usesXEdDSA {
 			out.WriteString(xeddsaRuntime)
+			out.WriteByte('\n')
+		}
+		if g.usesZlib {
+			out.WriteString(zlibRuntime)
 			out.WriteByte('\n')
 		}
 	}
@@ -6015,6 +6089,12 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 		return fmt.Sprintf("mfl_bytes_index(%s, %s, %s)", args[0], args[1], args[2]), nil
 	case "bytes_concat":
 		return fmt.Sprintf("mfl_bytes_concat(%s, %s)", args[0], args[1]), nil
+	case "zlib_compress":
+		g.usesZlib = true
+		return fmt.Sprintf("mfl_zlib_compress(%s, %s)", args[0], args[1]), nil
+	case "zlib_decompress":
+		g.usesZlib = true
+		return fmt.Sprintf("mfl_zlib_decompress(%s)", args[0]), nil
 	case "rand_bytes":
 		g.usesCrypto = true
 		return fmt.Sprintf("mfl_crypto_rand(%s)", args[0]), nil

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -451,6 +451,8 @@ first := users[0]                                // value copy
 | `byte_at(b, i)`             | byte value 0–255 at index `i` (−1 if out of range) |
 | `bytes_sub(b, start, end)`  | sub-range `[start, end)` of a `bytes` value  |
 | `bytes_concat(a, b)`        | concatenate two `bytes` values               |
+| `zlib_compress(b, level)`   | zlib-compress raw `bytes` (`level` 0–9, −1 for default 6) → `bytes`; links `-lz` only when used |
+| `zlib_decompress(b)`        | zlib-decompress a raw zlib stream → `bytes`; empty on an invalid stream |
 | `bytes_index(b, needle, from)` | find `needle` in `b` at/after index `from`, NUL-safe (`-1` if absent); for binary protocols / multipart boundaries |
 | `alloc(n)` / `free(p)`      | allocate/free `n` zeroed raw bytes on the heap → pointer (an `int`); for building C buffers/structs to pass over FFI |
 | `poke_f32(p, off, v)` / `peek_f32(p, off)` | write/read a 4-byte float at byte offset `off` from pointer `p` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,7 @@ machin build examples/complex/primes.mfl --emit-c   # see the generated C
 | `grep`            | `regex_match`/`regex_find`/`regex_groups`/`regex_replace` |
 | `time`            | `time_make`/`time_format`/`time_fields` — build, format, and round-trip a timestamp |
 | `bytes`           | `bytes` type: construct, `to_hex`/`from_hex`, `byte_at`, `bytes_sub`, `bytes_concat`, `bytes_str`; NUL-safe vs string |
+| `zlib`            | `zlib_compress`/`zlib_decompress` over raw `bytes` — level 6 round-trip with a Go `compress/zlib` stream |
 | `sha256`          | `sha256(s)` → lowercase hex; `hmac_sha256(key, msg)` → lowercase hex; webhook signature verification |
 | `crypto`          | OpenSSL crypto suite: SHA-256, HMAC, AES-GCM round-trip (`ct\|\|tag` layout), Ed25519 sign/verify |
 | `base64`          | `base64_encode`/`base64_decode`: standard padded encode, lenient decode (standard + URL-safe alphabets, ignores padding) |

--- a/examples/complex/zlib.mfl
+++ b/examples/complex/zlib.mfl
@@ -1,0 +1,16 @@
+//zlib:zlib compress/decompress over raw bytes.
+
+func main(){
+//compress a JSON-shaped orderbook snapshot at level 6
+in:=bytes("{\"bids\":[[\"100.50\",\"1.2\"],[\"100.25\",\"0.8\"]],\"asks\":[[\"100.75\",\"0.5\"]]}")
+c:=zlib_compress(in,6)
+println("compressed len:",len(c))
+
+//decompress back to the original bytes
+out:=zlib_decompress(c)
+println("decompressed:",bytes_str(out))
+
+//decompress a Go-produced level-6 stream(hex of compressed "MFL/Go round-trip")
+goStream:=from_hex("789cf275f3d177cf5728ca2fcd4bd12d29ca2c00040000ffff316905f9")
+println("go round-trip:",bytes_str(zlib_decompress(goStream)))
+}

--- a/guide.go
+++ b/guide.go
@@ -320,6 +320,8 @@ func machinGuide() guideCatalog {
 			{"bytes_sub", "(bytes, int, int) -> bytes", "sub-range [start, end) of a bytes value", "bytes"},
 			{"bytes_index", "(bytes, bytes, int) -> int", "find a needle in bytes at/after an offset, NUL-safe (-1 if absent); for binary protocols / multipart boundaries", "bytes"},
 			{"bytes_concat", "(bytes, bytes) -> bytes", "concatenate two bytes values", "bytes"},
+			{"zlib_compress", "(bytes, int) -> bytes", "zlib-compress raw bytes at the given level (0-9, -1 for default 6); links libz only when used", "bytes"},
+			{"zlib_decompress", "(bytes) -> bytes", "zlib-decompress a raw zlib stream back to raw bytes; empty bytes on error", "bytes"},
 			// crypto over bytes (OpenSSL libcrypto, linked only when used)
 			{"rand_bytes", "(int) -> bytes", "n cryptographically-random bytes (CSPRNG)", "crypto"},
 			{"sha256_bytes", "(bytes) -> bytes", "SHA-256 of binary -> 32-byte digest (binary-safe, unlike sha256)", "crypto"},

--- a/types.go
+++ b/types.go
@@ -1892,6 +1892,19 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 		c.addPair(argSlots[0], c.cBytes)
 		c.addPair(argSlots[1], c.cBytes)
 		return c.cBytes, nil
+	case "zlib_compress":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("zlib_compress: 2 args (data bytes, level int)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		c.addPair(argSlots[1], c.cInt)
+		return c.cBytes, nil
+	case "zlib_decompress":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("zlib_decompress: 1 arg (data bytes)")
+		}
+		c.addPair(argSlots[0], c.cBytes)
+		return c.cBytes, nil
 	case "rand_bytes":
 		if len(argSlots) != 1 {
 			return 0, fmt.Errorf("rand_bytes: 1 arg (count)")

--- a/zlib_test.go
+++ b/zlib_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestZlibRoundTrip verifies that zlib_compress -> zlib_decompress is lossless
+// and works at the level the issue calls out (6).
+func TestZlibRoundTrip(t *testing.T) {
+	src := `func main(){
+		in := bytes("orderbook bids and asks")
+		c := zlib_compress(in, 6)
+		out := zlib_decompress(c)
+		println(bytes_str(out))
+	}`
+	if got := runNative(t, src); got != "orderbook bids and asks\n" {
+		t.Fatalf("round-trip: got %q", got)
+	}
+}
+
+// TestZlibEmpty verifies that the empty input round-trips cleanly. zlib_compress
+// of empty data produces a short, valid stream; zlib_decompress of it returns
+// an empty bytes value.
+func TestZlibEmpty(t *testing.T) {
+	src := `func main(){
+		c := zlib_compress(bytes(""), 6)
+		out := zlib_decompress(c)
+		println(len(c), len(out))
+	}`
+	got := runNative(t, src)
+	parts := strings.Fields(strings.TrimSpace(got))
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 fields, got %q", got)
+	}
+	if parts[0] == "0" || parts[1] != "0" {
+		t.Fatalf("empty compress produced 0-length or empty did not round-trip: got %q", got)
+	}
+}
+
+// TestZlibLevel0And9 verifies the level parameter is honored across the range.
+func TestZlibLevels(t *testing.T) {
+	for _, level := range []int{0, 1, 6, 9} {
+		src := fmt.Sprintf(`func main(){
+			in := bytes("level %d test payload")
+			c := zlib_compress(in, %d)
+			out := zlib_decompress(c)
+			println(bytes_str(out))
+		}`, level, level)
+		want := fmt.Sprintf("level %d test payload\n", level)
+		if got := runNative(t, src); got != want {
+			t.Fatalf("level %d: got %q, want %q", level, got, want)
+		}
+	}
+}
+
+// TestZlibCompressGoDecompress verifies MFL's zlib_compress output can be
+// decompressed by Go's compress/zlib (the exact cross-language round-trip the
+// issue needs for the collector's existing blobs).
+func TestZlibCompressGoDecompress(t *testing.T) {
+	src := `func main(){
+		in := bytes("MFL compress -> Go compress/zlib decompress")
+		c := zlib_compress(in, 6)
+		println(to_hex(c))
+	}`
+	got := strings.TrimSpace(runNative(t, src))
+	b, err := hex.DecodeString(got)
+	if err != nil {
+		t.Fatalf("hex decode %q: %v", got, err)
+	}
+	r, err := zlib.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("zlib reader: %v", err)
+	}
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(out) != "MFL compress -> Go compress/zlib decompress" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+// TestZlibDecompressGoCompress verifies MFL can decompress a stream produced by
+// Go's compress/zlib at level 6 (the collector's existing on-disk format).
+func TestZlibDecompressGoCompress(t *testing.T) {
+	input := []byte("Go compress/zlib compress -> MFL decompress")
+	var buf bytes.Buffer
+	w, err := zlib.NewWriterLevel(&buf, 6)
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	if _, err := w.Write(input); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	src := fmt.Sprintf(`func main(){
+		z := from_hex("%s")
+		out := zlib_decompress(z)
+		println(bytes_str(out))
+	}`, hex.EncodeToString(buf.Bytes()))
+	if got := runNative(t, src); got != string(input)+"\n" {
+		t.Fatalf("MFL decompress of Go stream: got %q", got)
+	}
+}
+
+// TestZlibInvalidInput verifies zlib_decompress returns empty bytes on an
+// invalid stream instead of crashing.
+func TestZlibInvalidInput(t *testing.T) {
+	src := `func main(){
+		out := zlib_decompress(bytes("not a zlib stream"))
+		println(len(out))
+	}`
+	if got := runNative(t, src); got != "0\n" {
+		t.Fatalf("invalid input: got %q", got)
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #537: "Add zlib compress/decompress builtins (blocks a WebSocket + SQLite collector port)")

ISSUE DESCRIPTION:
## Gap

There is no compression primitive in MFL. Checked against `machin guide`: **0 of 172 builtins** match `zlib|deflate|inflate|gzip|compress|zstd|lz4|brotli`. The `bytes_*` family is `bytes_concat`, `bytes_index`, `bytes_str`, `bytes_sub` — no codec.

## Why it blocks a real port

Evaluating MFL for a market-data collector (`javika-multi-scraper`, currently Go). Everything else the collector needs is already there and looks good:

- `wss_open` / `wss_send` / `wss_recv` / `wss_send_bin` / `wss_recv_bin` / `wss_close` — a complete WebSocket client with auto ping/pong
- goroutines + channels, with compile-time race detection (`RACE001/002/004`) that Go doesn't give
- native SQLite, `--static` for a `FROM scratch` binary
- `arena_reset()` + `malloc_trim(0)` for a long-running daemon that must keep RSS flat

The blocker is storage format. Orderbook snapshots are persisted as **zlib-compressed JSON blobs** (`compress/zlib`, level 6) in a SQLite BLOB column. That format is fixed by downstream consumers — an offloader, a distiller, a parquet featurestore builder and a backtest runner all read those blobs today. A port cannot change it without rewriting the whole chain.

Measured on live production data (500 blobs sampled): orderbook books average **36.9 levels** (min 5, max 63), and a compressed blob pair is ~437 B/row. Uncompressed JSON would be several times that, on ~17k rows/day/market — so "just store raw JSON" is not a viable workaround at this volume.

## Proposed

A minimal codec pair over `bytes`, matching the existing `bytes_*` style:

```
zlib_compress(data bytes, level int) -> bytes
zlib_decompress(data bytes) -> bytes
```

zlib specifically (not gzip) — that is the wire format already on disk. `level` matters: the existing data is written at level 6, and round-trip compatibility is the point.

If a wider surface is preferred, `gzip_*` and a raw `deflate_*` variant would cover most other uses (HTTP `Content-Encoding`, `.gz` log reading), but **zlib is the one that unblocks this**.

## Alternatives considered

- **C FFI to libz** — presumably possible, but a codec this common feels like it belongs in the stdlib rather than in every caller's FFI glue. Happy to be told otherwise if FFI is the intended path.
- **`exec()` to `gzip`** — a process spawn per blob, at ~17k blobs/day/market. Not viable.
- **Change the storage format** — breaks four downstream consumers and the existing historical archive.

## Not urgent

This is a "would unlock a future port", not a blocker on anything shipping. Filing it so the gap is recorded with a concrete use case attached. Happy to test a branch against the real blobs — I have production data to round-trip against, which would be a decent correctness check (compress in MFL, decompress in Go's `compress/zlib` and vice versa).


APPROACH: Refactored fix — implement the change described in the issue, but also lightly clean up the immediate surrounding code (rename for clarity, extract a small helper if it simplifies things). Keep scope tight.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#537): <brief description>
5. The PR body MUST include 'Fixes #537' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-7b5889-dkdsd3o7f77k-441c2689`

> ⚠️ **Verification failed** — this PR is a draft. Last output:
```
err=0
0 root=0 kind=var
1 root=1 kind=num
2 root=2 kind=int
3 root=3 kind=float
4 root=4 kind=bool
5 root=5 kind=string
6 root=6 kind=void
7 root=7 kind=bytes
8 root=8 kind=slice elem=2
9 root=9 kind=chan elem=2
10 root=10 kind=struct sname=Bar
11 root=11 kind=map mkey=0 mval=1
12 root=12 kind=func fsig=0,1|2
err=1
0 root=0 kind=int
1 root=1 kind=string
err=1
err=0
--- FAIL: TestWindowsNetCompiles (0.29s)
    windows_target_test.go:120: BuildWindows (net): zig failed: exit status 1
        /tmp/mfl-2264887383.c:1741:13: error: call to undeclared function 'fsync'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
         1741 |     int r = fsync(fd);
              |             ^
        1 error generated.
--- FAIL: TestWindowsBuildsPE (0.31s)
    windows_target_test.go:202: BuildWindows: zig failed: exit status 1
        /tmp/mfl-859721298.c:1741:13: error: call to undeclared function 'fsync'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
         1741 |     int r = fsync(fd);
              |             ^
        1 error generated.
SIGQUIT: quit
PC=0x477941 m=0 sigcode=0

*** Test killed with quit: ran too long (11m0s).
signal: killed
FAIL	machin	720.636s
FAIL

[verify timed out]
[verify environment problem — the command can't run in the worktree; not auto-fixable]
```

> ⚠️ **Overlaps open PR(s)** — this run adds files another open AM PR already creates, so the two will conflict on merge. Opened as a draft for review (supersede one, or split):
>   - `examples/complex/zlib.mfl` also in #543 ([needs work] fix(#537): add zlib_compress and zlib_decompress builtins)
>   - `zlib_test.go` also in #543 ([needs work] fix(#537): add zlib_compress and zlib_decompress builtins)


**Diff:**
```
README.md                 |   1 +
 SPEC.md                   |   2 +
 build.go                  |   5 ++
 codegen.go                |  80 +++++++++++++++++++++++++++++
 docs/LANGUAGE.md          |   2 +
 examples/README.md        |   1 +
 examples/complex/zlib.mfl |  16 ++++++
 guide.go                  |   2 +
 types.go                  |  13 +++++
 zlib_test.go              | 125 ++++++++++++++++++++++++++++++++++++++++++++++
 10 files changed, 247 insertions(+)
```
