### PR TITLE
ci: gate coverage, and refuse to release a tag that is not green and on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
           go build -o /tmp/machin-ci .
           /tmp/machin-ci test framework/flags.src framework/tests/flags_test.src
 
+      # Coverage FLOOR, not a report: a ratchet set just under what the suites
+      # measure today, so a regression fails here rather than being noticed later.
+      # Raise it as #593 adds suites; lowering it must be deliberate and explained.
+      - name: MFL coverage floor
+        run: make mfl-cov-floor
+
       - name: Run every example (integration smoke test)
         run: ./examples/run.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,50 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth 0: the guard below needs main's history to prove the tag is on it.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # RELEASE GUARD. A tag push is not a protected operation: `git push origin
+      # vX.Y.Z` succeeds even when a push to main was just rejected, and this
+      # workflow used to build whatever it was handed. That made "the release is
+      # green and reproducible from main" a matter of the releaser's discipline
+      # rather than something enforced.
+      #
+      # Two checks, both hard failures:
+      #   1. the tagged commit is contained in origin/main — no releases from a
+      #      branch, a fork point, or a commit that never merged;
+      #   2. the CI run for that exact commit concluded success — no releases from
+      #      a red or never-tested tree.
+      #
+      # Overriding either is deliberate: delete the tag, fix the problem, re-tag.
+      - name: Verify the tag is on main and CI passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SHA="${GITHUB_SHA}"
+          echo "tagged commit: $SHA"
+
+          # A tag checkout does not necessarily carry origin/main (verified: a
+          # `clone --branch <tag>` has no such ref), and without it the ancestry
+          # check below would fail for the wrong reason and block a good release.
+          git fetch --quiet origin main
+
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::$SHA is not contained in origin/main — refusing to release a commit that is not on the default branch."
+            exit 1
+          fi
+          echo "  on main: yes"
+
+          CONCLUSION=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&status=completed" \
+            --jq '[.workflow_runs[] | select(.name == "ci")] | first | .conclusion // "none"')
+          echo "  ci conclusion: $CONCLUSION"
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::CI for $SHA is '${CONCLUSION}', not 'success' — refusing to release an unverified commit. Wait for CI, or fix it, then re-tag."
+            exit 1
+          fi
 
       - uses: actions/setup-go@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,11 +166,19 @@ GitHub release.
 > like everything else, and the tag is applied to the **squashed commit on `main`**
 > afterwards.
 >
-> **A tag push is NOT protected.** `git push origin vX.Y.Z` succeeds even when the
-> branch push was just rejected, and it immediately triggers the release workflow —
-> so it is easy to end up with a tag pointing at a commit that is not on `main`,
-> building a release nobody can reproduce from the default branch. Tag **last**,
-> and only after the release PR has merged.
+> **A tag push is still not a protected operation** — `git push origin vX.Y.Z`
+> succeeds even when a push to `main` was just rejected — but since v0.127.0 the
+> release workflow **refuses to build an unverified tag**. Before compiling
+> anything it checks that:
+>
+> 1. the tagged commit is contained in `origin/main`, and
+> 2. the `ci` run for that exact commit concluded `success`.
+>
+> Either failing stops the release with an explicit error. So a mis-tag now costs
+> you a failed workflow instead of a published binary nobody can reproduce from
+> the default branch. Still tag **last**, after the release PR has merged and its
+> CI is green — that is now the only sequence that works, rather than merely the
+> recommended one.
 
 **To cut a release:**
 
@@ -183,6 +191,11 @@ GitHub release.
    silently (`SPEC.md` had fallen three releases behind by v0.124.0):
    - the `Version` line in `SPEC.md`
    - a new section at the top of `CHANGELOG.md` (newest first)
+
+   CI also enforces an **MFL coverage floor** (`make mfl-cov-floor`, #589): a
+   ratchet set just under what the MFL suites measure today. If you added tests,
+   raise it; lowering it is allowed but must be deliberate and explained in the
+   commit.
 
    If you touched a **bundled skill** under `skills/`, also run
    `tools/sync-plugin-skills.sh` — `TestPluginSkillsInSync` requires

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BIN     := bin/machin
 PREFIX  ?= /usr/local
 GOFLAGS ?= -trimpath
 
-.PHONY: all build test mfl-test mfl-cover cover examples bench cov-floor install uninstall clean
+.PHONY: all build test mfl-test mfl-cover mfl-cov-floor cover examples bench cov-floor install uninstall clean
 
 all: build
 
@@ -30,11 +30,25 @@ test: mfl-test
 mfl-test: build
 	$(BIN) test framework/flags.src framework/tests/flags_test.src
 
-# Same suites with function + statement coverage (#589). Not wired into `test`:
-# coverage is a report to read, not a gate, and there is no threshold to enforce
-# yet — 15 of 16 framework modules have no MFL tests at all (see the tracking issue).
+# Same suites with function + statement coverage (#589), as a human-readable report.
 mfl-cover: build
 	$(BIN) test --cover framework/flags.src framework/tests/flags_test.src
+
+# MFL coverage floors — a RATCHET, like cov-floor is for the Go side. Set just
+# under what the suites measure today (flags.src: 90.9% function, 82.1% statement
+# for the whole composed program), so a regression fails CI without the repo
+# claiming a number it has not earned.
+#
+# Raise these as #593 adds suites for the other pure modules. Lowering one is
+# allowed but must be deliberate and explained in the commit — that is the whole
+# point of a floor being a number in a file rather than a habit.
+MFL_FUNC_FLOOR ?= 90
+MFL_STMT_FLOOR ?= 75
+
+mfl-cov-floor: build
+	@$(BIN) test --cover --json framework/flags.src framework/tests/flags_test.src 2>/dev/null \
+		| python3 tools/cov-floor.py --module framework/flags.src \
+			--func $(MFL_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
 
 # Statement coverage of the compiler. `make cover` prints the % and writes an
 # HTML report to coverage.html (open it to see which lines are unhit). The corpus

--- a/tools/cov-floor.py
+++ b/tools/cov-floor.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fail if `machin test --cover --json` reports coverage below a floor.
+
+Mirrors the Go side's TestTypesCoverageFloor: a ratchet, not a target. The floors
+are set just under what the suites measure TODAY, so they catch a regression
+without pretending to a number the repo has not earned.
+
+Two floors, because the two blocks measure different things:
+
+  --func   function coverage OF THE MODULE UNDER TEST. Scoped to one file on
+           purpose: the composed program also contains framework/test.src (the
+           assert helpers) and the test file itself, and a suite that happens not
+           to call assert_eq_str must not fail a gate about the module it tests.
+
+  --stmt   statement coverage of the WHOLE composed program. `machin test --cover`
+           reports statements globally (per owning function, not per file), so
+           this floor is necessarily coarser and is set lower to reflect that.
+           Tighten it when statement coverage grows a per-file breakdown.
+
+Usage:
+  machin test --cover --json <module> <suite> | cov-floor.py --module <module> \
+      --func 90 --stmt 75
+"""
+import argparse
+import json
+import sys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--module", required=True, help="path of the module under test")
+    ap.add_argument("--func", type=float, required=True, help="function coverage floor %")
+    ap.add_argument("--stmt", type=float, default=0.0, help="statement coverage floor %")
+    args = ap.parse_args()
+
+    try:
+        report = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"cov-floor: could not parse `machin test --cover --json` output: {e}", file=sys.stderr)
+        return 2
+
+    cov = report.get("coverage")
+    if not cov:
+        print("cov-floor: no coverage block — was --cover passed?", file=sys.stderr)
+        return 2
+
+    # A missing module entry is a hard error, not a pass. Silently skipping it is
+    # how a gate stops guarding anything: rename the file and the floor evaporates.
+    entry = next((f for f in cov.get("files", []) if f["file"] == args.module), None)
+    if entry is None:
+        seen = ", ".join(f["file"] for f in cov.get("files", []))
+        print(f"cov-floor: {args.module} absent from the report (saw: {seen})", file=sys.stderr)
+        return 2
+
+    failures = []
+    fn_pct = entry["covered"] / entry["total"] * 100 if entry["total"] else 100.0
+    print(f"  {args.module}: function {entry['covered']}/{entry['total']} "
+          f"({fn_pct:.1f}%), floor {args.func:.0f}%")
+    if entry["uncovered"]:
+        print(f"    uncovered: {', '.join(entry['uncovered'])}")
+    if fn_pct + 1e-9 < args.func:
+        failures.append(f"function coverage {fn_pct:.1f}% is below the {args.func:.0f}% floor")
+
+    if args.stmt > 0:
+        sc = cov.get("statements")
+        if not sc:
+            print("cov-floor: no statement block in the report", file=sys.stderr)
+            return 2
+        print(f"  whole program: statement {sc['covered']}/{sc['total']} "
+              f"({sc['pct']:.1f}%), floor {args.stmt:.0f}%")
+        if sc["pct"] + 1e-9 < args.stmt:
+            failures.append(f"statement coverage {sc['pct']:.1f}% is below the {args.stmt:.0f}% floor")
+
+    if failures:
+        for f in failures:
+            print(f"cov-floor: FAIL — {f}", file=sys.stderr)
+        print("cov-floor: add tests, or lower the floor deliberately and say why in the commit.",
+              file=sys.stderr)
+        return 1
+    print("  cov-floor: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Answers "today we cut releases manually?" — yes, **and unverified**. `release.yml` fired on any `v*` tag push and immediately built whatever it was handed: it never checked the commit was on `main`, never checked CI passed. A tag push is not protected, so "green and reproducible from main" was the releaser's discipline, not an enforced property.

## Release guard

Before compiling anything, `release.yml` now hard-fails unless:

1. the tagged commit is **contained in `origin/main`**, and
2. the **`ci` run for that exact commit concluded `success`**.

Verified against real data:

| case | result |
|---|---|
| `main` HEAD (`3cacf4b0`) | ci=`success`, ancestry passes → allowed |
| commit that never merged | ancestry fails → **blocked** |

It also explicitly `git fetch origin main` first — **a tag checkout does not carry that ref** (confirmed with `clone --branch <tag>`), so without it the guard would fail for the wrong reason and block good releases.

## MFL coverage floor

`make mfl-cov-floor` + `tools/cov-floor.py`, wired into CI. A **ratchet**, like the Go side's `cov-floor` — set just under today's measurements (flags.src **90.9%** function, **82.1%** statement), so a regression fails rather than being noticed later.

Two scoping decisions worth review:

- The **function floor applies to the module under test**, not the composed program. That program also contains `framework/test.src` and the test file; a suite that happens not to call `assert_eq_str` must not fail a gate about the module it tests.
- The **statement floor is coarser** — coverage reports statements per owning function, not per file — and is set lower to reflect that honestly rather than pretending it's per-module.

A module missing from the report is a **hard error, not a pass**. Silently skipping it is how a gate quietly stops guarding anything.

**Proven to fail:**

```
pass case        exit=0
func floor 95    exit=2   (actual 90.9%)
stmt floor 90    exit=2   (actual 82.1%)
missing module   exit=2
```

Raise the floors as #593 lands suites; lowering one must be deliberate and explained in the commit.

`AGENTS.md` updated — its warning that tag pushes are unguarded is now wrong.

Full suite green — `ok machin 167.867s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated coverage thresholds for MFL functions and statements.
  * Added coverage reporting that identifies uncovered functions and enforces configured minimums.

* **Bug Fixes**
  * Release builds now require tagged commits to be on the main branch and backed by a successful CI run.

* **Documentation**
  * Updated release and coverage documentation, including coverage-threshold ratcheting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->