### PR TITLE
release: v0.126.1 — ship the corrected Zig binary-size claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## Unreleased
 
+## v0.126.1
+
+No compiler changes. This ships a **correction** that was living only in the repo:
+`machin guide` had been telling every agent that machin beats Zig on static binary
+size, and it does not.
+
+**The Zig binary-size claim was wrong** (PR #588). We reported "fully static, Zig
+wins" by about 2x — 491 kB against machin's 940 kB. That 491 kB was measured on
+zig **0.16.0**, which inflates it ~32x. Measured on 0.15.2:
+
+```
+zig 0.15.2    873,760 B as-produced ->   15,760 B stripped  [static]
+zig 0.16.0  3,594,056 B as-produced ->  503,256 B stripped  [static]
+machin                                   14,544 B stripped  [dynamic]
+machin --static                         940,000 B           [static]
+```
+
+Zig's **fully static** binary is ~16 kB — about the size of machin's *dynamic*
+one, needing nothing on the target — and **~60x smaller than machin's own
+`--static` build**. So machin's binary-size win is over **Rust, not over Zig**;
+for shipping a self-contained artifact Zig is simply better at this. Corrected in
+`machin guide`, the README, `docs/BENCHMARKS.md` and `bench/compile-speed`.
+
+**The benchmark suite was verified on a second machine** (PR #588), which is how
+that error was found. `docs/BENCHMARKS.md` had been telling readers that absolute
+milliseconds are machine-specific but the *ratios* are portable — an assertion
+never tested, since every number came from one laptop with 41% worst-case
+run-to-run spread. Re-run on a GitHub runner (AMD EPYC 7763, gcc 13, rustc 1.97.1,
+zig 0.15.2, 15% spread):
+
+- **Verdicts are portable.** machin still wins recursion (26% -> 28%); mandelbrot
+  and intsum are still ties; the sieve is still a loss; every `evidence` verdict
+  (DL001, FALS001, who hangs, who traps) reproduces identically.
+- **Precise ratios are not.** The sieve gap moved 1.46x -> 1.32x, which fits its
+  cause: `append` faulting in fresh pages (#578) is the most
+  memory-subsystem-sensitive thing in the suite.
+
+Read a verdict as portable and a precise ratio as machine-specific; where the docs
+quote a ratio it is the laptop's.
+
+**A manual `bench` workflow** (PRs #586, #587) runs the suite on demand
+(`gh workflow run bench.yml`) and writes the tables to both the log and the job
+summary, so the second machine is one nobody involved controls and anyone can
+re-check the numbers.
+
 ## v0.126.0
 
 A missing builtin, and a benchmark suite that stopped flattering itself. Both

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.126.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.126.1-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.126.0
+Version 0.126.1
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.126.0"
+const machinVersion = "0.126.1"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
No compiler changes. This exists to get a correction out of the repo and into users' binaries: `machin guide` had been telling every agent that machin beats Zig on static binary size, and **it does not**.

```
zig 0.15.2    873,760 B as-produced ->   15,760 B stripped  [static]
zig 0.16.0  3,594,056 B as-produced ->  503,256 B stripped  [static]
machin                                   14,544 B stripped  [dynamic]
machin --static                         940,000 B           [static]
```

Zig's **fully static** binary is ~16 kB — about the size of machin's *dynamic* one, needing nothing on the target — and **~60× smaller than machin's own `--static` build**. machin's size win is over **Rust, not Zig**. The guide catalog is compiled into the binary, so a release is the only way that correction reaches anyone.

Also records the second-machine verification that caught it (#588) and the manual bench workflow that ran it (#586, #587).

Version bumped in all four guarded/unguarded places: `guide.go`, README badge, `SPEC.md`, `CHANGELOG.md`.

Full suite green — `ok machin 251.725s`.

**One honest note:** an earlier full-suite run failed with four TLS/socket tests reporting `connection refused` (the MFL TLS server never started). Not reproducible — the same tests pass individually, together, and on `main`, and the diff at that point was a version string plus three docs. Treated as a flake, but recorded rather than quietly re-run until green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.126.1, including corrected binary-size comparisons, verified benchmark results, machine-specific guidance, and manual benchmarking instructions.
  * Updated the README, language specification, and application version information to 0.126.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->