### PR TITLE
fix(#553): support non-empty []struct literals

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -5519,8 +5519,10 @@ func (g *cgen) sliceLit(ex *SliceLit) (string, error) {
 		builder, cast = "mfl_lit_str", "char*"
 	case KInt, KBool:
 		builder, cast = "mfl_lit_i64", "int64_t"
+	case KStruct:
+		return g.structSliceLit(ex)
 	default:
-		// struct / nested-slice elements: build empty + append in source instead
+		// nested-slice elements: build empty + append in source instead
 		return "", fmt.Errorf("non-empty []%s literals are not supported; build with append", ek)
 	}
 	return g.seqExprs(ex.Elems, func(names []string) (string, error) {
@@ -5530,6 +5532,32 @@ func (g *cgen) sliceLit(ex *SliceLit) (string, error) {
 		}
 		return builder + "(" + strings.Join(parts, ", ") + ")", nil
 	})
+}
+
+// structSliceLit builds a non-empty []T literal whose element T is a struct:
+// an arena-backed T array sized to the literal, filled one element per
+// assignment (the same shape the append-based workaround writes by hand),
+// wrapped in an mfl_slice.
+func (g *cgen) structSliceLit(ex *SliceLit) (string, error) {
+	ct := g.c.ElemCType(g.curFn, ex)
+	n := len(ex.Elems)
+	names := make([]string, n)
+	for i, el := range ex.Elems {
+		s, err := g.expr(el)
+		if err != nil {
+			return "", err
+		}
+		names[i] = s
+	}
+	id := g.tmpID
+	g.tmpID++
+	arr := fmt.Sprintf("_arrlit%d", id)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s* %s = (%s*)mfl_alloc(%d * sizeof(%s)); ", ct, arr, ct, n, ct)
+	for i, s := range names {
+		fmt.Fprintf(&b, "%s[%d] = %s; ", arr, i, s)
+	}
+	return fmt.Sprintf("({ %s(mfl_slice){%s, %d, %d}; })", b.String(), arr, n, n), nil
 }
 
 // stringZeroInits returns designated initializers that set every string reachable in

--- a/structlit_test.go
+++ b/structlit_test.go
@@ -54,3 +54,31 @@ func main() {
 		t.Fatalf("string ops on an absent-map-key value = %q", got)
 	}
 }
+
+// Non-empty []struct literals (#553): []P{P{1,2}, P{3,4}} must compile and read
+// back correctly, including a struct field that is itself a slice or a string,
+// and a nested struct literal inside an element.
+func TestNonEmptyStructSliceLit(t *testing.T) {
+	prog := progFromSrc(t, `
+type Inner struct { tag string }
+type P struct { a int  b int }
+type Row struct { name string  vals []int  inner Inner }
+func main() {
+    xs := []P{P{1,2}, P{3,4}}
+    println("len=" + str(len(xs)))
+    println("xs0=" + str(xs[0].a) + "," + str(xs[0].b))
+    println("xs1=" + str(xs[1].a) + "," + str(xs[1].b))
+
+    rows := []Row{Row{name: "r0", vals: []int{1,2}, inner: Inner{tag: "t0"}}}
+    println("rows0=" + rows[0].name + " " + str(len(rows[0].vals)) + " " + rows[0].inner.tag)
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := strings.Join(strings.Fields(out), " ")
+	want := "len=2 xs0=1,2 xs1=3,4 rows0=r0 2 t0"
+	if got != want {
+		t.Fatalf("non-empty []struct literal:\ngot:  %q\nwant: %q", got, want)
+	}
+}


### PR DESCRIPTION
Automated run for issue #553. The run pushed this commit but PR creation failed on a transient GitHub API error (`error_during_execution` after 30 turns; the same token opened #548/#558/#559 minutes earlier). Opened manually so the work isn't lost.

Closes #553 once reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for non-empty struct slice literals, including nested structs and fields containing slices or strings.
  - Generated slices can be compiled, accessed, and evaluated as expected.

- **Bug Fixes**
  - Resolved failures when using non-empty struct slices in supported literal expressions.

- **Tests**
  - Added regression coverage for compilation, element access, lengths, and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->