### PR TITLE
fix(check): reject a param sharing its function's named-return name

### DIFF
--- a/param_return_name_collision_test.go
+++ b/param_return_name_collision_test.go
@@ -22,6 +22,20 @@ func TestParamNamedReturnCollisionString(t *testing.T) {
 	)
 }
 
+func TestDuplicateParamNames(t *testing.T) {
+	checkErr(t, `duplicate parameter "n"`,
+		`func foo(n, n) { println(n) }`,
+		`func main() { foo(1, 2) }`,
+	)
+}
+
+func TestDuplicateNamedReturns(t *testing.T) {
+	checkErr(t, `duplicate named return value "n"`,
+		`func foo() (n, n) { n = 1 }`,
+		`func main() { a, b := foo() println(a) println(b) }`,
+	)
+}
+
 func TestParamNamedReturnNoCollision(t *testing.T) {
 	got := runNative(t,
 		`func bump(n) (out) { out = n + 1 }`,

--- a/param_return_name_collision_test.go
+++ b/param_return_name_collision_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+// Issue #546: a parameter sharing a name with its own function's named return
+// used to alias the same env slot in the checker (types.go instantiate), which
+// downstream became two conflicting C declarations of the same identifier —
+// cc rejected it with a raw symbol-collision error instead of a clean MFL
+// diagnostic. Check now rejects this at the type-checking stage, for any type.
+
+func TestParamNamedReturnCollision(t *testing.T) {
+	checkErr(t, `parameter "n" has the same name as a named return value`,
+		`func bump(n) (n) { n = n + 1 }`,
+		`func main() { r := bump(5) println(r) }`,
+	)
+}
+
+func TestParamNamedReturnCollisionString(t *testing.T) {
+	checkErr(t, `parameter "s" has the same name as a named return value`,
+		`func shout(s) (s) { s = s + "!" }`,
+		`func main() { r := shout("hi") println(r) }`,
+	)
+}
+
+func TestParamNamedReturnNoCollision(t *testing.T) {
+	got := runNative(t,
+		`func bump(n) (out) { out = n + 1 }`,
+		`func main() { r := bump(5) println(r) }`,
+	)
+	if got != "6\n" {
+		t.Fatalf("distinct param/return names: got %q, want \"6\\n\"", got)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -659,17 +659,26 @@ func Check(p *Program) (*Checker, error) {
 		if _, dup := c.funcs[fn.Name]; dup {
 			return nil, fmt.Errorf("duplicate function %q", fn.Name)
 		}
-		// A parameter sharing a name with one of the function's own named
-		// returns would alias the same local slot in env (see instantiate),
-		// and downstream that collides as two C declarations of the same
-		// identifier — cc would reject it with an opaque symbol error
-		// instead of a clear MFL-level diagnostic.
-		for _, r := range fn.Returns {
-			for _, p := range fn.Params {
-				if p == r {
-					return nil, fmt.Errorf("function %q: parameter %q has the same name as a named return value", fn.Name, p)
-				}
+		// Two parameters, two named returns, or a parameter and a named
+		// return sharing a name all alias the same local slot in env (see
+		// instantiate), and downstream that collides as two C declarations
+		// of the same identifier — cc would reject it with an opaque
+		// symbol error instead of a clear MFL-level diagnostic.
+		seen := map[string]string{}
+		for _, p := range fn.Params {
+			if _, dup := seen[p]; dup {
+				return nil, fmt.Errorf("function %q: duplicate parameter %q", fn.Name, p)
 			}
+			seen[p] = "parameter"
+		}
+		for _, r := range fn.Returns {
+			switch seen[r] {
+			case "parameter":
+				return nil, fmt.Errorf("function %q: parameter %q has the same name as a named return value", fn.Name, r)
+			case "named return value":
+				return nil, fmt.Errorf("function %q: duplicate named return value %q", fn.Name, r)
+			}
+			seen[r] = "named return value"
 		}
 		c.funcs[fn.Name] = fn
 		if fn.Exported {

--- a/types.go
+++ b/types.go
@@ -659,6 +659,18 @@ func Check(p *Program) (*Checker, error) {
 		if _, dup := c.funcs[fn.Name]; dup {
 			return nil, fmt.Errorf("duplicate function %q", fn.Name)
 		}
+		// A parameter sharing a name with one of the function's own named
+		// returns would alias the same local slot in env (see instantiate),
+		// and downstream that collides as two C declarations of the same
+		// identifier — cc would reject it with an opaque symbol error
+		// instead of a clear MFL-level diagnostic.
+		for _, r := range fn.Returns {
+			for _, p := range fn.Params {
+				if p == r {
+					return nil, fmt.Errorf("function %q: parameter %q has the same name as a named return value", fn.Name, p)
+				}
+			}
+		}
 		c.funcs[fn.Name] = fn
 		if fn.Exported {
 			exported = append(exported, fn.Name)


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Go compiler for the MFL language; fix scoped correctness issues with tests

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These automaintainer pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #548 (am/am-84a3be-dkgg1xrnzdlz-a0321bd2): [needs work] fix(build): pass -fwrapv to all three cc invocations
    touches: build.go, fwrapv_test.go, guide.go
- PR #545 (am/docs-arena-reset-persistence-540): docs(arena_reset): document the persistence rule for globals across a reset
    touches: SPEC.md, guide.go
- PR #544 (am/am-7b5889-dkdsd3o7f77k-441c2689): [needs work] fix(#537): add zlib_compress and zlib_decompress builtins
    touches: README.md, SPEC.md, build.go, codegen.go, docs/LANGUAGE.md, examples/README.md, examples/complex/zlib.mfl, guide.go, types.go, zlib_test.go


**Branch:** `am/am-84a3be-dkggcoo67q00-4e543add`

> ⚠️ **Verification failed** — this PR is a draft. Last output:
```
  searching for a cheaper equivalent of x...
  no cheaper equivalent found within the search bounds  (explored 0 candidates, 0 distinct behaviors)
TEST_SUMMARY passed=1 failed=0
TEST_SUMMARY passed=1 failed=0
0 root=0 kind=int
1 root=1 kind=func fsig=|0
err=0
0 root=0 kind=var
1 root=1 kind=num
2 root=2 kind=int
3 root=3 kind=float
4 root=4 kind=bool
5 root=5 kind=string
6 root=6 kind=void
7 root=7 kind=bytes
8 root=8 kind=slice elem=2
9 root=9 kind=chan elem=2
10 root=10 kind=struct sname=Bar
11 root=11 kind=map mkey=0 mval=1
12 root=12 kind=func fsig=0,1|2
err=1
0 root=0 kind=int
1 root=1 kind=string
err=1
err=0
--- FAIL: TestWindowsNetCompiles (0.62s)
    windows_target_test.go:120: BuildWindows (net): zig failed: exit status 1
        /tmp/mfl-2607419151.c:1741:13: error: call to undeclared function 'fsync'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
         1741 |     int r = fsync(fd);
              |             ^
        1 error generated.
--- FAIL: TestWindowsBuildsPE (0.63s)
    windows_target_test.go:202: BuildWindows: zig failed: exit status 1
        /tmp/mfl-214984311.c:1741:13: error: call to undeclared function 'fsync'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
         1741 |     int r = fsync(fd);
              |             ^
        1 error generated.
FAIL
FAIL	machin	311.735s
FAIL
[verify environment problem — the command can't run in the worktree; not auto-fixable]
```

**Diff:**
```
param_return_name_collision_test.go | 47 +++++++++++++++++++++++++++++++++++++
 types.go                            | 21 +++++++++++++++++
 2 files changed, 68 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject duplicate parameter names.
  * Added validation to reject duplicate named return names.
  * Added validation to reject collisions between parameter and named return names.
  * Improved diagnostics for invalid function declarations.

* **Tests**
  * Added coverage for invalid name collisions and duplicate declarations.
  * Added coverage confirming valid distinct parameter and return names execute successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->