### PR TITLE
fix(arena): ARENA001 catches a global filled by a callee inside the block (#539)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,6 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Test
-        run: go test ./...
-
-      - name: Run every example (integration smoke test)
-        run: ./examples/run.sh
-
-      # Guard the wasm target: a POSIX-only helper (mmap, madvise, a <sys/*> include)
-      # that lands in the always-on cRuntime compiles fine natively but breaks
-      # `--target wasm` under a strict zig (wasi-libc has no mmap). This smoke build
-      # fails CI if that regresses again. See issue #463.
       # Install zig straight from ziglang.org, not mlugg/setup-zig: that action fetches
       # only from community mirrors, which lag the canonical site and were 404/503-ing for
       # every version. `zig cc` is clang-based and version-stable for the C->wasm smoke
@@ -47,9 +37,34 @@ jobs:
           mkdir -p /tmp/zig && tar -xf /tmp/zig.tar.xz -C /tmp/zig --strip-components=1
           echo "/tmp/zig" >> "$GITHUB_PATH"
 
+      # zig is installed ABOVE this step on purpose. The wasm and windows target
+      # tests call zigPath() and `t.Skipf` when zig is missing — so with the install
+      # below them they SKIPPED in CI, and a broken windows target shipped in
+      # v0.122.0 and survived two releases while `TestWindowsNetCompiles` and
+      # `TestWindowsBuildsPE` were red on every developer machine (#549, #517).
+      - name: Test
+        run: go test ./...
+
+      - name: Run every example (integration smoke test)
+        run: ./examples/run.sh
+
+      # Guard the wasm target: a POSIX-only helper (mmap, madvise, a <sys/*> include)
+      # that lands in the always-on cRuntime compiles fine natively but breaks
+      # `--target wasm` under a strict zig (wasi-libc has no mmap). This smoke build
+      # fails CI if that regresses again. See issue #463.
       - name: wasm smoke build (guards POSIX-only code out of cRuntime — #463)
         run: |
           go build -o /tmp/machin .
           printf 'export func ping() (n) { n = 1 }\n' > /tmp/wasm_smoke.mfl
           /tmp/machin build /tmp/wasm_smoke.mfl --target wasm -o /tmp/wasm_smoke.wasm
           test -s /tmp/wasm_smoke.wasm && echo "wasm smoke build OK ($(wc -c < /tmp/wasm_smoke.wasm) bytes)"
+
+      # Same guard for the windows target: a builtin whose emitted C calls a POSIX
+      # function with no _WIN32 shim breaks `--target windows`. Exercises the file/dir
+      # I/O family specifically — that is where the last two breakages were (#549).
+      - name: windows smoke build (guards POSIX-only code out of the windows target — #517)
+        run: |
+          printf 'func main() {\n  p := "probe.txt"\n  write_file(p, "payload")\n  kind, size, mtime := stat(p)\n  sy := fsync(p)\n  n := len(list_dir("."))\n  remove(p)\n  println(str(kind) + str(size) + str(mtime) + str(sy) + str(n) + str(is_dir(".")))\n}\n' > /tmp/win_smoke.src
+          /tmp/machin encode /tmp/win_smoke.src > /tmp/win_smoke.mfl
+          /tmp/machin build /tmp/win_smoke.mfl --target windows -o /tmp/win_smoke.exe
+          test -s /tmp/win_smoke.exe && echo "windows smoke build OK ($(wc -c < /tmp/win_smoke.exe) bytes)"

--- a/arena_check.go
+++ b/arena_check.go
@@ -112,6 +112,10 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 		return nil
 	}
 	retProv := computeRetProv(prog, c) // interprocedural return-provenance summary
+	// Which globals does calling f fill with memory it allocated? (#539) Without
+	// this, `arena { build() }` where build() does `g = out` is invisible: the
+	// assignment is one stack frame deeper than the block.
+	globalWrites := computeGlobalWrites(prog, c, retProv)
 
 	var out []arenaFinding
 	seen := map[string]bool{} // dedup per (function, detail)
@@ -253,6 +257,15 @@ func detectArenaEscapes(prog *Program, c *Checker) []arenaFinding {
 								setPlace(n, tv)
 							} else if tv {
 								flag("ARENA001", "`"+n+"` outlives this arena block but is assigned a value allocated inside it — it dangles after the block's memory is reclaimed")
+							}
+						}
+					case *ExprStmt:
+						// A call whose callee assigns a global memory it allocated: the
+						// store happens inside this block, so the global dangles once the
+						// block is reclaimed — the interprocedural half of ARENA001 (#539).
+						if call, ok := st.X.(*Call); ok {
+							for _, g := range arenaCallWrites(call.Callee, globalWrites) {
+								flag("ARENA001", "`"+g+"` outlives this arena block but `"+call.Callee+"()` assigns it a value allocated inside it — it dangles after the block's memory is reclaimed")
 							}
 						}
 					case *ReturnStmt:

--- a/arena_escape_test.go
+++ b/arena_escape_test.go
@@ -268,3 +268,82 @@ func TestScopedArenaReturnsPagesToTheOS(t *testing.T) {
 		t.Fatalf("scoped arena did not return pages: scoped %d kB vs unscoped %d kB", scopedRSS, unscopedRSS)
 	}
 }
+
+// ARENA001's interprocedural half (#539): a global assigned arena memory one
+// call deeper than the block. This is the normal way to write MFL — you call a
+// helper inside `arena { }` — and it produced silent wrong data with a clean
+// `machin check`: the global's length still read right while its contents were
+// freed memory.
+func TestArenaEscapeThroughCallee(t *testing.T) {
+	findings := arenaEscapes(t, `var g_cache = []string{}`,
+		`func build_cache() { out := []string{} i := 0 while i < 3 { out = append(out, "e" + str(i)) i = i + 1 } g_cache = out }`,
+		`func main() { arena { build_cache() } println(str(len(g_cache))) }`)
+	if !arenaDetailHas(findings, "g_cache") || !arenaDetailHas(findings, "build_cache()") {
+		t.Fatalf("expected ARENA001 naming both the global and the callee, got %v", findings)
+	}
+}
+
+// Two hops: arena { a() } -> b() -> g = <fresh>. The summary is a fixpoint over
+// the call graph, so depth must not matter.
+func TestArenaEscapeThroughCalleeTransitive(t *testing.T) {
+	findings := arenaEscapes(t, `var g = []string{}`,
+		`func b() { out := []string{} out = append(out, "x") g = out }`,
+		`func a() { b() }`,
+		`func main() { arena { a() } println(str(len(g))) }`)
+	if !arenaDetailHas(findings, "`g`") {
+		t.Fatalf("expected ARENA001 through two call hops, got %v", findings)
+	}
+}
+
+// The `fresh` gate is what keeps this usable. A global assigned something that
+// was NOT allocated in the block does not dangle, and must not be flagged —
+// ARENA001 is only worth having if every finding is real.
+func TestArenaEscapeThroughCalleeNoFalsePositives(t *testing.T) {
+	cases := []struct {
+		name  string
+		decls []string
+	}{
+		{"assigns a literal", []string{
+			`var g = ""`,
+			`func store() { g = "constant" }`,
+			`func main() { arena { store() } println(g) }`}},
+		{"assigns a parameter", []string{
+			`var g = ""`,
+			`func store(s) { g = s }`,
+			`func main() { arena { store("x") } println(g) }`}},
+		{"assigns another global", []string{
+			`var g = ""`, `var h = "x"`,
+			`func store() { g = h }`,
+			`func main() { arena { store() } println(g) }`}},
+		{"callee writes no global", []string{
+			`func work() { x := []string{} x = append(x, "a") println(str(len(x))) }`,
+			`func main() { arena { work() } println("done") }`}},
+		{"the write is outside any arena", []string{
+			`var g = []string{}`,
+			`func build() { out := []string{} out = append(out, "a") g = out }`,
+			`func main() { build() println(str(len(g))) }`}},
+		{"escape() carries it out legitimately", []string{
+			`var g = []string{}`,
+			`func build() { out := []string{} out = append(out, "a") g = escape(out) }`,
+			`func main() { arena { build() } println(str(len(g))) }`}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, f := range arenaEscapes(t, tc.decls...) {
+				if f.Code == "ARENA001" {
+					t.Fatalf("false positive: %s", f.Detail)
+				}
+			}
+		})
+	}
+}
+
+// arenaDetailHas reports whether any ARENA001 finding mentions want.
+func arenaDetailHas(fs []arenaFinding, want string) bool {
+	for _, f := range fs {
+		if f.Code == "ARENA001" && strings.Contains(f.Detail, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/arena_prov.go
+++ b/arena_prov.go
@@ -1,5 +1,7 @@
 package main
 
+import "sort"
+
 // arena_prov.go — interprocedural provenance for arena escape analysis (Slice 2).
 //
 // v1 of the escape analysis treated ANY heap-returning call inside an arena block as a fresh
@@ -203,4 +205,160 @@ func provWalkReturns(body []Stmt, fn func(vals []Expr)) {
 			provWalkReturns(st.Body, fn)
 		}
 	}
+}
+
+// ---- global-write provenance (Slice 3, issue #539) ----
+//
+// computeRetProv answers "does calling f RETURN arena memory". This answers the
+// other direction: "does calling f STORE arena memory somewhere that outlives the
+// block" — specifically, into a package global.
+//
+// Why it is needed: ARENA001 catches `g = out` written literally inside an
+// `arena { }`, but not the identical assignment one call deeper —
+//
+//	func build() { out := []string{}  ...  g_cache = out }
+//	func main()  { arena { build() }  println(g_cache[0]) }   // reads freed memory
+//
+// which is the normal way to write MFL, and produced silent wrong data with a
+// clean `machin check` (#539). The analysis was sound for what it inspected; the
+// boundary was one stack frame deep, which is narrower than the claim reads.
+//
+// Summary: function name -> the globals it may assign FRESHLY-ALLOCATED heap to,
+// directly or through a call. Fixpoint over the call graph, monotone (sets only
+// grow) so it converges. The `fresh` gate is what keeps this from flagging every
+// global write: assigning a global a parameter, another global, or a literal
+// allocates nothing in the block, so it does not dangle.
+func computeGlobalWrites(prog *Program, c *Checker, retProv map[string]*provSummary) map[string]map[string]bool {
+	writes := map[string]map[string]bool{}
+	for _, f := range prog.Funcs {
+		writes[f.Name] = map[string]bool{}
+	}
+	for iter := 0; iter < 40; iter++ { // fixpoint over the call graph
+		changed := false
+		for _, inst := range c.reps {
+			f := c.instFn[inst]
+			if f == nil || writes[f.Name] == nil {
+				continue
+			}
+			isParam := map[string]bool{}
+			for _, p := range f.Params {
+				isParam[p] = true
+			}
+			localFresh := map[string]bool{}
+
+			// fresh reports whether e evaluates to heap allocated in THIS call —
+			// the same question `prov` asks for returns, minus the pass-through
+			// bookkeeping (a parameter or a global is pre-existing, so neither
+			// can dangle when the block is reclaimed).
+			var fresh func(e Expr) bool
+			fresh = func(e Expr) bool {
+				if slot, ok := c.nodeSlot[inst][e]; ok && !arenaHeapKind(c, slot) {
+					return false
+				}
+				switch t := e.(type) {
+				case *Ident:
+					if isParam[t.Name] {
+						return false
+					}
+					if _, isGlobal := c.globalSlot[t.Name]; isGlobal {
+						return false
+					}
+					return localFresh[t.Name]
+				case *Binary:
+					return true // heap-kind binary = string concat, allocated here
+				case *SliceLit:
+					return true
+				case *Unary:
+					return fresh(t.X)
+				case *Index:
+					return fresh(t.X)
+				case *FieldAccess:
+					return fresh(t.X)
+				case *StructLit:
+					for _, v := range t.Vals {
+						if fresh(v) {
+							return true
+						}
+					}
+					return false
+				case *Call:
+					if t.Callee == "escape" {
+						return false // escape() copies into the enclosing arena
+					}
+					if s := retProv[t.Callee]; s != nil {
+						if s.fresh {
+							return true
+						}
+						for i := range s.pass { // passes an argument through
+							if i < len(t.Args) && fresh(t.Args[i]) {
+								return true
+							}
+						}
+						return false
+					}
+					return true // builtin / unknown callee: conservatively fresh
+				}
+				// Default FALSE, matching carriesArena in arena_check.go: a literal
+				// is static storage, not arena memory, and ARENA001 is only worth
+				// having if every finding is real. An allocating form not listed
+				// above is a false negative, which is the trade this analysis has
+				// always made.
+				return false
+			}
+
+			var walk func(body []Stmt)
+			walk = func(body []Stmt) {
+				for _, s := range body {
+					switch st := s.(type) {
+					case *AssignStmt:
+						if _, isGlobal := c.globalSlot[st.Name]; isGlobal {
+							if _, shadowed := c.vars[inst][st.Name]; !shadowed {
+								if fresh(st.Val) && !writes[f.Name][st.Name] {
+									writes[f.Name][st.Name] = true
+									changed = true
+								}
+							}
+						} else if fresh(st.Val) != localFresh[st.Name] {
+							localFresh[st.Name] = fresh(st.Val)
+							changed = true
+						}
+					case *ExprStmt:
+						if call, ok := st.X.(*Call); ok {
+							for g := range writes[call.Callee] {
+								if !writes[f.Name][g] {
+									writes[f.Name][g] = true
+									changed = true
+								}
+							}
+						}
+					case *IfStmt:
+						walk(st.Then)
+						walk(st.Else)
+					case *WhileStmt:
+						walk(st.Body)
+					case *RangeStmt:
+						walk(st.Body)
+					case *ArenaStmt:
+						walk(st.Body)
+					}
+				}
+			}
+			walk(f.Body)
+		}
+		if !changed {
+			break
+		}
+	}
+	return writes
+}
+
+// arenaCallWrites returns the globals a call made inside an arena block may fill
+// with memory from that block, sorted for a stable message.
+func arenaCallWrites(callee string, writes map[string]map[string]bool) []string {
+	var gs []string
+	for g := range writes[callee] {
+		gs = append(gs, g)
+	}
+	sort.Strings(gs)
+	return gs
 }

--- a/mismatch_identifier_test.go
+++ b/mismatch_identifier_test.go
@@ -148,3 +148,82 @@ func TestMismatchWithoutIdentifierUnchanged(t *testing.T) {
 		t.Fatalf("expected a type mismatch error, got %v", cerr)
 	}
 }
+
+// A mismatch must name the EXPRESSION that produced the conflicting type, not
+// only the variable that ended up with it (#551). The variable is the effect;
+// the expression is the cause, and on a long function the cause is what you have
+// to go find. No line number: MFL's canonical form is one declaration per line,
+// so every expression in a function shares one.
+func TestMismatchNamesTheConflictingBuiltin(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func hash(h, s) (o) { o = h i := 0 while i < len(s) { o = o + charat(s, i) i = i + 1 } }`,
+		`func main() { println(str(hash(7, "ab"))) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	// charat returns a string, not a byte — that is the actual mistake, and the
+	// message used to blame only the accumulator `h`.
+	if !strings.Contains(cerr.Error(), "charat(s, i)") {
+		t.Fatalf("message does not name the builtin whose return type conflicts: %q", cerr.Error())
+	}
+}
+
+// The same for a parameter whose type was fixed by an earlier call: name the
+// call that conflicts, so you do not bisect a dozen call sites by hand.
+func TestMismatchNamesTheConflictingCall(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func report(flag, name) (n) { n = 0 if flag == 1 { println(name) } }`,
+		`func main() { x := report(1, "int call") y := report(2 == 2, "bool call") println(str(x + y)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	if !strings.Contains(cerr.Error(), "report(2 == 2") {
+		t.Fatalf("message does not name the conflicting call: %q", cerr.Error())
+	}
+}
+
+// An assignment is caused by its right-hand side.
+func TestMismatchNamesTheAssignedExpression(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { steps := "a,b,c" steps = split("a,b,c", ",") println(steps[0]) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	if !strings.Contains(cerr.Error(), `split("a,b,c", ",")`) {
+		t.Fatalf("message does not name the assigned expression: %q", cerr.Error())
+	}
+}
+
+// A bare identifier or literal adds nothing the message does not already say, so
+// it must NOT be appended — the cause is only worth printing when it is a real
+// expression.
+func TestMismatchOmitsNoisyCause(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { v := 1 v = "s" println(v) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, cerr := Check(prog)
+	if cerr == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	if strings.Contains(cerr.Error(), "— from") {
+		t.Fatalf("a literal cause should be omitted as noise: %q", cerr.Error())
+	}
+}

--- a/types.go
+++ b/types.go
@@ -90,6 +90,14 @@ type Checker struct {
 	externs map[string]*ExternFunc // foreign C functions, by name
 
 	pairs []int      // flattened pairs: pairs[2i], pairs[2i+1]
+	// pairSrc[i] is the expression that generated pairs[2i]/pairs[2i+1], kept as
+	// an AST node and rendered only on failure (#551). When unification fails,
+	// the failing constraint IS the conflicting use — naming it is the whole
+	// difference between "'h' is num vs string" and "the string comes from
+	// charat(s, i)". Not a line number: MFL's canonical form is one declaration
+	// per line, so every expression inside a function shares its line.
+	pairSrc []Expr
+	curExpr Expr // expression being constraint-generated; recorded by addPair
 	plus  []plusCons // overloaded '+' constraints, resolved by fixpoint
 
 	lenArgs   []int      // slots passed to len(); must resolve to string/slice/map
@@ -185,7 +193,10 @@ type indexUse struct {
 	result int
 }
 
-type plusCons struct{ l, r, res int }
+type plusCons struct {
+	l, r, res int
+	src       Expr // the `+` expression, for the #551 mismatch cause
+}
 
 // funcSig is a function value's signature: parameter slots and a single return
 // slot (ret < 0 means void).
@@ -868,7 +879,10 @@ func (c *Checker) sigString(inst string) string {
 	return b.String()
 }
 
-func (c *Checker) addPair(a, b int) { c.pairs = append(c.pairs, a, b) }
+func (c *Checker) addPair(a, b int) {
+	c.pairs = append(c.pairs, a, b)
+	c.pairSrc = append(c.pairSrc, c.curExpr)
+}
 
 // checkTypeName validates that a declared type string is known.
 func (c *Checker) checkTypeName(t string) error {
@@ -1112,7 +1126,31 @@ func (c *Checker) slotVar(slot int) (string, bool) {
 // identifier — and, via the enclosing function, the declaration `check` maps to a
 // line — removes the guesswork. Non-mismatch errors and anonymous slots pass
 // through unchanged.
-func (c *Checker) annotateMismatch(err error, a, b int) error {
+// pairSrcAt returns the expression behind pairs[i]/pairs[i+1], or nil.
+func (c *Checker) pairSrcAt(i int) Expr {
+	if j := i / 2; j < len(c.pairSrc) {
+		return c.pairSrc[j]
+	}
+	return nil
+}
+
+// mismatchCause renders the expression that produced the failing constraint,
+// but only when it actually adds information: a bare identifier or literal just
+// repeats what the message already says, and naming it would be noise.
+func mismatchCause(e Expr) string {
+	switch e.(type) {
+	case nil, *Ident, *IntLit, *FloatLit, *StringLit, *BoolLit:
+		return ""
+	}
+	r := &renderer{complete: true}
+	src := r.expr(e, 0)
+	if len(src) > 60 {
+		src = src[:57] + "..."
+	}
+	return src
+}
+
+func (c *Checker) annotateMismatch(err error, a, b int, src Expr) error {
 	msg := err.Error()
 	if !strings.HasPrefix(msg, "type mismatch: ") {
 		return err
@@ -1134,9 +1172,17 @@ func (c *Checker) annotateMismatch(err error, a, b int) error {
 		// (issue #551). Say so, since a reader with Go instincts expects two
 		// independent block-local variables. Only append this hint when a `:=`
 		// redeclaration is actually involved — otherwise it is a red herring.
-		return fmt.Errorf("type mismatch for %s: %s; := does not shadow — variables are function-scoped", who, detail)
+		return fmt.Errorf("type mismatch for %s: %s%s; := does not shadow — variables are function-scoped", who, detail, causeSuffix(src))
 	}
-	return fmt.Errorf("type mismatch for %s: %s", who, detail)
+	return fmt.Errorf("type mismatch for %s: %s%s", who, detail, causeSuffix(src))
+}
+
+// causeSuffix formats the conflicting expression for an error message.
+func causeSuffix(src Expr) string {
+	if cause := mismatchCause(src); cause != "" {
+		return " — from " + cause
+	}
+	return ""
 }
 
 func (c *Checker) solve() error {
@@ -1145,7 +1191,7 @@ func (c *Checker) solve() error {
 		for i := 0; i+1 < len(c.pairs); i += 2 {
 			ch, err := c.union(c.pairs[i], c.pairs[i+1])
 			if err != nil {
-				return c.annotateMismatch(err, c.pairs[i], c.pairs[i+1])
+				return c.annotateMismatch(err, c.pairs[i], c.pairs[i+1], c.pairSrcAt(i))
 			}
 			changed = changed || ch
 		}
@@ -1161,11 +1207,11 @@ func (c *Checker) solve() error {
 			}
 			ch1, err := c.union(a, b)
 			if err != nil {
-				return c.annotateMismatch(err, a, b)
+				return c.annotateMismatch(err, a, b, p.src)
 			}
 			ch2, err := c.union(p.res, p.l)
 			if err != nil {
-				return c.annotateMismatch(err, p.res, p.l)
+				return c.annotateMismatch(err, p.res, p.l, p.src)
 			}
 			changed = changed || ch1 || ch2
 		}
@@ -1187,6 +1233,11 @@ func (c *Checker) genStmt(fn *FuncDecl, s Stmt) error {
 		if err != nil {
 			return err
 		}
+		// An assignment's constraint is caused by its right-hand side (#551):
+		// `steps = split(...)` should blame split, not the bare name.
+		prevAssign := c.curExpr
+		c.curExpr = st.Val
+		defer func() { c.curExpr = prevAssign }()
 		if st.Name == "_" {
 			// the blank identifier discards the value: never readable, never
 			// allocated as a local, and it counts as neither a new binding nor
@@ -1416,7 +1467,10 @@ func (c *Checker) genExpr(fn *FuncDecl, e Expr) (int, error) {
 	if s, ok := ns[e]; ok {
 		return s, nil
 	}
+	prev := c.curExpr
+	c.curExpr = e
 	slot, err := c.genExprInner(fn, e)
+	c.curExpr = prev
 	if err != nil {
 		return 0, err
 	}
@@ -1602,7 +1656,7 @@ func (c *Checker) genBinary(fn *FuncDecl, ex *Binary) (int, error) {
 	switch ex.Op {
 	case "+":
 		res := newSlot(c, KVar)
-		c.plus = append(c.plus, plusCons{l: ls, r: rs, res: res})
+		c.plus = append(c.plus, plusCons{l: ls, r: rs, res: res, src: ex})
 		return res, nil
 	case "-", "*", "/":
 		c.addPair(ls, rs)


### PR DESCRIPTION
Closes #539.

```
var g_cache = []string{}
func build_cache() { out := []string{} … g_cache = out }
func main()        { arena { build_cache() }  println(g_cache[0]) }
```

```
before:  machin check → ok — no errors        (program prints len=200, first=[])
after:   warning: [ARENA001] `g_cache` outlives this arena block but
         `build_cache()` assigns it a value allocated inside it — it dangles
         after the block's memory is reclaimed
```

Re-verified reproducing on v0.124.1 before starting. Silent wrong data, exit 0 — the length
still reads right while the contents are freed memory. This is the shape that segfaulted grange.

### Approach

`computeRetProv` already answers *"does calling f RETURN arena memory"*. This adds
**`computeGlobalWrites`**, the write-side companion: per function, which globals it may assign
**freshly-allocated** heap to, directly or through a call, to a fixpoint over the call graph.
A call statement inside an arena block then reports the globals its callee fills. Two hops work
because it is a fixpoint, and there is a test for that.

### The `fresh` gate, and why it defaults to false

The issue proposed a cheaper interim — flag *any* global assignment reachable from a call inside
`arena { }`, accepting false positives. **I did not take that**, because `carriesArena` in
`arena_check.go` defaults to `false` and this repo treats a finding as something you can act on.
A warning that cries wolf gets filtered out, and the real one goes with it.

My first draft *did* default to `true`, and it immediately produced a false positive on
`g = "constant"` — a string literal is static storage, not arena memory. I caught that in a
false-positive sweep before writing any tests, and matched the existing convention instead.

Six no-flag cases are pinned by tests:

| case | flags? |
|---|---|
| global = a literal | no |
| global = a parameter | no |
| global = another global | no |
| callee writes no global | no |
| the write is outside any arena | no |
| `g = escape(out)` — the sanctioned way out | no |

### Honest limit

Still false-negative-permitting, unchanged from v1: an allocating form not enumerated in
`fresh` is missed. That is the trade this analysis has always made, and it is what keeps every
finding real.

**#540 remains open** — `arena_reset()` corrupting computed globals is the other half of the
same hazard and is not addressed here.

### Verification

Full suite green (192s). One note: `TestSocketTimeout` failed once under full-suite load and
passes alone — a timing flake unrelated to this diff, which touches only the arena analysis.
Same class as `TestMachwebMultipartUpload` earlier today; worth an issue if either recurs.
