### PR TITLE
fix(check): a type mismatch now names the expression that caused it (#551)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,6 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Test
-        run: go test ./...
-
-      - name: Run every example (integration smoke test)
-        run: ./examples/run.sh
-
-      # Guard the wasm target: a POSIX-only helper (mmap, madvise, a <sys/*> include)
-      # that lands in the always-on cRuntime compiles fine natively but breaks
-      # `--target wasm` under a strict zig (wasi-libc has no mmap). This smoke build
-      # fails CI if that regresses again. See issue #463.
       # Install zig straight from ziglang.org, not mlugg/setup-zig: that action fetches
       # only from community mirrors, which lag the canonical site and were 404/503-ing for
       # every version. `zig cc` is clang-based and version-stable for the C->wasm smoke
@@ -47,9 +37,34 @@ jobs:
           mkdir -p /tmp/zig && tar -xf /tmp/zig.tar.xz -C /tmp/zig --strip-components=1
           echo "/tmp/zig" >> "$GITHUB_PATH"
 
+      # zig is installed ABOVE this step on purpose. The wasm and windows target
+      # tests call zigPath() and `t.Skipf` when zig is missing — so with the install
+      # below them they SKIPPED in CI, and a broken windows target shipped in
+      # v0.122.0 and survived two releases while `TestWindowsNetCompiles` and
+      # `TestWindowsBuildsPE` were red on every developer machine (#549, #517).
+      - name: Test
+        run: go test ./...
+
+      - name: Run every example (integration smoke test)
+        run: ./examples/run.sh
+
+      # Guard the wasm target: a POSIX-only helper (mmap, madvise, a <sys/*> include)
+      # that lands in the always-on cRuntime compiles fine natively but breaks
+      # `--target wasm` under a strict zig (wasi-libc has no mmap). This smoke build
+      # fails CI if that regresses again. See issue #463.
       - name: wasm smoke build (guards POSIX-only code out of cRuntime — #463)
         run: |
           go build -o /tmp/machin .
           printf 'export func ping() (n) { n = 1 }\n' > /tmp/wasm_smoke.mfl
           /tmp/machin build /tmp/wasm_smoke.mfl --target wasm -o /tmp/wasm_smoke.wasm
           test -s /tmp/wasm_smoke.wasm && echo "wasm smoke build OK ($(wc -c < /tmp/wasm_smoke.wasm) bytes)"
+
+      # Same guard for the windows target: a builtin whose emitted C calls a POSIX
+      # function with no _WIN32 shim breaks `--target windows`. Exercises the file/dir
+      # I/O family specifically — that is where the last two breakages were (#549).
+      - name: windows smoke build (guards POSIX-only code out of the windows target — #517)
+        run: |
+          printf 'func main() {\n  p := "probe.txt"\n  write_file(p, "payload")\n  kind, size, mtime := stat(p)\n  sy := fsync(p)\n  n := len(list_dir("."))\n  remove(p)\n  println(str(kind) + str(size) + str(mtime) + str(sy) + str(n) + str(is_dir(".")))\n}\n' > /tmp/win_smoke.src
+          /tmp/machin encode /tmp/win_smoke.src > /tmp/win_smoke.mfl
+          /tmp/machin build /tmp/win_smoke.mfl --target windows -o /tmp/win_smoke.exe
+          test -s /tmp/win_smoke.exe && echo "windows smoke build OK ($(wc -c < /tmp/win_smoke.exe) bytes)"

--- a/mismatch_identifier_test.go
+++ b/mismatch_identifier_test.go
@@ -148,3 +148,82 @@ func TestMismatchWithoutIdentifierUnchanged(t *testing.T) {
 		t.Fatalf("expected a type mismatch error, got %v", cerr)
 	}
 }
+
+// A mismatch must name the EXPRESSION that produced the conflicting type, not
+// only the variable that ended up with it (#551). The variable is the effect;
+// the expression is the cause, and on a long function the cause is what you have
+// to go find. No line number: MFL's canonical form is one declaration per line,
+// so every expression in a function shares one.
+func TestMismatchNamesTheConflictingBuiltin(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func hash(h, s) (o) { o = h i := 0 while i < len(s) { o = o + charat(s, i) i = i + 1 } }`,
+		`func main() { println(str(hash(7, "ab"))) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	// charat returns a string, not a byte — that is the actual mistake, and the
+	// message used to blame only the accumulator `h`.
+	if !strings.Contains(cerr.Error(), "charat(s, i)") {
+		t.Fatalf("message does not name the builtin whose return type conflicts: %q", cerr.Error())
+	}
+}
+
+// The same for a parameter whose type was fixed by an earlier call: name the
+// call that conflicts, so you do not bisect a dozen call sites by hand.
+func TestMismatchNamesTheConflictingCall(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func report(flag, name) (n) { n = 0 if flag == 1 { println(name) } }`,
+		`func main() { x := report(1, "int call") y := report(2 == 2, "bool call") println(str(x + y)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	if !strings.Contains(cerr.Error(), "report(2 == 2") {
+		t.Fatalf("message does not name the conflicting call: %q", cerr.Error())
+	}
+}
+
+// An assignment is caused by its right-hand side.
+func TestMismatchNamesTheAssignedExpression(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { steps := "a,b,c" steps = split("a,b,c", ",") println(steps[0]) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	if !strings.Contains(cerr.Error(), `split("a,b,c", ",")`) {
+		t.Fatalf("message does not name the assigned expression: %q", cerr.Error())
+	}
+}
+
+// A bare identifier or literal adds nothing the message does not already say, so
+// it must NOT be appended — the cause is only worth printing when it is a real
+// expression.
+func TestMismatchOmitsNoisyCause(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { v := 1 v = "s" println(v) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	if strings.Contains(cerr.Error(), "— from") {
+		t.Fatalf("a literal cause should be omitted as noise: %q", cerr.Error())
+	}
+}

--- a/types.go
+++ b/types.go
@@ -90,6 +90,14 @@ type Checker struct {
 	externs map[string]*ExternFunc // foreign C functions, by name
 
 	pairs []int      // flattened pairs: pairs[2i], pairs[2i+1]
+	// pairSrc[i] is the expression that generated pairs[2i]/pairs[2i+1], kept as
+	// an AST node and rendered only on failure (#551). When unification fails,
+	// the failing constraint IS the conflicting use — naming it is the whole
+	// difference between "'h' is num vs string" and "the string comes from
+	// charat(s, i)". Not a line number: MFL's canonical form is one declaration
+	// per line, so every expression inside a function shares its line.
+	pairSrc []Expr
+	curExpr Expr // expression being constraint-generated; recorded by addPair
 	plus  []plusCons // overloaded '+' constraints, resolved by fixpoint
 
 	lenArgs   []int      // slots passed to len(); must resolve to string/slice/map
@@ -185,7 +193,10 @@ type indexUse struct {
 	result int
 }
 
-type plusCons struct{ l, r, res int }
+type plusCons struct {
+	l, r, res int
+	src       Expr // the `+` expression, for the #551 mismatch cause
+}
 
 // funcSig is a function value's signature: parameter slots and a single return
 // slot (ret < 0 means void).
@@ -868,7 +879,10 @@ func (c *Checker) sigString(inst string) string {
 	return b.String()
 }
 
-func (c *Checker) addPair(a, b int) { c.pairs = append(c.pairs, a, b) }
+func (c *Checker) addPair(a, b int) {
+	c.pairs = append(c.pairs, a, b)
+	c.pairSrc = append(c.pairSrc, c.curExpr)
+}
 
 // checkTypeName validates that a declared type string is known.
 func (c *Checker) checkTypeName(t string) error {
@@ -1112,7 +1126,31 @@ func (c *Checker) slotVar(slot int) (string, bool) {
 // identifier — and, via the enclosing function, the declaration `check` maps to a
 // line — removes the guesswork. Non-mismatch errors and anonymous slots pass
 // through unchanged.
-func (c *Checker) annotateMismatch(err error, a, b int) error {
+// pairSrcAt returns the expression behind pairs[i]/pairs[i+1], or nil.
+func (c *Checker) pairSrcAt(i int) Expr {
+	if j := i / 2; j < len(c.pairSrc) {
+		return c.pairSrc[j]
+	}
+	return nil
+}
+
+// mismatchCause renders the expression that produced the failing constraint,
+// but only when it actually adds information: a bare identifier or literal just
+// repeats what the message already says, and naming it would be noise.
+func mismatchCause(e Expr) string {
+	switch e.(type) {
+	case nil, *Ident, *IntLit, *FloatLit, *StringLit, *BoolLit:
+		return ""
+	}
+	r := &renderer{complete: true}
+	src := r.expr(e, 0)
+	if len(src) > 60 {
+		src = src[:57] + "..."
+	}
+	return src
+}
+
+func (c *Checker) annotateMismatch(err error, a, b int, src Expr) error {
 	msg := err.Error()
 	if !strings.HasPrefix(msg, "type mismatch: ") {
 		return err
@@ -1134,9 +1172,17 @@ func (c *Checker) annotateMismatch(err error, a, b int) error {
 		// (issue #551). Say so, since a reader with Go instincts expects two
 		// independent block-local variables. Only append this hint when a `:=`
 		// redeclaration is actually involved — otherwise it is a red herring.
-		return fmt.Errorf("type mismatch for %s: %s; := does not shadow — variables are function-scoped", who, detail)
+		return fmt.Errorf("type mismatch for %s: %s%s; := does not shadow — variables are function-scoped", who, detail, causeSuffix(src))
 	}
-	return fmt.Errorf("type mismatch for %s: %s", who, detail)
+	return fmt.Errorf("type mismatch for %s: %s%s", who, detail, causeSuffix(src))
+}
+
+// causeSuffix formats the conflicting expression for an error message.
+func causeSuffix(src Expr) string {
+	if cause := mismatchCause(src); cause != "" {
+		return " — from " + cause
+	}
+	return ""
 }
 
 func (c *Checker) solve() error {
@@ -1145,7 +1191,7 @@ func (c *Checker) solve() error {
 		for i := 0; i+1 < len(c.pairs); i += 2 {
 			ch, err := c.union(c.pairs[i], c.pairs[i+1])
 			if err != nil {
-				return c.annotateMismatch(err, c.pairs[i], c.pairs[i+1])
+				return c.annotateMismatch(err, c.pairs[i], c.pairs[i+1], c.pairSrcAt(i))
 			}
 			changed = changed || ch
 		}
@@ -1161,11 +1207,11 @@ func (c *Checker) solve() error {
 			}
 			ch1, err := c.union(a, b)
 			if err != nil {
-				return c.annotateMismatch(err, a, b)
+				return c.annotateMismatch(err, a, b, p.src)
 			}
 			ch2, err := c.union(p.res, p.l)
 			if err != nil {
-				return c.annotateMismatch(err, p.res, p.l)
+				return c.annotateMismatch(err, p.res, p.l, p.src)
 			}
 			changed = changed || ch1 || ch2
 		}
@@ -1187,6 +1233,11 @@ func (c *Checker) genStmt(fn *FuncDecl, s Stmt) error {
 		if err != nil {
 			return err
 		}
+		// An assignment's constraint is caused by its right-hand side (#551):
+		// `steps = split(...)` should blame split, not the bare name.
+		prevAssign := c.curExpr
+		c.curExpr = st.Val
+		defer func() { c.curExpr = prevAssign }()
 		if st.Name == "_" {
 			// the blank identifier discards the value: never readable, never
 			// allocated as a local, and it counts as neither a new binding nor
@@ -1416,7 +1467,10 @@ func (c *Checker) genExpr(fn *FuncDecl, e Expr) (int, error) {
 	if s, ok := ns[e]; ok {
 		return s, nil
 	}
+	prev := c.curExpr
+	c.curExpr = e
 	slot, err := c.genExprInner(fn, e)
+	c.curExpr = prev
 	if err != nil {
 		return 0, err
 	}
@@ -1602,7 +1656,7 @@ func (c *Checker) genBinary(fn *FuncDecl, ex *Binary) (int, error) {
 	switch ex.Op {
 	case "+":
 		res := newSlot(c, KVar)
-		c.plus = append(c.plus, plusCons{l: ls, r: rs, res: res})
+		c.plus = append(c.plus, plusCons{l: ls, r: rs, res: res, src: ex})
 		return res, nil
 	case "-", "*", "/":
 		c.addPair(ls, rs)


### PR DESCRIPTION
Closes #551 — the half that PR #558 left undone.

#558 removed the misleading `:= does not shadow` hint (correctly, and with no regression). This
is the other ask: **name the expression or call site that caused the type**, which is the part
that actually costs you time.

```
before: type mismatch for 'h' in "hash": num vs string
after:  type mismatch for 'h' in "hash": num vs string — from o + charat(s, i)

before: type mismatch for 'flag' in "report": num vs bool
after:  type mismatch for 'flag' in "report": num vs bool — from report(2 == 2, "bool call")

before: type mismatch for 'steps' in "main": string vs slice
after:  type mismatch for 'steps' in "main": string vs slice — from split("a,b,c", ",")
```

The first is the one from the issue: `charat` returns a string, not a byte, and the message
never mentioned `charat`. The second names the conflicting **call site**, so you no longer
bisect a dozen callers by hand.

### Mechanism

The failing constraint **is** the conflicting use. So `pairs` gains a parallel `pairSrc []Expr`
carrying the AST node that generated each constraint, and `solve()` — which already knows the
failing index — hands it to `annotateMismatch`. Rendered via the existing `renderer` only on
failure, so there is no cost on the success path.

Two judgement calls:

- **An assignment blames its right-hand side.** `steps = split(...)` should name `split`, not
  the bare target.
- **A bare identifier or literal is suppressed.** `v := 1; v = "s"` already says everything in
  `num vs string`; appending `— from "s"` would be noise. Pinned by a test.

### Why there are no line numbers

The issue (mine) asked for output like `at line 5`. **That was wrong, and I would rather say so
than half-build it.** MFL's canonical form is one normalized declaration per line — after
`encode`, every expression inside a function shares the function's line. The AST carries no
positions at all (`grep Line ast.go` is empty), and the only line the checker can report today
is the declaration's start, which `check.go` already attaches. Naming the expression is the
granularity that exists; a line number would have been the same number for every candidate.

Adding real positions would mean threading them from the lexer's `Token.Pos` through the parser
into every AST node — a much larger change, and worth its own issue if source-mapped diagnostics
are ever wanted for non-canonical `.src` files.

### Verification

Full suite green (175s). Four new tests: the builtin case, the call-site case, the assignment
case, and one asserting a noisy literal cause is **not** appended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type mismatch errors by identifying the conflicting expression, including function calls, built-in calls, and assignments.
  * Reduced unnecessary details in errors for simple identifiers and literals.

* **Tests**
  * Added coverage for clearer type mismatch diagnostics across common expression types.
  * Expanded cross-platform integration checks, including Windows file and directory I/O compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->