### PR TITLE
[needs work] fix(codegen): use _commit instead of fsync on Windows target

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -161,6 +161,7 @@ const cRuntime = `#define _GNU_SOURCE
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <io.h>        /* _commit — the Windows fd-flush equivalent of fsync (#549) */
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -1893,7 +1894,11 @@ static int64_t mfl_remove_file(const char* path) { return remove(path) == 0 ? 0 
 static int64_t mfl_fsync(const char* path) {
     int fd = open(path, O_RDONLY);
     if (fd < 0) return -1;
+#ifdef _WIN32
+    int r = _commit(fd);
+#else
     int r = fsync(fd);
+#endif
     int e = errno;
     close(fd);
     if (r == 0) return 0;


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix open GitHub issues. Small PRs, conventional commits.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #562 (am/am-84a3be-dkhcrqdvnpk7-bfec4aa1): fix(#556): accept hex/binary/octal literals as 64-bit bit patterns
    touches: hex_bitpattern_test.go, parser.go
- PR #561 (am/am-84a3be-dkhcdy8wpoc0-f54cb599): fix(#555): accept `_` as the sole assignment destination
    touches: SPEC.md, assign_undefined_test.go, codegen.go, transform.go, types.go
- PR #560 (am/am-84a3be-dkhb5jjw5v4b-498dd449): fix(#553): support non-empty []struct literals
    touches: codegen.go, structlit_test.go
- PR #559 (am/am-84a3be-dkhautnrnfej-c78f7506): [needs work] fix(#552): panic on narrow cstruct field overflow under --safe
    touches: codegen.go, guide.go, mfl_test.go
- PR #558 (am/am-84a3be-dkhafiwqw1xn-34e49bf0): [needs work] fix(check): only show the := shadow hint on an actual redeclaration
    touches: mismatch_identifier_test.go, types.go
- PR #550 (am/am-84a3be-dkggcoo67q00-4e543add): [needs work] fix(check): reject a param sharing its function's named-return name
    touches: param_return_name_collision_test.go, types.go
- PR #548 (am/am-84a3be-dkgg1xrnzdlz-a0321bd2): [needs work] fix(build): pass -fwrapv to all three cc invocations
    touches: build.go, fwrapv_test.go, guide.go
- PR #545 (am/docs-arena-reset-persistence-540): docs(arena_reset): document the persistence rule for globals across a reset
    touches: SPEC.md, guide.go


**Branch:** `am/am-7b5889-dkhkeob7cb84-a55a9cd9`

> ⚠️ **Verification failed** — this PR is a draft. Last output:
```
	/usr/lib/go-1.22/src/io/io.go:411 +0x9d fp=0xc000254f00 sp=0xc000254e88 pc=0x4a457d
io.Copy(...)
	/usr/lib/go-1.22/src/io/io.go:388
os/exec.(*Cmd).writerDescriptor.func1()
	/usr/lib/go-1.22/src/os/exec/exec.go:577 +0x34 fp=0xc000254f60 sp=0xc000254f00 pc=0x514ef4
os/exec.(*Cmd).Start.func2(0x9e7f10?)
	/usr/lib/go-1.22/src/os/exec/exec.go:724 +0x2c fp=0xc000254fc8 sp=0xc000254f60 pc=0x515b8c
os/exec.(*Cmd).Start.gowrap1()
	/usr/lib/go-1.22/src/os/exec/exec.go:736 +0x24 fp=0xc000254fe0 sp=0xc000254fc8 pc=0x515b24
runtime.goexit({})
	/usr/lib/go-1.22/src/runtime/asm_amd64.s:1695 +0x1 fp=0xc000254fe8 sp=0xc000254fe0 pc=0x475b21
created by os/exec.(*Cmd).Start in goroutine 2111
	/usr/lib/go-1.22/src/os/exec/exec.go:723 +0x9ab

rax    0xca
rbx    0x0
rcx    0x477943
rdx    0x0
rdi    0xfb2c00
rsi    0x80
rbp    0x7ffcfe95fa60
rsp    0x7ffcfe95fa18
r8     0x0
r9     0x0
r10    0x0
r11    0x286
r12    0x13
r13    0x1
r14    0xfb22c0
r15    0x1
rip    0x477941
rflags 0x286
cs     0x33
fs     0x0
gs     0x0
*** Test killed with quit: ran too long (11m0s).
FAIL	machin	8247.109s
FAIL

[verify timed out]
[verify environment problem — the command can't run in the worktree; not auto-fixable]
```

**Diff:**
```
codegen.go | 5 +++++
 1 file changed, 5 insertions(+)
```
