### PR TITLE
ci(bench): tee results to the log, not just the job summary

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -55,7 +55,7 @@ jobs:
             echo "cores: $(nproc)   load: $(cut -d' ' -f1-3 /proc/loadavg)"
             echo "gcc $(gcc -dumpversion) | $(rustc --version) | zig $(zig version)"
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: native-speed (runtime — the ratio claim under test)
         run: |
@@ -64,7 +64,7 @@ jobs:
             echo '```'
             ( cd bench/native-speed && ./run.sh 2>&1 | tail -20 )
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: compile-speed (build time + binary size)
         run: |
@@ -73,7 +73,7 @@ jobs:
             echo '```'
             ( cd bench/compile-speed && python3 measure.py 2>&1 )
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: evidence (verdicts, not timings — must be machine-independent)
         run: |
@@ -82,4 +82,4 @@ jobs:
             echo '```'
             ( cd bench/evidence && ./run.sh 2>&1 | tail -40 )
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The first bench run put its tables only in `$GITHUB_STEP_SUMMARY`. That renders nicely in the UI but has **no public API**, so the output was unreadable to `gh`, to scripts, and to the agent that dispatched the run — the log contained the shell commands and none of the numbers.

`tee` sends the same text to both.