### PR TITLE
feat: sort / sort_by builtins (#580)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -294,6 +294,8 @@ startup (before `main`; at `_initialize` for a wasm reactor).
 | math | `(number[, number]) -> float` | native libm (linked `-lm` only when used): `sin` `cos` `tan` `asin` `acos` `atan` `atan2` `sqrt` `cbrt` `pow` `exp` `log` `log2` `log10` `floor` `ceil` `round` `trunc` `abs` `fmod` `hypot`, and `pi()`. Numeric in, `float` out. An `extern` of the same name shadows the builtin. |
 | `noise2`/`noise3` | `(number, ...) -> float` | Perlin gradient noise (2D / 3D), deterministic, ~`[-1,1]`, smooth. Layer it (fbm) for procedural terrain. Links `-lm`; emitted only when used. |
 | `append` | `([]T, T) -> []T` | grow a slice |
+| `sort` | `([]int\|[]float\|[]string) -> []T` | stable ascending sort |
+| `sort_by` | `([]T, (T T) -> bool) -> []T` | stable sort by a comparator `less(a, b)` |
 | `has`, `delete` | `(map, K) -> bool` / `-> ` | membership / removal |
 | `keys` | `(map[K]V) -> []K` | a map's keys |
 | `json` | `(any) -> string` | serialize to JSON |

--- a/codegen.go
+++ b/codegen.go
@@ -100,6 +100,8 @@ type cgen struct {
 	c            *Checker
 	buf          strings.Builder // function bodies
 	tramp        strings.Builder // goroutine trampolines
+	helpers      strings.Builder // generated per-call helper functions (e.g. sort_by comparators)
+	sortByID     int             // unique ids for sort_by comparator helpers
 	goID         int
 	jsonFns      strings.Builder      // generated per-type JSON serializers + parsers
 	jsonMemo     map[string]string    // type string -> serializer function name
@@ -999,6 +1001,62 @@ static mfl_slice mfl_map_keys(mfl_map* m) {
 // the string ops treat NULL as "" rather than dereferencing it.
 static const char* mfl_s(const char* s) { return s ? s : ""; }
 static int mfl_strcmp(const char* a, const char* b) { return strcmp(mfl_s(a), mfl_s(b)); }
+/* sort / sort_by: stable bottom-up merge sort. sort_by is generic over element
+   size and a comparator callback; the built-in sort() forms use the same path.
+   Both return a NEW slice: MFL slices share backing storage, so sorting in place
+   would silently reorder every alias. The input is copied before sorting. */
+static mfl_slice mfl_sort_by(mfl_slice s, int64_t es, mfl_closure* c, int (*cmp)(mfl_closure*, const void*, const void*)) {
+    mfl_slice res = s;
+    if (s.len > 0) {
+        res.data = mfl_alloc(s.len * es);
+        res.cap = s.len;
+        memcpy(res.data, s.data, s.len * es);
+    } else {
+        res.data = NULL;
+        res.cap = 0;
+    }
+    if (s.len <= 1) return res;
+    char* tmp = (char*)mfl_alloc(s.len * es);
+    char* src = (char*)res.data;
+    char* dst = tmp;
+    for (int64_t w = 1; w < s.len; w *= 2) {
+        for (int64_t i = 0; i < s.len; i += 2 * w) {
+            int64_t l = i, m = i + w, r = i + 2 * w;
+            if (m > s.len) m = s.len;
+            if (r > s.len) r = s.len;
+            int64_t p = l, q = m, k = l;
+            while (p < m && q < r) {
+                int cr = cmp(c, src + p * es, src + q * es);
+                if (cr <= 0) {
+                    memcpy(dst + k * es, src + p * es, es); p++; k++;
+                } else {
+                    memcpy(dst + k * es, src + q * es, es); q++; k++;
+                }
+            }
+            while (p < m) { memcpy(dst + k * es, src + p * es, es); p++; k++; }
+            while (q < r) { memcpy(dst + k * es, src + q * es, es); q++; k++; }
+        }
+        char* t = src; src = dst; dst = t;
+    }
+    if (src != (char*)res.data) memcpy(res.data, src, s.len * es);
+    return res;
+}
+static int mfl_sortcmp_i(mfl_closure* c, const void* a, const void* b) {
+    int64_t av = *(int64_t*)a, bv = *(int64_t*)b;
+    return av <= bv ? -1 : 1;
+}
+static int mfl_sortcmp_d(mfl_closure* c, const void* a, const void* b) {
+    double av = *(double*)a, bv = *(double*)b;
+    return av <= bv ? -1 : 1;
+}
+static int mfl_sortcmp_s(mfl_closure* c, const void* a, const void* b) {
+    char* av = *(char**)a;
+    char* bv = *(char**)b;
+    return mfl_strcmp(av, bv) <= 0 ? -1 : 1;
+}
+static mfl_slice mfl_sort_i(mfl_slice s) { return mfl_sort_by(s, sizeof(int64_t), NULL, mfl_sortcmp_i); }
+static mfl_slice mfl_sort_d(mfl_slice s) { return mfl_sort_by(s, sizeof(double), NULL, mfl_sortcmp_d); }
+static mfl_slice mfl_sort_s(mfl_slice s) { return mfl_sort_by(s, sizeof(char*), NULL, mfl_sortcmp_s); }
 static char* mfl_cat(const char* a, const char* b) {
     a = mfl_s(a); b = mfl_s(b);
     size_t la = strlen(a), lb = strlen(b);
@@ -4392,6 +4450,7 @@ func (g *cgen) program(p *Program) (string, error) {
 	}
 	out.WriteByte('\n')
 	out.WriteString(g.tramp.String())
+	out.WriteString(g.helpers.String())
 	out.WriteString(g.buf.String())
 	// package-global initializers run in a C constructor — before main (native) and
 	// at _initialize (wasm reactor). Compile each init into a scratch buffer so any
@@ -6606,6 +6665,19 @@ func (g *cgen) callBody(ex *Call, args []string) (string, error) {
 	case "tls_close":
 		g.usesTLS = true
 		return fmt.Sprintf("mfl_tls_close_h(%s)", args[0]), nil
+	case "sort":
+		ct := g.c.ElemCType(g.curFn, ex.Args[0])
+		switch ct {
+		case "int64_t":
+			return fmt.Sprintf("mfl_sort_i(%s)", args[0]), nil
+		case "double":
+			return fmt.Sprintf("mfl_sort_d(%s)", args[0]), nil
+		case "char*":
+			return fmt.Sprintf("mfl_sort_s(%s)", args[0]), nil
+		}
+		return "", fmt.Errorf("sort: element type %s has no ordering — use sort_by(xs, less) and say how to compare them", ct)
+	case "sort_by":
+		return g.genSortBy(args[0], args[1], ex.Args[0], ex.Args[1])
 	case "print", "println":
 		return "", fmt.Errorf("print/println may only be used as a statement")
 	}
@@ -6654,4 +6726,34 @@ func (g *cgen) closureCall(clos string, paramCTypes []string, retCType string, a
 		callArgs += ", " + a
 	}
 	return fmt.Sprintf("({ mfl_closure _c%d = %s; ((%s(*)%s)_c%d.fn)(%s); })", id, clos, retCType, fnSig, id, callArgs)
+}
+
+// genSortBy emits a sort_by call. It mints a per-call comparator helper that
+// knows the slice element's C type and calls the MFL closure with the right
+// signature; the helper is placed in g.helpers so it is defined before the
+// function bodies that use it.
+func (g *cgen) genSortBy(sliceArg, cmpArg string, sliceExpr, cmpExpr Expr) (string, error) {
+	ect := g.c.ElemCType(g.curFn, sliceExpr)
+	params, ret := g.c.NodeFuncSig(g.curFn, cmpExpr)
+	if len(params) != 2 {
+		return "", fmt.Errorf("sort_by: comparator must take two arguments")
+	}
+	g.sortByID++
+	hname := fmt.Sprintf("mfl_sortcmp_%d", g.sortByID)
+	fnType := fmt.Sprintf("%s (*)(void*, %s, %s)", ret, params[0], params[1])
+	var b strings.Builder
+	fmt.Fprintf(&b, "static int %s(mfl_closure* _c, const void* _a, const void* _b) {\n", hname)
+	fmt.Fprintf(&b, "    %s a = *(%s*)_a;\n", ect, ect)
+	fmt.Fprintf(&b, "    %s b = *(%s*)_b;\n", ect, ect)
+	fmt.Fprintf(&b, "    mfl_closure c = *_c;\n")
+	fmt.Fprintf(&b, "    int ab = ((%s)c.fn)(c.env, a, b);\n", fnType)
+	fmt.Fprintf(&b, "    if (ab) return -1;\n")
+	fmt.Fprintf(&b, "    int ba = ((%s)c.fn)(c.env, b, a);\n", fnType)
+	fmt.Fprintf(&b, "    if (ba) return 1;\n")
+	fmt.Fprintf(&b, "    return 0;\n")
+	fmt.Fprintf(&b, "}\n")
+	g.helpers.WriteString(b.String())
+	id := g.tmpID
+	g.tmpID++
+	return fmt.Sprintf("({ mfl_slice _s%d = %s; mfl_closure _c%d = %s; mfl_sort_by(_s%d, (int64_t)sizeof(%s), &_c%d, %s); })", id, sliceArg, id, cmpArg, id, ect, id, hname), nil
 }

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -389,6 +389,8 @@ first := users[0]                                // value copy
 | `time_make(y, mo, d, h, mi, s)` | build a unix timestamp from local calendar fields; inverse of `time_fields` |
 | `len(x)`                    | length of a slice or string                  |
 | `append(xs, v)`             | return `xs` with `v` appended                |
+| `sort(xs)`                  | stable ascending sort of an int/float/string slice |
+| `sort_by(xs, less)`         | stable sort by comparator `less(a, b)`       |
 | `has(m, k)`                 | whether map `m` contains key `k`             |
 | `delete(m, k)`              | remove key `k` from map `m`                  |
 | `keys(m)`                   | a slice of map `m`'s keys                    |

--- a/guide.go
+++ b/guide.go
@@ -297,6 +297,8 @@ func machinGuide() guideCatalog {
 			// collections
 			{"len", "(string|slice|map) -> int", "length", "collection"},
 			{"append", "([]T, T) -> []T", "grow a slice", "collection"},
+			{"sort", "([]int|[]float|[]string) -> []T", "stable ascending sort of an int/float/string slice", "collection"},
+			{"sort_by", "([]T, (T T) -> bool) -> []T", "stable sort by a comparator function less(a, b)", "collection"},
 			{"has", "(map, K) -> bool", "key membership", "collection"},
 			{"delete", "(map, K) ->", "remove a key", "collection"},
 			{"keys", "(map[K]V) -> []K", "a map's keys", "collection"},

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// sort / sort_by (#580). Before these existed, every program needing ordered
+// output hand-rolled a comparison loop — which cost tokens, and which an agent
+// under time pressure writes as an O(n^2) selection sort.
+
+func TestSortOrderedElementTypes(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    println("ints=" + json(sort([]int{5, 3, 9, 1, 3})))
+    println("strs=" + json(sort([]string{"pear", "apple", "fig"})))
+    println("floats=" + json(sort([]float{2.5, 1.5, 9.0})))
+    println("empty=" + json(sort([]int{})))
+    println("one=" + json(sort([]int{7})))
+    println("negatives=" + json(sort([]int{0, -5, 3, -1})))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"ints=[1,3,3,5,9]",
+		`strs=["apple","fig","pear"]`,
+		"floats=[1.5,2.5,9]",
+		"empty=[]",
+		"one=[7]",
+		"negatives=[-5,-1,0,3]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// sort() returns a NEW slice. MFL slices share backing storage, so sorting in
+// place would silently reorder every alias — the same hazard that made in-place
+// realloc unsound in #578. The input must be observably untouched.
+func TestSortDoesNotMutateInputOrAliases(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    xs := []int{5, 3, 9, 1}
+    alias := xs
+    sorted := sort(xs)
+    println("sorted=" + json(sorted))
+    println("orig=" + json(xs))
+    println("alias=" + json(alias))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"sorted=[1,3,5,9]",
+		"orig=[5,3,9,1]",
+		"alias=[5,3,9,1]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestSortByComparator(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    xs := []int{5, 3, 9, 1}
+    println("desc=" + json(sort_by(xs, func(a, b) { return a > b })))
+    println("asc=" + json(sort_by(xs, func(a, b) { return a < b })))
+    ss := []string{"ccc", "a", "bb"}
+    println("bylen=" + json(sort_by(ss, func(a, b) { return len(a) < len(b) })))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{
+		"desc=[9,5,3,1]",
+		"asc=[1,3,5,9]",
+		`bylen=["a","bb","ccc"]`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// The comparator asks "must b precede a?" exactly once per comparison, which is
+// what makes the merge stable: when neither element is less than the other the
+// predicate is false and the earlier element is taken first. Equal keys must
+// therefore come out in input order.
+func TestSortByIsStable(t *testing.T) {
+	prog := progFromSrc(t, `
+type P struct { name string  age int }
+
+func main() {
+    ps := []P{}
+    ps = append(ps, P{name: "zoe", age: 30})
+    ps = append(ps, P{name: "amy", age: 25})
+    ps = append(ps, P{name: "bob", age: 30})
+    ps = append(ps, P{name: "cid", age: 25})
+    out := ""
+    for _, p := range sort_by(ps, func(a, b) { return a.age < b.age }) {
+        out = out + p.name + " "
+    }
+    println("order=" + out)
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// amy/cid are both 25 and amy came first; zoe/bob are both 30 and zoe came first.
+	if !strings.Contains(out, "order=amy cid zoe bob") {
+		t.Fatalf("unstable sort, got:\n%s", out)
+	}
+}
+
+// A closure that captures state must work as a comparator — the environment
+// travels through mfl_sort_by's closure pointer and back out in the generated bridge.
+func TestSortByCapturingClosure(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    rank := make(map[string]int)
+    rank["low"] = 1
+    rank["mid"] = 2
+    rank["high"] = 3
+    xs := []string{"high", "low", "mid"}
+    println("byrank=" + json(sort_by(xs, func(a, b) { return rank[a] < rank[b] })))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out, `byrank=["low","mid","high"]`) {
+		t.Fatalf("captured comparator failed:\n%s", out)
+	}
+}
+
+// sort() on an element type with no natural ordering must be refused at compile
+// time, and the message must point at the fix rather than just saying "no".
+func TestSortRejectsUnorderedElementType(t *testing.T) {
+	prog := progFromSrc(t, `
+type P struct { name string  age int }
+
+func main() {
+    ps := []P{}
+    ps = append(ps, P{name: "a", age: 1})
+    println(len(sort(ps)))
+}`)
+	bin, ferr := os.CreateTemp("", "mfl-sort-*")
+	if ferr != nil {
+		t.Fatal(ferr)
+	}
+	bin.Close()
+	defer os.Remove(bin.Name())
+	err := BuildBinary(prog, bin.Name(), false)
+	if err == nil {
+		t.Fatal("expected sort() on a struct slice to be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no ordering") || !strings.Contains(msg, "sort_by") {
+		t.Fatalf("error should name the fix (sort_by), got: %s", msg)
+	}
+}
+
+// Sorting a large slice exercises the merge's width doubling past the first pass
+// and confirms the result is fully ordered, not just locally.
+func TestSortLargeSliceFullyOrdered(t *testing.T) {
+	prog := progFromSrc(t, `
+func main() {
+    xs := []int{}
+    i := 0
+    while i < 500 {
+        xs = append(xs, (i * 7919) % 1001)
+        i = i + 1
+    }
+    s := sort(xs)
+    bad := 0
+    j := 1
+    while j < len(s) {
+        if s[j] < s[j-1] { bad = bad + 1 }
+        j = j + 1
+    }
+    println("n=" + str(len(s)))
+    println("out_of_order=" + str(bad))
+}`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, want := range []string{"n=500", "out_of_order=0"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/types.go
+++ b/types.go
@@ -102,6 +102,7 @@ type Checker struct {
 
 	lenArgs   []int      // slots passed to len(); must resolve to string/slice/map
 	strArgs   []int      // slots passed to str(); must resolve to a number, bool, or string
+	sortArgs  []sortArg  // sort() element slots and sort_by() comparators, validated after solve
 	fieldUses []fieldUse // struct field access/assign, resolved after solve
 	indexUses []indexUse // x[i] access/assign, resolved after solve (slice or map)
 	rangeUses []rangeUse // for-range loops, resolved after solve
@@ -203,6 +204,13 @@ type plusCons struct {
 type funcSig struct {
 	params []int
 	ret    int
+}
+
+// sortArg records a slice element slot (and optional comparator slot) so
+// sort/sort_by can be validated after the element type is fully resolved.
+type sortArg struct {
+	elem int
+	cmp  int // -1 for sort(), the comparator slot for sort_by()
 }
 
 // fieldUse defers a struct field access/assignment: once base resolves to a
@@ -847,6 +855,29 @@ func Check(p *Program) (*Checker, error) {
 	for _, slot := range c.strArgs {
 		if k := c.kindOf(slot); !isNumeric(k) && k != KBool && k != KString {
 			return nil, fmt.Errorf("str: argument must be a number, bool, or string, got %s", k)
+		}
+	}
+	// 5c. validate sort()/sort_by() after the element type is resolved.
+	for _, a := range c.sortArgs {
+		if a.cmp < 0 {
+			// sort(): the slice element must be one of the directly-supported kinds.
+			k := c.kindOf(a.elem)
+			if k != KInt && k != KFloat && k != KString {
+				return nil, fmt.Errorf("sort: element type %s has no ordering — use sort_by(xs, less) and say how to compare them", k)
+			}
+			continue
+		}
+		// sort_by(): the comparator must be a (T, T) -> bool function.
+		if c.kindOf(a.cmp) != KFunc {
+			return nil, fmt.Errorf("sort_by: comparator must be a function, got %s", c.kindOf(a.cmp))
+		}
+		r := c.find(a.cmp)
+		sig := c.fsig[r]
+		if sig == nil || len(sig.params) != 2 || c.find(sig.params[0]) != c.find(a.elem) || c.find(sig.params[1]) != c.find(a.elem) {
+			return nil, fmt.Errorf("sort_by: comparator must be a function of the slice element type")
+		}
+		if c.kindOf(sig.ret) != KBool {
+			return nil, fmt.Errorf("sort_by: comparator must return bool")
 		}
 	}
 	// 6. dedup instances by concrete signature and assign C names
@@ -2144,6 +2175,28 @@ func (c *Checker) genCall(fn *FuncDecl, ex *Call) (int, error) {
 			return 0, err
 		}
 		c.addPair(argSlots[1], eslot)
+		return argSlots[0], nil
+	case "sort":
+		if len(argSlots) != 1 {
+			return 0, fmt.Errorf("sort: 1 arg")
+		}
+		eslot, err := c.sliceElem(argSlots[0])
+		if err != nil {
+			return 0, err
+		}
+		c.sortArgs = append(c.sortArgs, sortArg{elem: eslot, cmp: -1})
+		return argSlots[0], nil
+	case "sort_by":
+		if len(argSlots) != 2 {
+			return 0, fmt.Errorf("sort_by: 2 args")
+		}
+		eslot, err := c.sliceElem(argSlots[0])
+		if err != nil {
+			return 0, err
+		}
+		fsig := newFuncSlot(c, &funcSig{params: []int{eslot, eslot}, ret: c.cBool})
+		c.addPair(argSlots[1], fsig)
+		c.sortArgs = append(c.sortArgs, sortArg{elem: eslot, cmp: argSlots[1]})
 		return argSlots[0], nil
 	case "sleep":
 		if len(argSlots) != 1 {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix open GitHub issues. Small PRs, conventional commits.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #577 (am/am-7b5889-dkidr8jtcv78-d28a4fc8): [needs work] fix(windows): enable XEdDSA (xeddsa_sign/verify) on the Windows target
    touches: build.go, codegen.go, guide.go, main.go, windows_target_test.go


**Branch:** `am/am-7b5889-dkj1a1zi5nb0-c57763ed`

**Diff:**
```
SPEC.md          |   2 +
 codegen.go       | 102 ++++++++++++++++++++++++++++
 docs/LANGUAGE.md |   2 +
 guide.go         |   2 +
 sort_test.go     | 201 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 types.go         |  53 +++++++++++++++
 6 files changed, 362 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable ascending sorting for integer, float, and string slices.
  - Added comparator-based stable sorting for generic slices.
  - Sorting returns a new slice without modifying the original.
  - Added validation for supported element types and comparator signatures.

- **Documentation**
  - Documented the new sorting builtins in the language specification and guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->