### PR TITLE
fix(#555): accept `_` as the sole assignment destination

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -394,6 +394,11 @@ A multi-value call may appear only as the sole right-hand side of a
 multi-assignment. `_` discards a value. A function returning ≥2 values compiles
 to a generated result struct.
 
+`_` is also accepted as the sole destination of a single-value assignment —
+`_ = f()` and `_ := f()` both discard the result, identically to `_` inside a
+multi-assign. `_` is write-only in every position: it is never allocated, never
+counts as a use, and reading it back (`x := _`) is a compile-time error.
+
 **Named returns.** A function may name its return values in the signature; they
 become zero-initialized locals, and a bare `return` (or falling off the end)
 yields their current values:

--- a/assign_undefined_test.go
+++ b/assign_undefined_test.go
@@ -84,3 +84,50 @@ func TestAssignFlatScopeReassignOK(t *testing.T) {
 		t.Fatalf("check: %v", err)
 	}
 }
+
+// TestAssignBlankSingleDestOK confirms `_` is accepted as the sole assignment
+// destination (not just inside a multi-assign): the value is discarded, never
+// allocated as a local, and the assignment is never treated as undefined.
+func TestAssignBlankSingleDestOK(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func f() (v) { v = 1 }`,
+		`func main() { _ = f() println("ok") }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+}
+
+// TestAssignBlankSingleDestWalrusOK confirms `_ := f()` behaves the same as
+// `_ = f()`: the blank identifier discards the value either way.
+func TestAssignBlankSingleDestWalrusOK(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func f() (v) { v = 1 }`,
+		`func main() { _ := f() println("ok") }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+}
+
+// TestAssignBlankUnreadableRejected confirms `_` remains write-only: reading
+// it back (`x := _`) must still be a compile-time error.
+func TestAssignBlankUnreadableRejected(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func f() (v) { v = 1 }`,
+		`func main() { _ = f() x := _ println(str(x)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil || !strings.Contains(err.Error(), `undefined variable "_"`) {
+		t.Fatalf("expected undefined-variable error for reading _, got %v", err)
+	}
+}

--- a/codegen.go
+++ b/codegen.go
@@ -4474,6 +4474,12 @@ func (g *cgen) stmt(s Stmt, depth int) error {
 		if err != nil {
 			return err
 		}
+		if st.Name == "_" {
+			// the blank identifier discards the value; still evaluate it for
+			// any side effect (e.g. a function call), but drop the result.
+			g.buf.WriteString("(void)(" + e + ");\n")
+			return nil
+		}
 		fmt.Fprintf(&g.buf, "%s = %s;\n", g.varRef(st.Name), e)
 		g.emitProbe(st.Name, g.c.NodeKind(g.curFn, st.Val), depth)
 	case *ReturnStmt:

--- a/transform.go
+++ b/transform.go
@@ -178,7 +178,7 @@ func collectDeclared(body []Stmt, set map[string]bool) {
 	for _, s := range body {
 		switch st := s.(type) {
 		case *AssignStmt:
-			if st.Op == ":=" {
+			if st.Op == ":=" && st.Name != "_" {
 				set[st.Name] = true
 			}
 		case *MultiAssign:

--- a/types.go
+++ b/types.go
@@ -1167,6 +1167,13 @@ func (c *Checker) genStmt(fn *FuncDecl, s Stmt) error {
 		if err != nil {
 			return err
 		}
+		if st.Name == "_" {
+			// the blank identifier discards the value: never readable, never
+			// allocated as a local, and it counts as neither a new binding nor
+			// a reference to an existing one.
+			c.addPair(newSlot(c, KVar), vs)
+			return nil
+		}
 		env := c.vars[fn.Name]
 		slot, ok := env[st.Name]
 		if !ok {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #555: "'_' is not assignable as a single destination (_ = f() errors) though it works in multi-assign")

ISSUE DESCRIPTION:
## Problem

`_` works as one destination inside a multi-assign, but not as the only destination.

```
func f() (v) { v = 1 }
func main() { _ = f()  println("ok") }
```

```
error: typecheck: assignment to undefined variable "_"
```

Meanwhile this is fine today:

```
s, _, _ = sim_spawn(s, e)
```

So `_` is already understood as "discard" in one position and not in another. The
inconsistency is the bug — you hit it the moment you want to call something for its side
effect and ignore its single return.

## Workaround

Bind a throwaway name, which then has to be *used* or it may itself warn:

```
unused := f()
```

## Suggested fix

Treat `_` as the blank identifier everywhere an assignment destination is accepted:
`_ = f()`, `_ := f()`, and inside multi-assign (already works). It is never readable, never
allocated, and never counts as a use.

## Acceptance criteria

1. `_ = f()` compiles and discards the value.
2. `_ := f()` behaves the same (or is rejected with a message pointing at `_ =`, if `:=`
   with only a blank is deliberately disallowed — either is fine, but pick one and say so).
3. Reading `_` remains an error (`x := _` must not compile).
4. `_` as a *function parameter* name and as a `range` variable behave consistently with
   whatever is decided; state the rule in the guide if it changes.
5. A test alongside the existing assignment tests.

## Out of scope

Unused-variable warnings generally.


APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#555): <brief description>
5. The PR body MUST include 'Fixes #555' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-84a3be-dkhcdy8wpoc0-f54cb599`

## Summary

Fixes #555: `_` is now accepted as the sole destination of an assignment, not just inside a multi-assign. `_ = f()` and `_ := f()` both discard the value (evaluating it for side effects but never allocating a local for it), matching the existing multi-assign behavior. Reading `_` back remains a compile-time error. Patched all three layers involved (typecheck in types.go, codegen.go, and transform.go's declared-locals collector) plus a SPEC.md note and 3 new tests in assign_undefined_test.go.

**Diff:**
```
SPEC.md                  |  5 +++++
 assign_undefined_test.go | 47 +++++++++++++++++++++++++++++++++++++++++++++++
 codegen.go               |  6 ++++++
 transform.go             |  2 +-
 types.go                 |  7 +++++++
 5 files changed, 66 insertions(+), 1 deletion(-)
```
