### PR TITLE
fix(#556): accept hex/binary/octal literals as 64-bit bit patterns

### DIFF
--- a/hex_bitpattern_test.go
+++ b/hex_bitpattern_test.go
@@ -1,0 +1,49 @@
+package main
+
+import "testing"
+
+// #556: a hex/binary/octal literal is a bit pattern, not a magnitude — the top
+// bit being set shouldn't be a parse error. If it fits in 64 bits unsigned,
+// interpret it as its two's-complement int value, matching the arithmetic
+// (0 - 7046029254386353131 already produces this exact value).
+func TestHexLiteralTopBitSetParses(t *testing.T) {
+	src := `func main() { x := 0x9E3779B97F4A7C15
+  println(str(x)) }`
+	if got, want := runNative(t, src), "-7046029254386353131\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBinaryLiteralTopBitSetParses(t *testing.T) {
+	// 64 ones == -1 in two's complement.
+	src := `func main() { x := 0b1111111111111111111111111111111111111111111111111111111111111111
+  println(str(x)) }`
+	if got, want := runNative(t, src), "-1\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestOctalLiteralTopBitSetParses(t *testing.T) {
+	// 0o1777777777777777777777 is the 64-bit all-ones bit pattern == -1.
+	src := `func main() { x := 0o1777777777777777777777
+  println(str(x)) }`
+	if got, want := runNative(t, src), "-1\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDecimalLiteralAboveInt64MaxStillErrors(t *testing.T) {
+	_, err := ParseFunc(`func main() { x := 99999999999999999999
+  println(str(x)) }`)
+	if err == nil {
+		t.Fatal("expected an error for a decimal literal above 2^63-1, got nil")
+	}
+}
+
+func TestHexLiteralAbove64BitsStillErrors(t *testing.T) {
+	_, err := ParseFunc(`func main() { x := 0xFFFFFFFFFFFFFFFFF
+  println(str(x)) }`)
+	if err == nil {
+		t.Fatal("expected an error for a hex literal above 2^64-1, got nil")
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -1078,7 +1079,17 @@ func (p *Parser) parsePrimary() (Expr, error) {
 		p.next()
 		n, err := strconv.ParseInt(t.Val, 0, 64) // base 0: decimal, 0x hex, 0b binary, 0o octal
 		if err != nil {
-			return nil, err
+			// A non-decimal literal (0x/0b/0o) is a bit pattern, not a magnitude: if it
+			// fits in 64 bits unsigned, reinterpret it as its two's-complement int value
+			// instead of erroring, matching how the arithmetic already treats overflow.
+			isDecimal := len(t.Val) < 2 || t.Val[0] != '0' || (t.Val[1] != 'x' && t.Val[1] != 'X' && t.Val[1] != 'b' && t.Val[1] != 'B' && t.Val[1] != 'o' && t.Val[1] != 'O')
+			if !isDecimal {
+				if u, uerr := strconv.ParseUint(t.Val, 0, 64); uerr == nil {
+					return &IntLit{Val: int64(u)}, nil
+				}
+				return nil, fmt.Errorf("literal %s exceeds 64-bit range (max 0xFFFFFFFFFFFFFFFF)", t.Val)
+			}
+			return nil, fmt.Errorf("decimal literal %s exceeds int range (max %d); for a bit pattern, write it in hex/binary/octal instead", t.Val, int64(math.MaxInt64))
 		}
 		return &IntLit{Val: n}, nil
 	case TFloat:


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #556: "hex literals with the top bit set fail to PARSE (0x9E3779B97F4A7C15)")

ISSUE DESCRIPTION:
## Problem

A 64-bit hex constant whose top bit is set fails to **parse**:

```
func main() { x := 0x9E3779B97F4A7C15  println(str(x)) }
```

```
error: parse: strconv.ParseInt: parsing "0x9E3779B97F4A7C15": value out of range
```

Those constants are not exotic — `0x9E3779B97F4A7C15` (the golden-ratio mixer),
`0xCBF29CE484222325` (the FNV-1a 64 offset basis), `0x2545F4914F6CDD1D`, most SplitMix64
and xxHash constants. They are *bit patterns*, not magnitudes; the sign is meaningless.

## Two things are wrong

1. **It is a parse error, not a value error.** The rest of the language is fine with the
   same bit pattern — `0 - 7046029254386353131` produces exactly that value — so this is
   purely about the literal's spelling.
2. **The message is the raw Go `strconv` error.** It leaks an implementation detail and
   does not say what to write instead.

## Suggested fix

Accept a hex/binary/octal literal that fits in **64 bits unsigned** and interpret it as its
two's-complement `int` value, which is what every language with fixed-width ints does for
mask constants (Go does this for typed constants; Rust, C and Zig all accept the pattern).
Decimal literals above `2^63-1` should keep erroring — there the sign genuinely is meant.

If accepting them is considered wrong, then at minimum the error must be actionable:

```
error: hex literal 0x9E3779B97F4A7C15 exceeds int64 range (max 0x7FFFFFFFFFFFFFFF).
       For a bit pattern, write the two's-complement value: 0 - 7046029254386353131
```

Note this is the same family as #547: MFL ints are two's-complement 64-bit and
(with `-fwrapv`) wrap on overflow, so the literal syntax refusing a bit pattern the
arithmetic accepts is an inconsistency.

## Acceptance criteria

1. `x := 0x9E3779B97F4A7C15` compiles and `x == 0 - 7046029254386353131`.
2. Same for binary (`0b1...`) and octal if those are supported.
3. A decimal literal above `2^63-1` still errors, with an actionable message.
4. A hex literal above **2^64-1** still errors, with an actionable message.
5. Lexer tests pinning all four cases.

## Out of scope

Unsigned integer types. This is about how an existing `int` is *spelled*.


APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#556): <brief description>
5. The PR body MUST include 'Fixes #556' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-84a3be-dkhcrqdvnpk7-bfec4aa1`

## Summary

Fixes #556: hex/binary/octal integer literals whose top bit is set (e.g. 0x9E3779B97F4A7C15, the golden-ratio mixer / FNV-1a / SplitMix64 style constants) previously failed to parse with a raw Go strconv error. parser.go now falls back to parsing these non-decimal literals as unsigned 64-bit and reinterprets them as their two's-complement int value when strconv.ParseInt overflows, matching the language's existing wrap-on-overflow arithmetic semantics. Decimal literals above 2^63-1, and any literal above 2^64-1, still error, now with an actionable message instead of the leaked implementation detail. Added hex_bitpattern_test.go pinning all four acceptance-criteria cases.

**Diff:**
```
hex_bitpattern_test.go | 49 +++++++++++++++++++++++++++++++++++++++++++++++++
 parser.go              | 13 ++++++++++++-
 2 files changed, 61 insertions(+), 1 deletion(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hexadecimal, binary, and octal integer literals with the top bit set.
  * These literals are now correctly interpreted as signed two’s-complement values.
  * Added clearer range validation for oversized decimal and non-decimal literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->