### PR TITLE
release: v0.124.1 — closures can reference a slice inside a range bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+## v0.124.1
+
+Patch: **a closure could not reference a slice inside a range bound** (PR #567).
+
+`v0.124.0` added slice ranges (`s[lo:hi]`) as a new `SliceExpr` AST node, but three
+passes that walk the AST were never taught about it — most importantly the
+free-identifier walker in `transform.go`, which drives closure lifting. A closure
+whose only reference to an outer variable sat inside a range bound therefore did
+not capture it, and the program failed to compile:
+
+```
+xs := []int{1,2,3,4,5}
+lo := 2
+f := func() { s := xs[lo:]  println(len(s)) }
+→ error: typecheck: lambda_0$1: undefined variable "xs"
+```
+
+`render.go` and `optimize.go` had the same gap. Fixed by adding the missing
+`*SliceExpr` cases, with tests for capture, rendering and traversal.
+
+Worth recording *why* this shipped: v0.124.0's slice-range work was reviewed for
+bounds, copy semantics, element types and the arena interaction, and the full
+suite was green — but nothing put a slice range inside a closure, so no test
+covered the combination. **Adding an AST node means auditing every pass that
+walks the AST**, not only the ones the new syntax obviously touches.
+
 ## v0.124.0
 
 Nine changes, all of them surfaced by building a real thing in MFL — a 2D game

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.124.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.124.1-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.124.0
+Version 0.124.1
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.124.0"
+const machinVersion = "0.124.1"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Patch release for #567, which fixes a defect **shipped in v0.124.0**.

Slice ranges landed as a new `SliceExpr` AST node; three passes that walk the AST were never
taught about it. The consequential one is the free-identifier walker in `transform.go` (closure
lifting), so this failed to compile on the released binary:

```
xs := []int{1,2,3,4,5}
lo := 2
f := func() { s := xs[lo:]  println(len(s)) }
→ error: typecheck: lambda_0$1: undefined variable "xs"
```

Reproduced against the published v0.124.0 artifact, not just against `main`. Fixed on `main` now
(prints `3 3`).

**Verification:** full unscoped `go test ./...` green — 410s, zero failures.

The changelog entry records *why* it shipped rather than just what broke: v0.124.0's slice-range
review covered bounds, copy semantics, element types and the arena interaction, and the suite was
green — but nothing exercised a slice range inside a closure. Adding an AST node means auditing
every pass that walks the AST, not only the ones the new syntax obviously touches.