### PR TITLE
fix(#557): support slice-range syntax s[lo:hi], s[lo:], s[:hi]

### DIFF
--- a/arena_check.go
+++ b/arena_check.go
@@ -79,6 +79,10 @@ func arenaPlaceString(e Expr) (string, bool) {
 		if p, ok := arenaPlaceString(t.X); ok {
 			return p + "#", true
 		}
+	case *SliceExpr:
+		if p, ok := arenaPlaceString(t.X); ok {
+			return p + "#", true
+		}
 	}
 	return "", false
 }
@@ -181,6 +185,8 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 					return false
 				case *SliceLit:
 					return true
+				case *SliceExpr:
+					return true // mfl_subslice always allocates a fresh copy
 				case *MakeClosure:
 					// a closure created here dangles if it captures a variable that currently
 					// holds arena memory: the capture is read at this make site (inside the

--- a/ast.go
+++ b/ast.go
@@ -127,6 +127,13 @@ type Index struct {
 	Idx Expr
 }
 
+// SliceExpr is a slice-range expression: x[lo:hi]. Lo/Hi are nil when omitted
+// (defaulting to 0 / len(x)). Always produces a fresh copy — see guide.go.
+type SliceExpr struct {
+	X      Expr
+	Lo, Hi Expr
+}
+
 // StructLit constructs a struct value: Point{x: 1, y: 2} or Point{1, 2}.
 // FieldNames is nil for positional literals.
 type StructLit struct {
@@ -181,6 +188,7 @@ func (Binary) node()      {}
 func (Call) node()        {}
 func (SliceLit) node()    {}
 func (Index) node()       {}
+func (SliceExpr) node()   {}
 func (StructLit) node()   {}
 func (FieldAccess) node() {}
 func (FuncLit) node()     {}

--- a/codegen.go
+++ b/codegen.go
@@ -346,6 +346,22 @@ static int64_t mfl_bounds(int64_t i, int64_t n) {
     if (i < 0 || i >= n) { char b[80]; snprintf(b, 80, "index out of range [%lld] with length %lld", (long long)i, (long long)n); mfl_panic(b); }
     return i;
 }
+/* s[lo:hi]: always a fresh copy (never a view sharing s's backing storage) —
+   matches substr's copy semantics on strings and sidesteps cap/aliasing
+   surprises when the result escapes the current block. Bounds are checked
+   unconditionally (like s[i] is under --safe), since an out-of-range slice
+   would otherwise read/copy past the backing array. */
+static mfl_slice mfl_subslice(mfl_slice s, int64_t lo, int64_t hi, int64_t es) {
+    if (lo < 0 || hi < lo || hi > s.len) {
+        char b[96];
+        snprintf(b, 96, "slice bounds out of range [%lld:%lld] with length %lld", (long long)lo, (long long)hi, (long long)s.len);
+        mfl_panic(b);
+    }
+    int64_t n = hi - lo;
+    mfl_slice r = { n ? mfl_alloc(n * es) : NULL, n, n };
+    if (n) memcpy(r.data, (char*)s.data + lo * es, n * es);
+    return r;
+}
 static int64_t mfl_idiv(int64_t a, int64_t b) { if (b == 0) mfl_panic("integer divide by zero"); return a / b; }
 static int64_t mfl_imod(int64_t a, int64_t b) { if (b == 0) mfl_panic("integer modulo by zero"); return a % b; }
 static int64_t mfl_iadd(int64_t a, int64_t b) { int64_t r; if (__builtin_add_overflow(a, b, &r)) mfl_panic("integer overflow (+)"); return r; }
@@ -5276,6 +5292,29 @@ func (g *cgen) expr(e Expr) (string, error) {
 			return fmt.Sprintf("({ %s _g; mfl_map_get(%s, %s, %s, &_g); %s })", g.c.NodeCType(g.curFn, ex), x, ik, sk, tail), nil
 		}
 		return fmt.Sprintf("((%s*)(%s).data)[%s]", g.c.ElemCType(g.curFn, ex.X), x, g.boundsIdx(idx, x)), nil
+	case *SliceExpr:
+		x, err := g.expr(ex.X)
+		if err != nil {
+			return "", err
+		}
+		id := g.tmpID
+		g.tmpID++
+		lo := "0"
+		if ex.Lo != nil {
+			lo, err = g.expr(ex.Lo)
+			if err != nil {
+				return "", err
+			}
+		}
+		hi := fmt.Sprintf("_sl%d.len", id)
+		if ex.Hi != nil {
+			hi, err = g.expr(ex.Hi)
+			if err != nil {
+				return "", err
+			}
+		}
+		ct := g.c.ElemCType(g.curFn, ex.X)
+		return fmt.Sprintf("({ mfl_slice _sl%d = %s; mfl_subslice(_sl%d, %s, %s, sizeof(%s)); })", id, x, id, lo, hi, ct), nil
 	case *StructLit:
 		return g.structLit(ex)
 	case *FieldAccess:
@@ -5368,6 +5407,8 @@ func exprHasSideEffect(e Expr) bool {
 		return exprHasSideEffect(x.L) || exprHasSideEffect(x.R)
 	case *Index:
 		return exprHasSideEffect(x.X) || exprHasSideEffect(x.Idx)
+	case *SliceExpr:
+		return exprHasSideEffect(x.X) || (x.Lo != nil && exprHasSideEffect(x.Lo)) || (x.Hi != nil && exprHasSideEffect(x.Hi))
 	case *FieldAccess:
 		return exprHasSideEffect(x.X)
 	case *SliceLit:

--- a/guide.go
+++ b/guide.go
@@ -194,7 +194,7 @@ func machinGuide() guideCatalog {
 			{"bool", "true/false"},
 			{"string", "immutable UTF-8 bytes; zero value \"\""},
 			{"bytes", "NUL-safe binary buffer (ptr+len); from bytes()/from_hex(); inspect with len/byte_at/to_hex. For binary protocols & crypto (strings truncate at NUL)"},
-			{"[]T", "slice (append to grow); for i, v := range. T can be a struct, another slice, or `func` (`[]func{}` — a slice of closures, for dispatch tables / effect lists)"},
+			{"[]T", "slice (append to grow); for i, v := range. T can be a struct, another slice, or `func` (`[]func{}` — a slice of closures, for dispatch tables / effect lists). Slice-range s[lo:hi] / s[lo:] / s[:hi] (lo defaults 0, hi defaults len(s)) ALWAYS returns a fresh COPY, never a view sharing s's backing storage — matches substr's copy semantics on strings and means mutating the result (e.g. via append or index-assign) never affects s. Bounds (0 <= lo <= hi <= len(s)) are checked unconditionally, like s[i] under --safe; a violation panics the same way"},
 			{"map[K]V", "K is int or string; make(map[K]V); has/delete/keys"},
 			{"struct", "type T struct { f T ... }; value semantics; T{f: v}"},
 			{"chan T", "make(chan T); ch <- v; <-ch; close; for v := range ch; v, ok := <-ch"},

--- a/parser.go
+++ b/parser.go
@@ -1058,14 +1058,44 @@ func (p *Parser) parsePostfix() (Expr, error) {
 			x = &CallValue{Fn: x, Args: args}
 		default: // "["
 			p.next()
-			idx, err := p.parseExpr()
+			if p.peek().Val == ":" { // x[:hi]
+				p.next()
+				var hi Expr
+				if p.peek().Val != "]" {
+					hi, err = p.parseExpr()
+					if err != nil {
+						return nil, err
+					}
+				}
+				if _, err := p.expect(TPunct, "]"); err != nil {
+					return nil, err
+				}
+				x = &SliceExpr{X: x, Hi: hi}
+				break
+			}
+			first, err := p.parseExpr()
 			if err != nil {
 				return nil, err
+			}
+			if p.peek().Val == ":" { // x[lo:hi] or x[lo:]
+				p.next()
+				var hi Expr
+				if p.peek().Val != "]" {
+					hi, err = p.parseExpr()
+					if err != nil {
+						return nil, err
+					}
+				}
+				if _, err := p.expect(TPunct, "]"); err != nil {
+					return nil, err
+				}
+				x = &SliceExpr{X: x, Lo: first, Hi: hi}
+				break
 			}
 			if _, err := p.expect(TPunct, "]"); err != nil {
 				return nil, err
 			}
-			x = &Index{X: x, Idx: idx}
+			x = &Index{X: x, Idx: first}
 		}
 	}
 	return x, nil

--- a/slicerange_test.go
+++ b/slicerange_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// s[lo:hi] / s[lo:] / s[:hi] — see guide.go's []T entry for the semantics
+// this pins: always a fresh copy, bounds checked like s[i].
+
+func TestSliceRangeLengthsAndElements(t *testing.T) {
+	got := runNative(t, `func main() {
+    s := []int{1, 2, 3, 4}
+    a := s[1:]
+    b := s[:2]
+    c := s[1:3]
+    println(str(len(a)) + " " + str(a[0]) + " " + str(a[1]) + " " + str(a[2]))
+    println(str(len(b)) + " " + str(b[0]) + " " + str(b[1]))
+    println(str(len(c)) + " " + str(c[0]) + " " + str(c[1]))
+}`)
+	want := "3 2 3 4\n2 1 2\n2 2 3\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestSliceRangeStrings(t *testing.T) {
+	got := runNative(t, `func main() {
+    s := []string{"a", "b", "c", "d"}
+    t := s[1:3]
+    println(str(len(t)) + " " + t[0] + " " + t[1])
+}`)
+	if got != "2 b c\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSliceRangeStructs(t *testing.T) {
+	prog := progFromSrc(t, `
+type P struct { x int }
+func main() {
+    s := []P{}
+    s = append(s, P{x: 1})
+    s = append(s, P{x: 2})
+    s = append(s, P{x: 3})
+    t := s[1:]
+    println(str(len(t)) + " " + str(t[0].x) + " " + str(t[1].x))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out != "2 2 3\n" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestSliceRangeIsACopyNotAView(t *testing.T) {
+	got := runNative(t, `func main() {
+    s := []int{1, 2, 3, 4}
+    t := s[1:]
+    t[0] = 99
+    println(str(s[1]) + " " + str(t[0]))
+}`)
+	if got != "2 99\n" {
+		t.Fatalf("expected mutating the slice-range result to leave the source untouched, got %q", got)
+	}
+}
+
+func TestSliceRangeLoGreaterThanHiPanics(t *testing.T) {
+	cases := []struct{ name, src, want string }{
+		{"lo_gt_hi", `func main() { xs := []int{1, 2, 3} println(str(len(xs[2:1]))) }`, "slice bounds out of range"},
+		{"hi_past_len", `func main() { xs := []int{1, 2, 3} println(str(len(xs[0:5]))) }`, "slice bounds out of range"},
+		{"lo_negative", `func main() { xs := []int{1, 2, 3} lo := -1 println(str(len(xs[lo:2]))) }`, "slice bounds out of range"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bin, err := os.CreateTemp("", "mfl-slicerange-*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			bin.Close()
+			defer os.Remove(bin.Name())
+			if err := BuildBinary(&Program{Funcs: parseFuncs(t, c.src)}, bin.Name(), true); err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			out, err := exec.Command(bin.Name()).CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected a non-zero exit (a panic), got output %q", out)
+			}
+			if !strings.Contains(string(out), c.want) {
+				t.Fatalf("got %q, want substring %q", out, c.want)
+			}
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1458,6 +1458,28 @@ func (c *Checker) genExprInner(fn *FuncDecl, e Expr) (int, error) {
 		res := newSlot(c, KVar)
 		c.indexUses = append(c.indexUses, indexUse{base: xs, idx: is, result: res})
 		return res, nil
+	case *SliceExpr:
+		xs, err := c.genExpr(fn, ex.X)
+		if err != nil {
+			return 0, err
+		}
+		if ex.Lo != nil {
+			ls, err := c.genExpr(fn, ex.Lo)
+			if err != nil {
+				return 0, err
+			}
+			c.addPair(ls, c.cInt)
+		}
+		if ex.Hi != nil {
+			hs, err := c.genExpr(fn, ex.Hi)
+			if err != nil {
+				return 0, err
+			}
+			c.addPair(hs, c.cInt)
+		}
+		res := newSlot(c, KVar)
+		c.addPair(res, xs) // s[lo:hi] has the same type as s
+		return res, nil
 	case *MakeMap:
 		ks, err := c.typeSlot(ex.Key)
 		if err != nil {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #557: "no slice-range syntax (s[1:]) — every drop-first is a hand-rolled loop")

ISSUE DESCRIPTION:
## Problem

There is no slice-range syntax.

```
func main() { s := []int{1,2,3,4}  t := s[1:]  println(str(len(t))) }
```

```
error: parse: expected "]", got ":" at pos 35
```

Every "drop the first element", "take the first N", "the rest of the line" becomes a
hand-rolled loop:

```
func drop_first(xs) (o) {
    o = []int{}
    i := 1
    while i < len(xs) { o = append(o, xs[i])  i = i + 1 }
}
```

## Why it matters

This is the most common operation on a slice after `append` and `len`. Writing it out is
noise, and each hand-rolled copy is a place to get an off-by-one wrong — the demos already
carry several near-identical `drop_first` helpers.

`substr(s, a, b)` already exists for strings, so the concept is in the language; slices just
have no equivalent.

## Suggested fix

Support `s[lo:hi]`, `s[lo:]`, `s[:hi]` on slices, with Go's semantics and bounds rules:
`0 <= lo <= hi <= len(s)`, result length `hi - lo`.

**Aliasing must be decided explicitly and documented.** Go returns a view sharing backing
storage; MFL slices are already described as "reference-ish" for mutation through calls.
Whichever is chosen (view or copy), say so in the `guide.go` entry, because the difference
is observable the first time someone writes through the result. A copy is the safer default
and matches how `substr` behaves on immutable strings; a view is faster. Pick one, document
it, test it.

## Acceptance criteria

1. `s[1:]`, `s[:2]`, `s[1:3]` all compile and produce the right lengths and elements.
2. Out-of-range indices error the same way `s[i]` does today (and under `--safe`, panic).
3. `lo > hi` is an error.
4. Works for `[]int`, `[]string` and `[]<struct>`.
5. Aliasing semantics documented in `guide.go` and pinned by a test that mutates the result
   and checks (or checks the absence of) an effect on the original.

## Out of scope

Three-index slices (`s[a:b:c]`), and slicing strings (use `substr`).


APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#557): <brief description>
5. The PR body MUST include 'Fixes #557' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-84a3be-dkhpj4594pso-1726c8ad`

**Diff:**
```
arena_check.go     |  6 ++++
 ast.go             |  8 +++++
 codegen.go         | 41 +++++++++++++++++++++++
 guide.go           |  2 +-
 parser.go          | 34 +++++++++++++++++--
 slicerange_test.go | 98 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 types.go           | 22 ++++++++++++
 7 files changed, 208 insertions(+), 3 deletions(-)
```
