### PR TITLE
fix(#549): map fsync to _commit on the windows target

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -211,6 +211,13 @@ static struct tm* mfl_win_localtime_r(const time_t* t, struct tm* out) { struct 
 static struct tm* mfl_win_gmtime_r(const time_t* t, struct tm* out) { struct tm* p = gmtime(t); if (p) { *out = *p; return out; } return NULL; }
 #define localtime_r mfl_win_localtime_r
 #define gmtime_r mfl_win_gmtime_r
+/* fsync(2) is POSIX-only; mingw doesn't declare it and zig cc's C11 treats an
+   implicit declaration as a hard error (#549). _commit is the documented
+   MSVCRT/ucrt equivalent — flush a file descriptor's buffers to disk — and is
+   what mingw programs use in its place. */
+#include <io.h>
+static int mfl_win_fsync(int fd) { return _commit(fd); }
+#define fsync mfl_win_fsync
 #endif
 
 /* slices: a Go-style header over an unboxed backing array */


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #549: "windows target broken on main: emitted runtime calls undeclared 'fsync' (zig cc, C11)")

ISSUE DESCRIPTION:
## `main` cannot cross-compile to Windows

`TestWindowsNetCompiles` and `TestWindowsBuildsPE` both fail on `main` at `565c25c`:

```
$ go test -run 'TestWindowsNetCompiles|TestWindowsBuildsPE' ./...
windows_target_test.go:120: BuildWindows (net): zig failed: exit status 1
  /tmp/mfl-817508131.c:1741:13: error: call to undeclared function 'fsync';
  ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  1 error generated.
--- FAIL: TestWindowsNetCompiles (0.91s)
--- FAIL: TestWindowsBuildsPE (0.88s)
```

The emitted runtime calls `fsync(...)` unconditionally, but the Windows target has no
declaration for it — `fsync` is POSIX and mingw does not provide it. `zig cc` for
`x86_64-windows-gnu` compiles as C11, where an implicit declaration is a hard error.

## Origin

The `fsync` builtin landed in v0.122.0 (#536 / #538) without a Windows path. The Windows
target already carries this kind of guard elsewhere (`build.go`'s comment about winsock2
and winpthreads for #517), so the pattern to follow exists.

## Impact

`--target windows` is broken on `main` — not a flake. It also puts two permanent reds in
`go test ./...`, which means every AM run on this repo comes back `verify_failed` for a
reason unrelated to whatever it changed. That is how a real failure gets ignored.

## Suggested fix

In the runtime C preamble, guard the POSIX call and map it to the Win32 equivalent:

```c
#ifdef _WIN32
  #include <io.h>
  static int mfl_fsync(int fd) { return _commit(fd); }
#else
  static int mfl_fsync(int fd) { return fsync(fd); }
#endif
```

then emit `mfl_fsync(...)` instead of `fsync(...)`. `_commit` is the documented MSVCRT
equivalent (flush a file descriptor's buffers to disk) and is what mingw programs use.

## Acceptance criteria

1. `go test -run 'TestWindowsNetCompiles|TestWindowsBuildsPE' ./...` passes on Linux with
   `zig` installed.
2. `fsync` on Windows actually commits — do not stub it to a no-op returning success. If a
   true equivalent is unavailable for some fd kind, fail loudly rather than silently
   claiming durability, since that is the entire point of the builtin.
3. Check the same file for **other POSIX-only calls** reaching the Windows target. This
   one was found by a full-suite run, not by a review, so assume it is not alone.

## Out of scope

Do not change the `fsync` builtin's semantics or signature on POSIX.

---
*Found while reviewing #548, which was reported `verify_failed` entirely because of this.*


APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#549): <brief description>
5. The PR body MUST include 'Fixes #549' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-84a3be-dkhow4xu8ck1-70920ad5`

## Summary

Fixes #549: the Windows cross-compile target failed because the emitted runtime called POSIX fsync(fd) unconditionally, which mingw/zig-cc doesn't declare under C11. Added a _WIN32 shim mapping fsync to _commit (the real MSVCRT/ucrt durability equivalent, not a stub), following the existing localtime_r/gmtime_r shim pattern in the runtime preamble. TestWindowsNetCompiles and TestWindowsBuildsPE now pass; native fsync tests and behavior are untouched.

**Diff:**
```
codegen.go | 7 +++++++
 1 file changed, 7 insertions(+)
```
