### PR TITLE
fix(transform): capture closure vars referenced only in a slice bound

### DIFF
--- a/optimize.go
+++ b/optimize.go
@@ -250,6 +250,15 @@ func transformExpr(e Expr, rule func(Expr) Expr) Expr {
 		return rule(&CallValue{Fn: transformExpr(x.Fn, rule), Args: transformExprs(x.Args, rule)})
 	case *Index:
 		return rule(&Index{X: transformExpr(x.X, rule), Idx: transformExpr(x.Idx, rule)})
+	case *SliceExpr:
+		ne := &SliceExpr{X: transformExpr(x.X, rule)}
+		if x.Lo != nil {
+			ne.Lo = transformExpr(x.Lo, rule)
+		}
+		if x.Hi != nil {
+			ne.Hi = transformExpr(x.Hi, rule)
+		}
+		return rule(ne)
 	case *FieldAccess:
 		return rule(&FieldAccess{X: transformExpr(x.X, rule), Name: x.Name})
 	case *SliceLit:

--- a/render.go
+++ b/render.go
@@ -141,6 +141,15 @@ func (r *renderer) expr(e Expr, parentPrec int) string {
 		return r.expr(x.Fn, 10) + "(" + r.args(x.Args, false) + ")"
 	case *Index:
 		return r.expr(x.X, 10) + "[" + r.expr(x.Idx, 0) + "]"
+	case *SliceExpr:
+		lo, hi := "", ""
+		if x.Lo != nil {
+			lo = r.expr(x.Lo, 0)
+		}
+		if x.Hi != nil {
+			hi = r.expr(x.Hi, 0)
+		}
+		return r.expr(x.X, 10) + "[" + lo + ":" + hi + "]"
 	case *FieldAccess:
 		return r.expr(x.X, 10) + "." + x.Name
 	case *SliceLit:

--- a/render_sliceexpr_test.go
+++ b/render_sliceexpr_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// render.go's expr renderer had no *SliceExpr case, so any function body
+// containing a slice-range expression (x[lo:hi], x[lo:], x[:hi]) fell to the
+// default "unsupported node" branch: renderFuncSrc set complete=false and
+// emitted "/*?*/" instead of the slice expression. That silently breaks the
+// `machin optimize` command's rendered output for any program using #557
+// slice-range syntax.
+func TestRenderSliceExpr(t *testing.T) {
+	cases := []struct {
+		expr Expr
+		want string
+	}{
+		{&SliceExpr{X: &Ident{"xs"}, Lo: &IntLit{1}, Hi: &IntLit{3}}, "xs[1:3]"},
+		{&SliceExpr{X: &Ident{"xs"}, Lo: &IntLit{1}}, "xs[1:]"},
+		{&SliceExpr{X: &Ident{"xs"}, Hi: &IntLit{3}}, "xs[:3]"},
+	}
+	for _, c := range cases {
+		f := &FuncDecl{Name: "f", Params: []string{"xs"}, Body: []Stmt{
+			&ExprStmt{X: c.expr},
+		}}
+		src, complete := renderFuncSrc(f)
+		if !complete {
+			t.Fatalf("renderFuncSrc incomplete for %v: %s", c.expr, src)
+		}
+		if want := c.want; !strings.Contains(src, want) {
+			t.Fatalf("renderFuncSrc(%v) = %q, want to contain %q", c.expr, src, want)
+		}
+	}
+}

--- a/transform.go
+++ b/transform.go
@@ -103,6 +103,14 @@ func (l *lifter) expr(e Expr) Expr {
 	case *Index:
 		ex.X = l.expr(ex.X)
 		ex.Idx = l.expr(ex.Idx)
+	case *SliceExpr:
+		ex.X = l.expr(ex.X)
+		if ex.Lo != nil {
+			ex.Lo = l.expr(ex.Lo)
+		}
+		if ex.Hi != nil {
+			ex.Hi = l.expr(ex.Hi)
+		}
 	case *FieldAccess:
 		ex.X = l.expr(ex.X)
 	case *Recv:
@@ -259,6 +267,14 @@ func freeIdents(body []Stmt, params []string) map[string]bool {
 		case *Index:
 			we(ex.X)
 			we(ex.Idx)
+		case *SliceExpr:
+			we(ex.X)
+			if ex.Lo != nil {
+				we(ex.Lo)
+			}
+			if ex.Hi != nil {
+				we(ex.Hi)
+			}
 		case *FieldAccess:
 			we(ex.X)
 		case *Recv:

--- a/transform_slicecapture_test.go
+++ b/transform_slicecapture_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A closure whose ONLY reference to an outer variable is inside a slice-range
+// bound (x[lo:], x[:hi], x[lo:hi]) must still capture that variable. The
+// free-identifier walker (transform.go) previously had no *SliceExpr case, so
+// such a variable was invisible to closure lifting and either failed to
+// compile or read garbage instead of the captured value.
+func TestClosureCapturesSliceBound(t *testing.T) {
+	cases := []struct{ src, want string }{
+		{`func main() {
+			xs := []int{1, 2, 3, 4, 5}
+			lo := 2
+			f := func() { s := xs[lo:] println(len(s)) println(s[0]) }
+			f()
+		}`, "3 3"},
+		{`func main() {
+			xs := []int{1, 2, 3, 4, 5}
+			hi := 3
+			f := func() { s := xs[:hi] println(len(s)) println(s[2]) }
+			f()
+		}`, "3 3"},
+	}
+	for i, c := range cases {
+		prog := progFromSrc(t, c.src)
+		out, err := RunCaptured(prog)
+		if err != nil {
+			t.Fatalf("case %d run: %v", i, err)
+		}
+		if got := strings.Join(strings.Fields(out), " "); got != c.want {
+			t.Fatalf("case %d = %q, want %q", i, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Go compiler for the MFL language; fix scoped correctness issues with tests

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These automaintainer pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #566 (am/am-7b5889-dkhkeob7cb84-a55a9cd9): [needs work] fix(codegen): use _commit instead of fsync on Windows target
    touches: codegen.go
- PR #550 (am/am-84a3be-dkggcoo67q00-4e543add): [needs work] fix(check): reject a param sharing its function's named-return name
    touches: param_return_name_collision_test.go, types.go
- PR #545 (am/docs-arena-reset-persistence-540): docs(arena_reset): document the persistence rule for globals across a reset
    touches: SPEC.md, guide.go
- PR #544 (am/am-7b5889-dkdsd3o7f77k-441c2689): [needs work] fix(#537): add zlib_compress and zlib_decompress builtins
    touches: README.md, SPEC.md, build.go, codegen.go, docs/LANGUAGE.md, examples/README.md, examples/complex/zlib.mfl, guide.go, types.go, zlib_test.go


**Branch:** `am/am-84a3be-dkhspztwlpdw-7733f0a2`

**Diff:**
```
optimize.go                    |  9 +++++++++
 render.go                      |  9 +++++++++
 render_sliceexpr_test.go       | 35 +++++++++++++++++++++++++++++++++++
 transform.go                   | 16 ++++++++++++++++
 transform_slicecapture_test.go | 38 ++++++++++++++++++++++++++++++++++++++
 5 files changed, 107 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for slice expressions with lower, upper, or omitted bounds.
  * Closures now correctly capture variables used in slice boundaries.
  * Slice expressions are rendered accurately across supported forms.

* **Tests**
  * Added coverage for rendering slices and executing closures that use dynamic slice bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->