### PR TITLE
test(lexer): pin underscore separators in bit-pattern literals (#556 follow-up)

### DIFF
--- a/lexer_underscore_test.go
+++ b/lexer_underscore_test.go
@@ -136,3 +136,45 @@ func TestUnderscoreLiteralDoesNotSwallowIdentifier(t *testing.T) {
 		}
 	}
 }
+
+// v0.124.0 (#556) made a hex/binary/octal literal whose top bit is set parse as
+// its two's-complement value, so constants like the FNV-1a offset basis are
+// writable at all. Underscore separators keep working through that path — it
+// falls out of strconv.ParseUint(base 0) rather than being deliberate, so pin it
+// before someone rewrites the fallback and silently drops it.
+func TestLexBitPatternLiteralWithUnderscores(t *testing.T) {
+	cases := []struct {
+		src  string
+		want int64
+	}{
+		{"0x9E37_79B9_7F4A_7C15", -7046029254386353131}, // golden-ratio mixer
+		{"0xCBF2_9CE4_8422_2325", -3750763034362895579}, // FNV-1a 64 offset basis
+		{"0xFFFF_FFFF_FFFF_FFFF", -1},
+		{"0x2545_F491_4F6C_DD1D", 2685821657736338717}, // top bit clear: unchanged
+	}
+	for _, c := range cases {
+		toks, err := Lex(c.src)
+		if err != nil {
+			t.Errorf("Lex(%q) error: %v", c.src, err)
+			continue
+		}
+		if len(toks) != 2 || toks[0].Kind != TInt || toks[0].Val != c.src {
+			t.Errorf("Lex(%q) = %+v, want a single TInt preserving the raw literal", c.src, toks)
+			continue
+		}
+		p := &Parser{toks: toks}
+		e, err := p.parsePrimary()
+		if err != nil {
+			t.Errorf("parse(%q): %v", c.src, err)
+			continue
+		}
+		lit, ok := e.(*IntLit)
+		if !ok {
+			t.Errorf("parse(%q) = %T, want *IntLit", c.src, e)
+			continue
+		}
+		if lit.Val != c.want {
+			t.Errorf("parse(%q) = %d, want %d", c.src, lit.Val, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Two purposes, one small diff.

### 1. Closes a gap I flagged reviewing #562

v0.124.0 made a hex/binary/octal literal with the top bit set parse as its two's-complement
value (#556), so `0x9E3779B97F4A7C15` and `0xCBF29CE484222325` are writable at all. Underscore
separators keep working through that path — but only because `strconv.ParseUint(base 0)`
happens to accept them. It is **inherited, not deliberate**, and nothing covered it, while the
repo has a dedicated `lexer_underscore_test.go` for exactly this.

Pinned now, so a future rewrite of the fallback cannot silently drop grouping from the
constants that need it most.

```
0x9E37_79B9_7F4A_7C15  → -7046029254386353131   (golden-ratio mixer)
0xCBF2_9CE4_8422_2325  → -3750763034362895579   (FNV-1a 64 offset basis)
0xFFFF_FFFF_FFFF_FFFF  → -1
0x2545_F491_4F6C_DD1D  →  2685821657736338717   (top bit clear: unchanged)
```

### 2. Gives `main` the CI run it never got

#574 and #575 were merged during the **GitHub Actions major outage** with an `enforce_admins`
bypass (approved, with the protection restored and verified field-by-field each time). No
workflow runs were created at all during the outage, and `ci.yml` only triggers on `push` to
main or `pull_request` — so `main`'s current tree, including the v0.125.0 release commit, has
never had a green check.

Local verification stood in for it at the time: full suite green on the exact merged tree
before tagging, plus behavioural checks against the published binary. But that is one machine
and one platform; CI also runs the examples smoke test and the wasm/windows cross-builds. This
PR's run covers the tree properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for hexadecimal integer literals containing underscores.
  * Verified literals remain intact as single integer tokens.
  * Confirmed parsing produces the expected signed and positive 64-bit values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->