### PR TITLE
ci: run the windows/wasm target tests instead of silently skipping them (#517)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,6 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Test
-        run: go test ./...
-
-      - name: Run every example (integration smoke test)
-        run: ./examples/run.sh
-
-      # Guard the wasm target: a POSIX-only helper (mmap, madvise, a <sys/*> include)
-      # that lands in the always-on cRuntime compiles fine natively but breaks
-      # `--target wasm` under a strict zig (wasi-libc has no mmap). This smoke build
-      # fails CI if that regresses again. See issue #463.
       # Install zig straight from ziglang.org, not mlugg/setup-zig: that action fetches
       # only from community mirrors, which lag the canonical site and were 404/503-ing for
       # every version. `zig cc` is clang-based and version-stable for the C->wasm smoke
@@ -47,9 +37,34 @@ jobs:
           mkdir -p /tmp/zig && tar -xf /tmp/zig.tar.xz -C /tmp/zig --strip-components=1
           echo "/tmp/zig" >> "$GITHUB_PATH"
 
+      # zig is installed ABOVE this step on purpose. The wasm and windows target
+      # tests call zigPath() and `t.Skipf` when zig is missing — so with the install
+      # below them they SKIPPED in CI, and a broken windows target shipped in
+      # v0.122.0 and survived two releases while `TestWindowsNetCompiles` and
+      # `TestWindowsBuildsPE` were red on every developer machine (#549, #517).
+      - name: Test
+        run: go test ./...
+
+      - name: Run every example (integration smoke test)
+        run: ./examples/run.sh
+
+      # Guard the wasm target: a POSIX-only helper (mmap, madvise, a <sys/*> include)
+      # that lands in the always-on cRuntime compiles fine natively but breaks
+      # `--target wasm` under a strict zig (wasi-libc has no mmap). This smoke build
+      # fails CI if that regresses again. See issue #463.
       - name: wasm smoke build (guards POSIX-only code out of cRuntime — #463)
         run: |
           go build -o /tmp/machin .
           printf 'export func ping() (n) { n = 1 }\n' > /tmp/wasm_smoke.mfl
           /tmp/machin build /tmp/wasm_smoke.mfl --target wasm -o /tmp/wasm_smoke.wasm
           test -s /tmp/wasm_smoke.wasm && echo "wasm smoke build OK ($(wc -c < /tmp/wasm_smoke.wasm) bytes)"
+
+      # Same guard for the windows target: a builtin whose emitted C calls a POSIX
+      # function with no _WIN32 shim breaks `--target windows`. Exercises the file/dir
+      # I/O family specifically — that is where the last two breakages were (#549).
+      - name: windows smoke build (guards POSIX-only code out of the windows target — #517)
+        run: |
+          printf 'func main() {\n  p := "probe.txt"\n  write_file(p, "payload")\n  kind, size, mtime := stat(p)\n  sy := fsync(p)\n  n := len(list_dir("."))\n  remove(p)\n  println(str(kind) + str(size) + str(mtime) + str(sy) + str(n) + str(is_dir(".")))\n}\n' > /tmp/win_smoke.src
+          /tmp/machin encode /tmp/win_smoke.src > /tmp/win_smoke.mfl
+          /tmp/machin build /tmp/win_smoke.mfl --target windows -o /tmp/win_smoke.exe
+          test -s /tmp/win_smoke.exe && echo "windows smoke build OK ($(wc -c < /tmp/win_smoke.exe) bytes)"


### PR DESCRIPTION
Treating #517. I started by writing a new test to cover the windows-supported builtin surface — then checked the premise and found it was wrong, so this is a different and smaller change.

### The actual root cause is CI ordering

The windows target was broken from **v0.122.0 to v0.124.0** and CI was green the whole time.
Not a coverage gap:

```yaml
line 30:  - name: Test
            run: go test ./...
line 43:  - name: Install zig (the C -> wasm compiler)
```

`TestWindowsNetCompiles` and `TestWindowsBuildsPE` call `zigPath()` and `t.Skipf` when zig is
missing — so **they skipped in CI** and only failed locally, where zig exists. That is why three
PRs in one batch came back `verify_failed` for a reason none of them caused, and why nobody
acted on it: the signal was only visible to whoever ran the suite by hand.

### What I checked before writing this

My first assumption was that the old tests did not exercise file metadata, so `fsync` slipped
past them. **That was wrong** — the C runtime is emitted wholesale, so `fsync` appears 9 times
even in a program that never calls it, and removing the shim fails *every* windows compile. The
old tests were perfectly capable of catching it. They just never ran.

So the fix is ordering, not another test. I deleted the surface test I had written rather than
ship a redundant one with a rationale that did not hold up.

### Changes

1. **Hoist the zig install above the Test step** — one move, and the windows/wasm target tests
   start running in CI.
2. **Add a windows smoke build** next to the existing wasm one (#463), exercising the file/dir
   I/O family since both breakages landed there.

### Verification

- Full suite green (167s).
- The windows tests now run rather than skip: `TestWindowsNetCompiles`, `TestWindowsBuildsPE`,
  `TestWindowsPreflightRejects`, `TestWindowsCoreOmitsPosixRuntime` all PASS.
- The smoke step is a real guard — removing the `fsync` shim from `cRuntime` makes it fail with
  `undeclared function 'fsync'`, and I ran the exact CI commands locally (305 KB `.exe`).