### PR TITLE
ci: fail when main advertises a version that was never released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
       - name: MFL coverage floor
         run: make mfl-cov-floor
 
+      # main only: a release PR legitimately carries an untagged version bump, so
+      # this would fail every such PR. On main it catches the version bump that
+      # merged and never got tagged — the v0.123.0 failure, which was invisible.
+      - name: Released-version check
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git fetch --tags --quiet
+          make version-check
+
       - name: Run every example (integration smoke test)
         run: ./examples/run.sh
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BIN     := bin/machin
 PREFIX  ?= /usr/local
 GOFLAGS ?= -trimpath
 
-.PHONY: all build test mfl-test mfl-cover mfl-cov-floor cover examples bench cov-floor install uninstall clean
+.PHONY: all build test mfl-test mfl-cover mfl-cov-floor version-check cover examples bench cov-floor install uninstall clean
 
 all: build
 
@@ -42,6 +42,11 @@ mfl-cover: build
 # Raise these as #593 adds suites for the other pure modules. Lowering one is
 # allowed but must be deliberate and explained in the commit — that is the whole
 # point of a floor being a number in a file rather than a habit.
+# Fail if main advertises a version that was never released — see the script for
+# the v0.123.0 incident this exists to prevent recurring.
+version-check:
+	@./tools/version-check.sh
+
 MFL_FUNC_FLOOR ?= 90
 MFL_STMT_FLOOR ?= 75
 

--- a/tools/version-check.sh
+++ b/tools/version-check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Fail if main advertises a version that was never released.
+#
+# WHY: v0.123.0 shipped as a merged release commit — CHANGELOG entry, README
+# badge, machinVersion bumped — and the tag was never pushed. There is no
+# v0.123.0 on GitHub to this day. `machin guide` reported a version nobody could
+# download, and nothing anywhere went red. One silent miss in 134 releases.
+#
+# The release guard in release.yml only inspects tags that ARE pushed; it cannot
+# see one that never was. This closes that gap from the other side.
+#
+# THE ONE-COMMIT GRACE is what makes this usable. The release checklist bumps the
+# version in a PR and tags the squashed commit AFTER it merges, so there is always
+# a window where main carries an untagged version. That exact commit is allowed.
+# Merge anything ON TOP of an untagged version bump and this goes red, with the
+# fix stated in the failure: push the tag.
+set -euo pipefail
+
+VERSION=$(grep -oE 'machinVersion = "[0-9]+\.[0-9]+\.[0-9]+"' guide.go | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [ -z "${VERSION}" ]; then
+  echo "version-check: could not read machinVersion from guide.go" >&2
+  exit 2
+fi
+TAG="v${VERSION}"
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "  ${TAG} is tagged — ok"
+  exit 0
+fi
+
+# Untagged. Allowed only if HEAD is the release commit that introduced it.
+SUBJECT=$(git log -1 --pretty=%s)
+case "${SUBJECT}" in
+  "release: ${TAG}"*)
+    echo "  ${TAG} not tagged yet, but HEAD is its release commit — ok (tag it now)"
+    echo "    git tag -a ${TAG} -m \"MFL ${TAG}\" && git push origin ${TAG}"
+    exit 0
+    ;;
+esac
+
+cat >&2 <<EOF
+version-check: FAIL — guide.go says ${VERSION}, but ${TAG} was never tagged, and
+HEAD is not that version's release commit:
+
+  HEAD: ${SUBJECT}
+
+main is advertising a version nobody can download. This is exactly how v0.123.0
+was lost. Fix it by tagging the release commit:
+
+  git log --oneline --grep '^release: ${TAG}'
+  git tag -a ${TAG} -m "MFL ${TAG}" <that-commit> && git push origin ${TAG}
+
+(Or, if the bump was a mistake, correct machinVersion.)
+EOF
+exit 1


### PR DESCRIPTION
**v0.123.0 was released and never published.** The release commit merged (`565c25c`) — CHANGELOG entry, README badge, `machinVersion` bumped — and the tag was never pushed. There is still no `v0.123.0` on GitHub. `machin guide` reported a version nobody could download, and nothing went red. One silent miss in 134 releases.

The release guard from #594 only inspects tags that **are** pushed; it is structurally blind to one that never was. This closes the gap from the other side.

## The one-commit grace

The checklist bumps the version in a PR and tags the squashed commit *after* merge, so main always has a window carrying an untagged version. That exact commit is allowed — HEAD's subject must be `release: vX.Y.Z`. Merge anything **on top** of an untagged bump and CI goes red, with the fix printed:

```
version-check: FAIL — guide.go says 0.199.0, but v0.199.0 was never tagged, and
HEAD is not that version's release commit:

  HEAD: feat: something else

main is advertising a version nobody can download. This is exactly how v0.123.0
was lost. Fix it by tagging the release commit: ...
```

Runs on **main only** — a release PR legitimately carries an untagged bump and would otherwise fail every one.

## Verified three ways

| case | result |
|---|---|
| untagged version, HEAD is its release commit | pass (grace) |
| untagged version, another commit on top | **fail** |
| **replayed against real history** — `9997ed4`, the next merge after the untagged v0.123.0 | **fail** |

That last one is the proof: it would have caught the actual incident within one merge.

Full suite green — `ok machin 145.181s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated validation to ensure advertised release versions have corresponding Git tags.
  * Permits untagged versions only for commits explicitly marked as releases.
  * Reports actionable errors when version information or required tags are missing.

* **Chores**
  * Runs the release-version check automatically on the main branch during CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->