### PR TITLE
release: v0.125.0 — two new arena findings, zlib, and diagnostics that name the cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,84 @@
 
 ## Unreleased
 
+## v0.125.0
+
+Two new compile-time findings, a new builtin pair, and three diagnostics that
+stop naming the wrong thing. Every item came from working an issue by hand
+rather than from a feature plan.
+
+**`zlib_compress` / `zlib_decompress`** (PR #544, issue #537). A codec over
+`bytes`, matching the existing `bytes_*` style. `-lz` links **only when a program
+calls them**, the same feature-gate the OpenSSL prelude uses, so the
+no-dependency-binary property is untouched for everything else; the windows
+target refuses with a named reason until a mingw libz is wired. Verified
+**bidirectionally against Go's `compress/zlib`** — MFL-compressed data decodes in
+Go and vice versa — which is the point, since the use case is reading blobs that
+are already on disk.
+
+**ARENA001 now sees through a call** (PR #573, issue #539). It caught
+`g = out` written literally inside an `arena { }`, but not the identical
+assignment one frame deeper:
+
+```
+func build() { out := []string{} … g_cache = out }
+func main()  { arena { build() }  println(g_cache[0]) }
+```
+
+which is the normal way to write MFL. `machin check` said "ok — no errors" while
+the program printed a length of 200 with empty contents: silent wrong data,
+exit 0. It segfaulted grange in production-shaped use. `computeGlobalWrites` is
+the write-side companion to the existing return-provenance summary — per
+function, which globals it may fill with freshly-allocated heap, to a fixpoint
+over the call graph.
+
+**ARENA003: a value still live across `arena_reset()`** (PR #574, issue #540).
+The reset frees the arena wholesale and trusts you to have dropped every live
+reference. What survives was documented but not diagnosed: literals, `env()` and
+`args()` are re-derivation sources off the arena chain and survive; a **computed**
+value is corrupted — a global built as `"tok-" + env("T") + "-end"` read back as
+`1` after a reset plus allocation churn, with no crash and no diagnostic. Now
+reported. It also covers **locals**, which neither the issue nor the guide table
+mentioned and which corrupt identically; a local is flagged only when it is
+actually read after the reset.
+
+Both arena checks share one freshness predicate that defaults to **false** — a
+literal, a parameter, another global or `escape()` is never flagged. Fourteen
+no-flag cases are pinned by tests. Still false-negative-permitting, as this
+analysis has always been: every finding is real, not every hazard is found.
+
+**A type mismatch names the expression that caused it** (PR #572, issue #551).
+
+```
+before: type mismatch for 'h' in "hash": num vs string
+after:  type mismatch for 'h' in "hash": num vs string — from o + charat(s, i)
+```
+
+`charat` returns a string, not a byte — that is the actual mistake, and the
+message used to blame only the accumulator. A parameter conflict now names the
+**call site** that disagrees, so you stop bisecting callers by hand. No line
+numbers: MFL's canonical form is one declaration per line, so every expression in
+a function shares one, and a number would have pointed at all of them equally.
+
+**A parameter sharing its function's named-return name is rejected** (PR #550,
+issue #546). It used to reach the C compiler and fail there:
+`'v_v' redeclared as different kind of symbol`. Now
+`parameter "v" has the same name as a named return value`, at the type-checking
+stage, for any type. Same class as the mismatch fix — an error that named a
+generated C symbol instead of anything in your program.
+
+**CI runs the windows and wasm target tests instead of skipping them**
+(PR #571, issue #517). `--target windows` was broken from v0.122.0 to v0.124.0
+with CI green throughout, and it was not a coverage gap: `go test ./...` ran
+before the zig install, and those tests `t.Skipf` when zig is missing. They were
+red on every developer machine and invisible in CI. The install is hoisted above
+the test step, and a windows smoke build now sits next to the wasm one, covering
+the file/dir I/O family where both breakages landed.
+
+Also: the `arena_reset()` persistence rule is documented in `SPEC.md` and the
+guide (PR #545), now updated to say it is diagnosed and that locals are affected
+too.
+
 ## v0.124.1
 
 Patch: **a closure could not reference a slice inside a range bound** (PR #567).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.124.1-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.125.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.124.1
+Version 0.125.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.124.1"
+const machinVersion = "0.125.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Cuts **v0.125.0** over the seven PRs merged since v0.124.1.

Bumps `guide.go` / `README.md` / `SPEC.md` and adds the CHANGELOG section. No bundled skill
changed, so `tools/sync-plugin-skills.sh` is a no-op this time.

**Verification:** full `go test ./...` green — 153s, zero failures.

### Note on timing

GitHub Actions is in a **major outage** (`Actions: major_outage`, incident open). Two
consequences:

1. This PR's `test` check may not run at all — #574 got no workflow run created, and neither an
   empty commit nor a close/reopen produced one.
2. More importantly, **the tag must wait**. Pushing `v0.125.0` triggers `release.yml`, which
   cross-compiles and publishes the binaries; with Actions down that yields a tag with no
   artifacts. Per the checklist (as corrected in #571), the tag goes on the squashed commit
   *after* this merges — and I will hold it until Actions is healthy so the release actually
   ships binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.125.0.
  * Documented zlib compression and decompression built-ins.
  * Documented improved arena-related diagnostics and reset behavior.
  * Updated the language specification, README, and toolchain version to 0.125.0.
  * Documented enhanced type-mismatch and named-return diagnostics.
  * Added Windows and WebAssembly test execution details to CI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->