### PR TITLE
test: MFL suites for framework/bson.src and framework/xml.src (#593)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           /tmp/machin-ci test framework/flags.src framework/tests/flags_test.src
           /tmp/machin-ci test framework/bson.src framework/tests/bson_test.src
           /tmp/machin-ci test framework/xml.src framework/tests/xml_test.src
+          /tmp/machin-ci test framework/reactive.src framework/tests/reactive_test.src
 
       # Coverage FLOOR, not a report: a ratchet set just under what the suites
       # measure today, so a regression fails here rather than being noticed later.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           go build -o /tmp/machin-ci .
           /tmp/machin-ci test framework/flags.src framework/tests/flags_test.src
+          /tmp/machin-ci test framework/bson.src framework/tests/bson_test.src
 
       # Coverage FLOOR, not a report: a ratchet set just under what the suites
       # measure today, so a regression fails here rather than being noticed later.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           go build -o /tmp/machin-ci .
           /tmp/machin-ci test framework/flags.src framework/tests/flags_test.src
           /tmp/machin-ci test framework/bson.src framework/tests/bson_test.src
+          /tmp/machin-ci test framework/xml.src framework/tests/xml_test.src
 
       # Coverage FLOOR, not a report: a ratchet set just under what the suites
       # measure today, so a regression fails here rather than being noticed later.

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,12 @@ test: mfl-test
 # documented invocation had in fact stopped working.
 mfl-test: build
 	$(BIN) test framework/flags.src framework/tests/flags_test.src
+	$(BIN) test framework/bson.src framework/tests/bson_test.src
 
 # Same suites with function + statement coverage (#589), as a human-readable report.
 mfl-cover: build
 	$(BIN) test --cover framework/flags.src framework/tests/flags_test.src
+	$(BIN) test --cover framework/bson.src framework/tests/bson_test.src
 
 # MFL coverage floors — a RATCHET, like cov-floor is for the Go side. Set just
 # under what the suites measure today (flags.src: 90.9% function, 82.1% statement
@@ -49,11 +51,16 @@ version-check:
 
 MFL_FUNC_FLOOR ?= 90
 MFL_STMT_FLOOR ?= 75
+# bson.src is fully covered (24/24); hold it there rather than at the shared floor.
+BSON_FUNC_FLOOR ?= 100
 
 mfl-cov-floor: build
 	@$(BIN) test --cover --json framework/flags.src framework/tests/flags_test.src 2>/dev/null \
 		| python3 tools/cov-floor.py --module framework/flags.src \
 			--func $(MFL_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
+	@$(BIN) test --cover --json framework/bson.src framework/tests/bson_test.src 2>/dev/null \
+		| python3 tools/cov-floor.py --module framework/bson.src \
+			--func $(BSON_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
 
 # Statement coverage of the compiler. `make cover` prints the % and writes an
 # HTML report to coverage.html (open it to see which lines are unhit). The corpus

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,13 @@ test: mfl-test
 mfl-test: build
 	$(BIN) test framework/flags.src framework/tests/flags_test.src
 	$(BIN) test framework/bson.src framework/tests/bson_test.src
+	$(BIN) test framework/xml.src framework/tests/xml_test.src
 
 # Same suites with function + statement coverage (#589), as a human-readable report.
 mfl-cover: build
 	$(BIN) test --cover framework/flags.src framework/tests/flags_test.src
 	$(BIN) test --cover framework/bson.src framework/tests/bson_test.src
+	$(BIN) test --cover framework/xml.src framework/tests/xml_test.src
 
 # MFL coverage floors — a RATCHET, like cov-floor is for the Go side. Set just
 # under what the suites measure today (flags.src: 90.9% function, 82.1% statement
@@ -53,6 +55,8 @@ MFL_FUNC_FLOOR ?= 90
 MFL_STMT_FLOOR ?= 75
 # bson.src is fully covered (24/24); hold it there rather than at the shared floor.
 BSON_FUNC_FLOOR ?= 100
+# xml.src is fully covered too (31/31).
+XML_FUNC_FLOOR ?= 100
 
 mfl-cov-floor: build
 	@$(BIN) test --cover --json framework/flags.src framework/tests/flags_test.src 2>/dev/null \
@@ -61,6 +65,9 @@ mfl-cov-floor: build
 	@$(BIN) test --cover --json framework/bson.src framework/tests/bson_test.src 2>/dev/null \
 		| python3 tools/cov-floor.py --module framework/bson.src \
 			--func $(BSON_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
+	@$(BIN) test --cover --json framework/xml.src framework/tests/xml_test.src 2>/dev/null \
+		| python3 tools/cov-floor.py --module framework/xml.src \
+			--func $(XML_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
 
 # Statement coverage of the compiler. `make cover` prints the % and writes an
 # HTML report to coverage.html (open it to see which lines are unhit). The corpus

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,14 @@ mfl-test: build
 	$(BIN) test framework/flags.src framework/tests/flags_test.src
 	$(BIN) test framework/bson.src framework/tests/bson_test.src
 	$(BIN) test framework/xml.src framework/tests/xml_test.src
+	$(BIN) test framework/reactive.src framework/tests/reactive_test.src
 
 # Same suites with function + statement coverage (#589), as a human-readable report.
 mfl-cover: build
 	$(BIN) test --cover framework/flags.src framework/tests/flags_test.src
 	$(BIN) test --cover framework/bson.src framework/tests/bson_test.src
 	$(BIN) test --cover framework/xml.src framework/tests/xml_test.src
+	$(BIN) test --cover framework/reactive.src framework/tests/reactive_test.src
 
 # MFL coverage floors — a RATCHET, like cov-floor is for the Go side. Set just
 # under what the suites measure today (flags.src: 90.9% function, 82.1% statement
@@ -57,6 +59,12 @@ MFL_STMT_FLOOR ?= 75
 BSON_FUNC_FLOOR ?= 100
 # xml.src is fully covered too (31/31).
 XML_FUNC_FLOOR ?= 100
+# reactive.src tops out at 13/17 (76.5%): bind/each/hydrate/mount call the
+# extern "env" DOM imports, which have no native definition, so calling one makes
+# the test program fail to LINK rather than fail an assertion. The ceiling is a
+# property of the module, not a gap in the suite — raising this floor requires a
+# native stub or a wasm test path (#593), not more tests.
+REACTIVE_FUNC_FLOOR ?= 76
 
 mfl-cov-floor: build
 	@$(BIN) test --cover --json framework/flags.src framework/tests/flags_test.src 2>/dev/null \
@@ -68,6 +76,9 @@ mfl-cov-floor: build
 	@$(BIN) test --cover --json framework/xml.src framework/tests/xml_test.src 2>/dev/null \
 		| python3 tools/cov-floor.py --module framework/xml.src \
 			--func $(XML_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
+	@$(BIN) test --cover --json framework/reactive.src framework/tests/reactive_test.src 2>/dev/null \
+		| python3 tools/cov-floor.py --module framework/reactive.src \
+			--func $(REACTIVE_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
 
 # Statement coverage of the compiler. `make cover` prints the % and writes an
 # HTML report to coverage.html (open it to see which lines are unhit). The corpus

--- a/framework/bson.src
+++ b/framework/bson.src
@@ -17,6 +17,15 @@ func bs_le64h(n) (h) { h = bs_le32h(n) + bs_le32h(n >> 32) }
 func bs_le32(b, i) (v) {
     v = byte_at(b, i) | (byte_at(b, i + 1) << 8) | (byte_at(b, i + 2) << 16) | (byte_at(b, i + 3) << 24)
 }
+// bs_i32 reads a SIGNED 32-bit int. bs_le32 is deliberately left unsigned: it also
+// reads document/string/binary lengths (always small positives) and forms bs_le64's
+// LOW HALF, where sign-extending would corrupt any 64-bit value whose low word has
+// the top bit set — e.g. 0x00000000FFFFFFFF would decode as -1 instead of
+// 4294967295. So the sign lives at the int32 decode site, not in the byte reader.
+func bs_i32(b, i) (v) {
+    v = bs_le32(b, i)
+    if v > 2147483647 { v = v - 4294967296 }
+}
 func bs_le64(b, i) (v) {
     v = bs_le32(b, i) | (byte_at(b, i + 4) << 32) | (byte_at(b, i + 5) << 40) | (byte_at(b, i + 6) << 48) | (byte_at(b, i + 7) << 56)
 }
@@ -74,7 +83,7 @@ func bs_val(b, i, t) (vj, nxt) {
         vj = bs_jstr(bytes_str(bytes_sub(b, i + 4, i + 4 + slen - 1)))
         nxt = i + 4 + slen
     }
-    if t == 16 { vj = str(bs_le32(b, i))  nxt = i + 4 }          // int32
+    if t == 16 { vj = str(bs_i32(b, i))  nxt = i + 4 }           // int32 (SIGNED — see bs_i32)
     if t == 18 { vj = str(bs_le64(b, i))  nxt = i + 8 }          // int64
     if t == 9  { vj = str(bs_le64(b, i))  nxt = i + 8 }          // datetime (ms) -> number
     if t == 8  { vj = "false"  if byte_at(b, i) == 1 { vj = "true" }  nxt = i + 1 }

--- a/framework/tests/bson_test.src
+++ b/framework/tests/bson_test.src
@@ -1,0 +1,187 @@
+// bson_test — exercises framework/bson.src's codec in MFL, via `machin test`.
+// Run from the repo root:
+//   machin test framework/bson.src framework/tests/bson_test.src
+// or `make mfl-test`, which is what CI runs.
+//
+// bson.src MUST be listed explicitly: `machin test` auto-composes only
+// framework/test.src (the assert helpers), never the module under test.
+//
+// The codec is a round-trip pair, so most assertions encode a document and decode
+// it back rather than pinning byte sequences. Byte-level expectations are kept for
+// the little-endian helpers, because that is where a width or sign mistake hides
+// without changing any round-trip.
+
+// ---- little-endian helpers: exact bytes, not round-trips ----
+
+func test_hex_byte() {
+    assert_eq_str(bs_hx2(0), "00", "hx2 zero")
+    assert_eq_str(bs_hx2(255), "ff", "hx2 max, lowercase")
+    assert_eq_str(bs_hx2(16), "10", "hx2 high nibble only")
+    assert_eq_str(bs_hx2(10), "0a", "hx2 pads to two digits")
+}
+
+func test_le_hex_is_little_endian() {
+    // 1 must land in the FIRST byte — a big-endian mistake still round-trips
+    // through the matching reader, so only the literal bytes catch it.
+    assert_eq_str(bs_le32h(1), "01000000", "le32h puts the low byte first")
+    assert_eq_str(bs_le32h(258), "02010000", "le32h 0x0102 spans two bytes")
+    assert_eq_str(bs_le64h(1), "0100000000000000", "le64h low byte first")
+    assert_eq_str(bs_le32h(-1), "ffffffff", "le32h of -1 is all ones")
+}
+
+func test_le_readers_round_trip() {
+    assert_eq_int(bs_le32(from_hex(bs_le32h(0)), 0), 0, "le32 zero")
+    assert_eq_int(bs_le32(from_hex(bs_le32h(1)), 0), 1, "le32 one")
+    assert_eq_int(bs_le32(from_hex(bs_le32h(305419896)), 0), 305419896, "le32 0x12345678")
+    assert_eq_int(bs_le64(from_hex(bs_le64h(0)), 0), 0, "le64 zero")
+    assert_eq_int(bs_le64(from_hex(bs_le64h(-1)), 0), -1, "le64 -1 sign-extends")
+    assert_eq_int(bs_le64(from_hex(bs_le64h(1099511627776)), 0), 1099511627776, "le64 beyond 32 bits")
+}
+
+// bs_le32 is deliberately UNSIGNED: it reads lengths and forms bs_le64's low half.
+// Pinning that keeps someone from "fixing" it and silently breaking 64-bit values
+// whose low word has the top bit set.
+func test_le32_is_unsigned_on_purpose() {
+    assert_eq_int(bs_le32(from_hex("ffffffff"), 0), 4294967295, "le32 stays unsigned")
+    assert_eq_int(bs_i32(from_hex("ffffffff"), 0), -1, "bs_i32 is the signed reader")
+    assert_eq_int(bs_i32(from_hex(bs_le32h(-42)), 0), -42, "bs_i32 round-trips a negative")
+    assert_eq_int(bs_i32(from_hex(bs_le32h(2147483647)), 0), 2147483647, "bs_i32 keeps max positive")
+    // The exact case a global sign-extension of bs_le32 would corrupt.
+    assert_eq_int(bs_le64(from_hex("ffffffff00000000"), 0), 4294967295, "le64 low word high bit is not a sign")
+}
+
+// ---- documents: encode then decode ----
+
+func test_string_field() {
+    d := bson_finish(bson_str(bson_new(), "s", "hello"))
+    assert_eq_str(bson_to_json(d), "{\"s\":\"hello\"}", "string round-trip")
+}
+
+func test_empty_string_and_empty_document() {
+    e := bson_finish(bson_str(bson_new(), "s", ""))
+    assert_eq_str(bson_to_json(e), "{\"s\":\"\"}", "empty string value")
+    assert_eq_str(bson_to_json(bson_finish(bson_new())), "{}", "empty document")
+}
+
+func test_int32_including_negatives() {
+    a := bson_finish(bson_i32(bson_new(), "n", 42))
+    assert_eq_str(bson_to_json(a), "{\"n\":42}", "int32 positive")
+    // Regression: this decoded as 4294967291 before bs_i32 existed. Any negative
+    // int32 in a Mongo document read back as a large positive.
+    b := bson_finish(bson_i32(bson_new(), "n", -5))
+    assert_eq_str(bson_to_json(b), "{\"n\":-5}", "int32 negative")
+    c := bson_finish(bson_i32(bson_new(), "n", 0))
+    assert_eq_str(bson_to_json(c), "{\"n\":0}", "int32 zero")
+}
+
+func test_int64_including_negatives_and_large() {
+    a := bson_finish(bson_i64(bson_new(), "n", -5))
+    assert_eq_str(bson_to_json(a), "{\"n\":-5}", "int64 negative")
+    b := bson_finish(bson_i64(bson_new(), "n", 4294967295))
+    assert_eq_str(bson_to_json(b), "{\"n\":4294967295}", "int64 past 32 bits")
+}
+
+func test_bool_and_null() {
+    t := bson_finish(bson_bool(bson_new(), "b", 1))
+    assert_eq_str(bson_to_json(t), "{\"b\":true}", "bool true")
+    f := bson_finish(bson_bool(bson_new(), "b", 0))
+    assert_eq_str(bson_to_json(f), "{\"b\":false}", "bool false")
+    n := bson_finish(bson_null(bson_new(), "z"))
+    assert_eq_str(bson_to_json(n), "{\"z\":null}", "null")
+}
+
+func test_double() {
+    d := bson_finish(bson_double(bson_new(), "d", 1.5))
+    assert_eq_str(bson_to_json(d), "{\"d\":1.5}", "double round-trip through f64_bits")
+}
+
+func test_object_id_decodes_to_hex() {
+    hex := "0123456789abcdef01234567"
+    d := bson_finish(bson_oid(bson_new(), "_id", hex))
+    assert_eq_str(bson_to_json(d), "{\"_id\":\"" + hex + "\"}", "ObjectId decodes back to its hex")
+}
+
+func test_multiple_fields_keep_insertion_order() {
+    acc := bson_str(bson_new(), "a", "x")
+    acc = bson_i32(acc, "b", 2)
+    acc = bson_bool(acc, "c", 1)
+    d := bson_finish(acc)
+    assert_eq_str(bson_to_json(d), "{\"a\":\"x\",\"b\":2,\"c\":true}", "fields decode in the order added")
+}
+
+func test_subdocument() {
+    inner := bson_finish(bson_i32(bson_new(), "n", 7))
+    d := bson_finish(bson_subdoc(bson_new(), "sub", inner))
+    assert_eq_str(bson_to_json(d), "{\"sub\":{\"n\":7}}", "embedded document")
+}
+
+func test_nested_subdocument_two_deep() {
+    deep := bson_finish(bson_str(bson_new(), "s", "v"))
+    mid := bson_finish(bson_subdoc(bson_new(), "in", deep))
+    d := bson_finish(bson_subdoc(bson_new(), "out", mid))
+    assert_eq_str(bson_to_json(d), "{\"out\":{\"in\":{\"s\":\"v\"}}}", "two levels of nesting")
+}
+
+func test_array() {
+    // A BSON array is a document whose keys are "0", "1", ...
+    arr := bson_i32(bson_new(), "0", 10)
+    arr = bson_i32(arr, "1", 20)
+    d := bson_finish(bson_subarr(bson_new(), "xs", bson_finish(arr)))
+    assert_eq_str(bson_to_json(d), "{\"xs\":[10,20]}", "array decodes to a JSON list")
+}
+
+func test_binary_field() {
+    d := bson_finish(bson_binary(bson_new(), "p", bytes("abc")))
+    assert_eq_str(bson_to_json(d), "{\"p\":\"abc\"}", "binary payload (SCRAM's case)")
+}
+
+func test_json_string_escaping() {
+    d := bson_finish(bson_str(bson_new(), "s", "a\"b"))
+    assert_eq_str(bson_to_json(d), "{\"s\":\"a\\\"b\"}", "a quote in a value is escaped")
+}
+
+// BSON datetime (type 0x09) has no encoder in bson.src, so no round-trip can reach
+// its decode branch — but MongoDB returns dates constantly, so the branch matters.
+// Hand-build the element: type byte, key, NUL, then 8 bytes of little-endian ms.
+func test_datetime_decodes_as_a_number() {
+    ms := 1700000000000
+    d := bson_finish(bytes_concat(bson_new(), bs_el(9, "at", from_hex(bs_le64h(ms)))))
+    assert_eq_str(bson_to_json(d), "{\"at\":" + str(ms) + "}", "datetime decodes to epoch ms")
+    // Dates before 1970 are negative ms — the int64 path must keep the sign.
+    neg := 0 - 86400000
+    d2 := bson_finish(bytes_concat(bson_new(), bs_el(9, "at", from_hex(bs_le64h(neg)))))
+    assert_eq_str(bson_to_json(d2), "{\"at\":" + str(neg) + "}", "pre-epoch datetime stays negative")
+}
+
+func test_document_length_prefix_is_correct() {
+    // A wrong length prefix still decodes here but corrupts the wire protocol, so
+    // check the header rather than trusting the round-trip.
+    d := bson_finish(bson_new())
+    assert_eq_int(bs_le32(d, 0), 5, "empty document is 5 bytes: length + terminator")
+    assert_eq_int(bs_le32(d, 0), len(d), "declared length matches actual length")
+    d2 := bson_finish(bson_i32(bson_new(), "n", 1))
+    assert_eq_int(bs_le32(d2, 0), len(d2), "declared length matches for a populated document")
+}
+
+func main() {
+    test_hex_byte()
+    test_le_hex_is_little_endian()
+    test_le_readers_round_trip()
+    test_le32_is_unsigned_on_purpose()
+    test_string_field()
+    test_empty_string_and_empty_document()
+    test_int32_including_negatives()
+    test_int64_including_negatives_and_large()
+    test_bool_and_null()
+    test_double()
+    test_object_id_decodes_to_hex()
+    test_multiple_fields_keep_insertion_order()
+    test_subdocument()
+    test_nested_subdocument_two_deep()
+    test_array()
+    test_binary_field()
+    test_json_string_escaping()
+    test_datetime_decodes_as_a_number()
+    test_document_length_prefix_is_correct()
+    test_summary()
+}

--- a/framework/tests/reactive_test.src
+++ b/framework/tests/reactive_test.src
@@ -1,0 +1,251 @@
+// reactive_test — exercises framework/reactive.src's signal graph in MFL, via
+// `machin test`. Run from the repo root:
+//   machin test framework/reactive.src framework/tests/reactive_test.src
+// or `make mfl-test`, which is what CI runs.
+//
+// reactive.src MUST be listed explicitly: `machin test` auto-composes only
+// framework/test.src (the assert helpers), never the module under test.
+//
+// WHAT THIS SUITE CAN AND CANNOT REACH
+//
+// bind / each / mount / hydrate call the `extern "env"` DOM imports (dom_patch,
+// dom_mount, list_insert, ...), which have no native definition — calling one
+// makes the program fail to LINK, not fail an assertion. They are excluded here,
+// so 13 of 17 functions are reachable and the module's floor is set accordingly.
+// That is a property of the module (it is half a DOM binding), not a gap in the
+// tests. See #593.
+//
+// The interesting behaviour here is ORDERING, not values: does a reaction re-run
+// exactly when it should, and does the dependency graph forget edges it should
+// forget. Counters, not return values, are what those assertions look at.
+
+var runs_a = 0
+var runs_b = 0
+var runs_cond = 0
+
+// ---- signals ---------------------------------------------------------------
+
+func test_signal_get_set() {
+    s := signal(1)
+    assert_eq_int(get(s), 1, "signal holds its initial value")
+    set(s, 5)
+    assert_eq_int(get(s), 5, "set updates it")
+}
+
+func test_signals_are_independent() {
+    a := signal(1)
+    b := signal(2)
+    set(a, 10)
+    assert_eq_int(get(a), 10, "a changed")
+    assert_eq_int(get(b), 2, "b untouched")
+}
+
+// ---- reactions -------------------------------------------------------------
+
+func test_reaction_runs_once_on_registration() {
+    runs_a = 0
+    s := signal(0)
+    reaction(func() { get(s)  runs_a = runs_a + 1 })
+    assert_eq_int(runs_a, 1, "a reaction runs immediately when registered")
+}
+
+func test_reaction_reruns_when_its_dependency_changes() {
+    runs_a = 0
+    s := signal(0)
+    reaction(func() { get(s)  runs_a = runs_a + 1 })
+    assert_eq_int(runs_a, 1, "initial run")
+    set(s, 1)
+    assert_eq_int(runs_a, 2, "re-ran after its signal changed")
+    set(s, 2)
+    assert_eq_int(runs_a, 3, "and again")
+}
+
+func test_reaction_ignores_unrelated_signals() {
+    runs_a = 0
+    mine := signal(0)
+    other := signal(0)
+    reaction(func() { get(mine)  runs_a = runs_a + 1 })
+    assert_eq_int(runs_a, 1, "initial run")
+    set(other, 99)
+    assert_eq_int(runs_a, 1, "a signal it never read must not wake it")
+}
+
+// set() returns early when the value is unchanged. That is an optimization with
+// OBSERVABLE semantics: writing the same value must not re-run anything.
+func test_setting_an_equal_value_is_a_no_op() {
+    runs_a = 0
+    s := signal(7)
+    reaction(func() { get(s)  runs_a = runs_a + 1 })
+    assert_eq_int(runs_a, 1, "initial run")
+    set(s, 7)
+    assert_eq_int(runs_a, 1, "writing the same value does not re-run")
+    set(s, 8)
+    assert_eq_int(runs_a, 2, "a real change still does")
+}
+
+// THE DEPENDENCY-TRACKING TEST. Edges are re-recorded on every run (clear_edges
+// then re-track), so a reaction that STOPS reading a signal must stop waking on
+// it. Get this wrong and reactions fire forever on inputs they no longer use —
+// a leak that is invisible in output and only shows up as wasted work.
+func test_stale_dependencies_are_dropped() {
+    runs_cond = 0
+    flag := signal(1)
+    watched := signal(0)
+    reaction(func() {
+        runs_cond = runs_cond + 1
+        if get(flag) == 1 {
+            get(watched)
+        }
+    })
+    assert_eq_int(runs_cond, 1, "initial run, reading both")
+
+    set(watched, 1)
+    assert_eq_int(runs_cond, 2, "while the branch is live, watched wakes it")
+
+    // Turn the branch off. This run re-tracks and no longer reads `watched`.
+    set(flag, 0)
+    assert_eq_int(runs_cond, 3, "flipping the flag re-runs it")
+
+    set(watched, 2)
+    assert_eq_int(runs_cond, 3, "watched is no longer a dependency and must NOT wake it")
+
+    // Turning the branch back on must re-acquire the edge.
+    set(flag, 1)
+    assert_eq_int(runs_cond, 4, "flag still wakes it")
+    set(watched, 3)
+    assert_eq_int(runs_cond, 5, "the dropped edge is re-acquired, not lost forever")
+}
+
+func test_two_reactions_on_one_signal_both_run() {
+    runs_a = 0
+    runs_b = 0
+    s := signal(0)
+    reaction(func() { get(s)  runs_a = runs_a + 1 })
+    reaction(func() { get(s)  runs_b = runs_b + 1 })
+    set(s, 1)
+    assert_eq_int(runs_a, 2, "first reaction re-ran")
+    assert_eq_int(runs_b, 2, "second reaction re-ran")
+}
+
+// ---- computed --------------------------------------------------------------
+
+func test_computed_derives_and_tracks() {
+    src := signal(2)
+    dbl := computed(func() { return get(src) * 2 })
+    assert_eq_int(get(dbl), 4, "computed has its derived value immediately")
+    set(src, 5)
+    assert_eq_int(get(dbl), 10, "and follows its source")
+}
+
+func test_computed_chain_propagates() {
+    a := signal(1)
+    b := computed(func() { return get(a) + 1 })
+    c := computed(func() { return get(b) * 10 })
+    assert_eq_int(get(c), 20, "a -> b -> c resolves on creation")
+    set(a, 2)
+    assert_eq_int(get(c), 30, "a change propagates the whole chain")
+}
+
+// commit() runs dirty reactions to a FIXPOINT, so a computed that dirties another
+// computed must settle within the same set(), not leave a stale value behind.
+func test_computed_settles_within_one_set() {
+    a := signal(1)
+    b := computed(func() { return get(a) + 1 })
+    c := computed(func() { return get(b) + 1 })
+    set(a, 10)
+    assert_eq_int(get(b), 11, "first hop settled")
+    assert_eq_int(get(c), 12, "second hop settled in the same commit")
+}
+
+// A reaction that writes a signal re-enters commit(); the flushing guard must
+// keep that from recursing. If the guard were missing this would not return.
+func test_writing_a_signal_inside_a_reaction_terminates() {
+    runs_a = 0
+    src := signal(0)
+    out := signal(0)
+    reaction(func() {
+        runs_a = runs_a + 1
+        set(out, get(src) + 100)
+    })
+    assert_eq_int(get(out), 100, "the nested write took effect")
+    set(src, 1)
+    assert_eq_int(get(out), 101, "and again after a change")
+    assert_eq_int(runs_a, 2, "the reaction ran twice, not unboundedly")
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+// in_list returns an INT flag (1/0), not a bool — pinned so a later change to a
+// real bool is a deliberate, visible break rather than a silent truthiness shift.
+func test_in_list() {
+    xs := []string{"a", "b"}
+    assert_eq_int(in_list(xs, "a"), 1, "finds the first")
+    assert_eq_int(in_list(xs, "b"), 1, "finds the last")
+    assert_eq_int(in_list(xs, "z"), 0, "absent key is 0")
+    empty := []string{}
+    assert_eq_int(in_list(empty, "a"), 0, "empty list finds nothing")
+}
+
+// The keyed-list keys are INTEGERS carried as a CSV string: csv() stringifies and
+// joins, parse_csv() splits and parse_int()s back to []int. That is why item
+// closures are indexed by int, and it is not obvious from the names alone.
+func test_csv_round_trip() {
+    xs := []int{1, 2, 3}
+    assert_eq_str(csv(xs), "1,2,3", "joined with commas")
+    back := parse_csv("1,2,3")
+    assert_eq_int(len(back), 3, "split back into three")
+    assert_eq_int(back[0], 1, "first")
+    assert_eq_int(back[2], 3, "last")
+    one := parse_csv("7")
+    assert_eq_int(len(one), 1, "a single field has no separator")
+    assert_eq_int(one[0], 7, "and survives intact")
+}
+
+func test_csv_of_empty_inputs() {
+    empty := []int{}
+    assert_eq_str(csv(empty), "", "empty list joins to empty string")
+    // The explicit early return in parse_csv: "" must be zero keys, not one
+    // bogus key of 0 — a list rendering one phantom row is the visible symptom.
+    assert_eq_int(len(parse_csv("")), 0, "empty string parses to no keys")
+}
+
+// ---- markup builders (no DOM calls) ---------------------------------------
+
+func test_slot_markup() {
+    m := slot("greeting", func() { return "hi" })
+    assert(contains(m, "greeting"), "slot markup carries its name")
+}
+
+// list's shape is easy to get wrong and the types spell it out: the key function
+// returns the keys CSV-ENCODED as one string (which is what csv/parse_csv in this
+// module are for), and the item function is indexed by INT, not by key.
+//   pend_lk : func() -> string        (csv keys)
+//   pend_li : func(int) -> string     (item html)
+func test_list_markup() {
+    m := list("items",
+        func() { return csv([]int{1, 2}) },
+        func(i) { return "<li>" + str(i) + "</li>" })
+    assert(contains(m, "items"), "list markup carries its container name")
+    assert(contains(m, "<div"), "and is a container element")
+}
+
+func main() {
+    test_signal_get_set()
+    test_signals_are_independent()
+    test_reaction_runs_once_on_registration()
+    test_reaction_reruns_when_its_dependency_changes()
+    test_reaction_ignores_unrelated_signals()
+    test_setting_an_equal_value_is_a_no_op()
+    test_stale_dependencies_are_dropped()
+    test_two_reactions_on_one_signal_both_run()
+    test_computed_derives_and_tracks()
+    test_computed_chain_propagates()
+    test_computed_settles_within_one_set()
+    test_writing_a_signal_inside_a_reaction_terminates()
+    test_in_list()
+    test_csv_round_trip()
+    test_csv_of_empty_inputs()
+    test_slot_markup()
+    test_list_markup()
+    test_summary()
+}

--- a/framework/tests/xml_test.src
+++ b/framework/tests/xml_test.src
@@ -1,0 +1,267 @@
+// xml_test — exercises framework/xml.src (parser + exclusive C14N + SAML DSig)
+// in MFL, via `machin test`. Run from the repo root:
+//   machin test framework/xml.src framework/tests/xml_test.src
+// or `make mfl-test`, which is what CI runs.
+//
+// xml.src MUST be listed explicitly: `machin test` auto-composes only
+// framework/test.src (the assert helpers), never the module under test.
+//
+// The parser is a lexer over a global node store, so most assertions parse a
+// document and read it back through the public accessors. Canonicalization is
+// asserted on its exact output string — C14N's whole purpose is that two
+// byte-different-but-equivalent documents canonicalize identically, so an
+// approximate check would defeat the point.
+
+// ---- lexing helpers --------------------------------------------------------
+
+func test_is_space() {
+    assert(xml_is_space(" "), "space")
+    assert(xml_is_space("\t"), "tab")
+    assert(xml_is_space("\n"), "newline")
+    assert(xml_is_space("\r"), "carriage return")
+    assert(xml_is_space("x") == false, "a letter is not space")
+    assert(xml_is_space("") == false, "empty is not space")
+}
+
+func test_entity_decoding() {
+    assert_eq_str(xml_decode("plain"), "plain", "no entities passes through")
+    assert_eq_str(xml_decode("a&lt;b"), "a<b", "lt")
+    assert_eq_str(xml_decode("a&gt;b"), "a>b", "gt")
+    assert_eq_str(xml_decode("a&amp;b"), "a&b", "amp")
+    assert_eq_str(xml_decode("a&quot;b"), "a\"b", "quot")
+    assert_eq_str(xml_decode("a&apos;b"), "a'b", "apos")
+    assert_eq_str(xml_decode("&lt;&gt;&amp;"), "<>&", "adjacent entities")
+    assert_eq_str(xml_decode(""), "", "empty string")
+}
+
+// The header promises numeric character references are NOT decoded, and that a
+// document using them fails closed rather than being silently mangled. Pin the
+// documented behaviour so a future "improvement" is a deliberate decision.
+func test_undecoded_forms_are_left_alone() {
+    assert_eq_str(xml_decode("a&#65;b"), "a&#65;b", "numeric refs are not decoded (documented)")
+    assert_eq_str(xml_decode("a&unknown;b"), "a&unknown;b", "unknown entity left intact")
+    assert_eq_str(xml_decode("a&b"), "a&b", "bare ampersand with no semicolon")
+}
+
+func test_strip_ws_removes_all_whitespace() {
+    // Removes all four whitespace characters, spaces included. That is what a
+    // base64 blob wrapped across lines in a certificate element needs.
+    assert_eq_str(xml_strip_ws("a\nb"), "ab", "newline removed")
+    assert_eq_str(xml_strip_ws("a\tb"), "ab", "tab removed")
+    assert_eq_str(xml_strip_ws("a\rb"), "ab", "carriage return removed")
+    assert_eq_str(xml_strip_ws("a b"), "ab", "spaces removed too")
+    assert_eq_str(xml_strip_ws("MIIB\n  ad\tQ"), "MIIBadQ", "a wrapped base64 blob rejoins")
+}
+
+// ---- parsing ---------------------------------------------------------------
+
+func test_parse_single_element() {
+    r := xml_parse("<a></a>")
+    assert(r >= 0, "root parsed")
+    assert_eq_str(g_xn[r].name, "a", "root name")
+    assert_eq_int(len(g_xn[r].kids), 0, "no children")
+}
+
+func test_parse_nesting_and_text() {
+    r := xml_parse("<a><b>hi</b></a>")
+    assert_eq_str(g_xn[r].name, "a", "root")
+    b := xml_find_local(r, "b")
+    assert(b > 0, "found child by local name")
+    assert_eq_str(xml_text(b), "hi", "child text")
+}
+
+func test_parse_self_closing() {
+    r := xml_parse("<a><c/></a>")
+    assert_eq_int(len(g_xn[r].kids), 1, "self-closing tag is one child")
+    c := xml_find_local(r, "c")
+    assert(c > 0, "self-closing element is findable")
+    assert_eq_str(xml_text(c), "", "self-closing element has no text")
+}
+
+func test_parse_attributes() {
+    r := xml_parse("<a x=\"1\" y=\"two\"></a>")
+    assert_eq_str(xml_attr(r, "x"), "1", "first attribute")
+    assert_eq_str(xml_attr(r, "y"), "two", "second attribute")
+    assert_eq_str(xml_attr(r, "missing"), "", "absent attribute is empty, not an error")
+}
+
+func test_attribute_values_are_entity_decoded() {
+    r := xml_parse("<a x=\"a&amp;b\"></a>")
+    assert_eq_str(xml_attr(r, "x"), "a&b", "attribute values decode entities")
+}
+
+func test_text_concatenates_across_children() {
+    r := xml_parse("<a>one<b/>two</a>")
+    assert_eq_str(xml_text(r), "onetwo", "text nodes either side of an element")
+}
+
+// Prolog, comments and DOCTYPE must be skipped rather than parsed as elements —
+// otherwise the root is wrong and every downstream offset shifts.
+func test_prolog_comment_and_doctype_are_skipped() {
+    r := xml_parse("<?xml version=\"1.0\"?><a></a>")
+    assert_eq_str(g_xn[r].name, "a", "XML declaration skipped")
+    r2 := xml_parse("<!-- a comment --><b></b>")
+    assert_eq_str(g_xn[r2].name, "b", "comment skipped")
+    r3 := xml_parse("<!DOCTYPE x><c></c>")
+    assert_eq_str(g_xn[r3].name, "c", "DOCTYPE skipped")
+    r4 := xml_parse("<?xml version=\"1.0\"?><!-- c --><d></d>")
+    assert_eq_str(g_xn[r4].name, "d", "several skippable prologue items")
+}
+
+func test_namespaced_names_are_kept_qualified() {
+    r := xml_parse("<ds:Signature xmlns:ds=\"urn:x\"></ds:Signature>")
+    assert_eq_str(g_xn[r].name, "ds:Signature", "qualified name kept verbatim")
+    assert_eq_str(c14n_local(g_xn[r].name), "Signature", "local part")
+    assert_eq_str(c14n_prefix(g_xn[r].name), "ds", "prefix part")
+}
+
+func test_find_local_ignores_prefix() {
+    r := xml_parse("<a><ds:Sig xmlns:ds=\"urn:x\">v</ds:Sig></a>")
+    n := xml_find_local(r, "Sig")
+    assert(n > 0, "found by LOCAL name regardless of prefix")
+    assert_eq_str(xml_text(n), "v", "and it is the right node")
+}
+
+func test_find_local_missing_returns_negative() {
+    r := xml_parse("<a><b/></a>")
+    assert_eq_int(xml_find_local(r, "nope"), -1, "absent local name returns -1")
+}
+
+func test_find_by_id() {
+    xml_parse("<a><b ID=\"x1\">v</b></a>")
+    n := xml_find_id("x1")
+    assert(n > 0, "found element by ID attribute")
+    assert_eq_str(xml_text(n), "v", "the right element")
+    assert_eq_int(xml_find_id("nosuch"), -1, "absent ID returns -1")
+}
+
+// ---- name / prefix splitting ----------------------------------------------
+
+func test_prefix_and_local_on_unprefixed_names() {
+    assert_eq_str(c14n_prefix("Plain"), "", "no prefix is empty")
+    assert_eq_str(c14n_local("Plain"), "Plain", "local of an unprefixed name is itself")
+}
+
+// ---- escaping --------------------------------------------------------------
+
+func test_text_escaping() {
+    assert_eq_str(c14n_text_escape("a<b"), "a&lt;b", "text escapes <")
+    assert_eq_str(c14n_text_escape("a>b"), "a&gt;b", "text escapes >")
+    assert_eq_str(c14n_text_escape("a&b"), "a&amp;b", "text escapes &")
+    assert_eq_str(c14n_text_escape("plain"), "plain", "nothing to escape")
+}
+
+func test_attribute_escaping() {
+    assert_eq_str(c14n_attr_escape("a\"b"), "a&quot;b", "attribute escapes the quote")
+    assert_eq_str(c14n_attr_escape("a&b"), "a&amp;b", "attribute escapes &")
+    assert_eq_str(c14n_attr_escape("a<b"), "a&lt;b", "attribute escapes <")
+}
+
+// ---- canonicalization ------------------------------------------------------
+
+func test_c14n_expands_self_closing_tags() {
+    // The defining property: a self-closing tag and an empty pair are the SAME
+    // document and must canonicalize to identical bytes, or a signature over one
+    // will not verify against the other.
+    a := c14n_subtree(xml_parse("<a><c/></a>"))
+    b := c14n_subtree(xml_parse("<a><c></c></a>"))
+    assert_eq_str(a, b, "self-closing and empty-pair canonicalize identically")
+    assert_eq_str(a, "<a><c></c></a>", "and the canonical form is the expanded pair")
+}
+
+func test_c14n_keeps_text_and_escapes_it() {
+    out := c14n_subtree(xml_parse("<a>x&lt;y</a>"))
+    assert_eq_str(out, "<a>x&lt;y</a>", "entity survives the decode/re-escape round trip")
+}
+
+func test_c14n_of_nested_document() {
+    out := c14n_subtree(xml_parse("<a><b>1</b><c>2</c></a>"))
+    assert_eq_str(out, "<a><b>1</b><c>2</c></a>", "children in document order")
+}
+
+func test_c14n_attributes_are_sorted() {
+    // Exclusive C14N sorts attributes; two documents differing only in attribute
+    // order must produce the same bytes.
+    x := c14n_subtree(xml_parse("<a b=\"1\" a=\"2\"></a>"))
+    y := c14n_subtree(xml_parse("<a a=\"2\" b=\"1\"></a>"))
+    assert_eq_str(x, y, "attribute order does not change the canonical form")
+    assert_eq_str(x, "<a a=\"2\" b=\"1\"></a>", "attributes come out sorted by name")
+}
+
+// ---- SAML signature verification: it must FAIL CLOSED ----------------------
+//
+// A real signed assertion needs a fixture and a private key, which this suite
+// does not carry. What it CAN pin — and what actually matters for a security
+// primitive — is that verification never returns success for input it did not
+// verify. The module's header promises exactly that: "a doc using them will fail
+// closed (verification returns 0), never falsely pass."
+
+// A prefix declared on an ancestor must resolve for a descendant that uses it —
+// this is what c14n_ctx_lookup / ns_resolve exist for, and getting it wrong makes
+// a signature over nested content fail for the wrong reason.
+func test_inherited_namespace_prefix_resolves() {
+    doc := "<r xmlns:ds=\"urn:x\"><ds:Inner>v</ds:Inner></r>"
+    r := xml_parse(doc)
+    inner := xml_find_local(r, "Inner")
+    assert(inner > 0, "descendant using an ancestor's prefix parses")
+    assert_eq_str(xml_text(inner), "v", "and keeps its text")
+    // EXCLUSIVE C14N moves the declaration to the element that actually uses the
+    // prefix, rather than leaving it on the ancestor that wrote it:
+    //   <r xmlns:ds="urn:x"><ds:Inner>v</ds:Inner></r>
+    //     -> <r><ds:Inner xmlns:ds="urn:x">v</ds:Inner></r>
+    out := c14n_subtree(r)
+    assert_eq_str(out, "<r><ds:Inner xmlns:ds=\"urn:x\">v</ds:Inner></r>",
+        "the declaration migrates to the element that uses it")
+
+    // ...and that is the whole point: a subtree canonicalizes to the SAME bytes
+    // whether or not you have its ancestors, which is what lets a signature over
+    // <ds:Inner> be verified independently of the document it was lifted from.
+    assert_eq_str(c14n_subtree(inner), "<ds:Inner xmlns:ds=\"urn:x\">v</ds:Inner>",
+        "canonicalizing the subtree alone gives identical bytes")
+}
+
+// saml_signing_cert pulls the base64 out of <X509Certificate>, which in real
+// assertions is wrapped across lines — so the whitespace stripping is load-bearing.
+func test_signing_cert_extraction() {
+    assert_eq_str(saml_signing_cert("<a></a>"), "", "no certificate element yields empty")
+    assert_eq_str(saml_signing_cert("not xml"), "", "unparseable input yields empty, not a crash")
+    doc := "<a><X509Certificate>MIIB\n  adQ\n</X509Certificate></a>"
+    assert_eq_str(saml_signing_cert(doc), "MIIBadQ", "wrapped base64 is rejoined")
+}
+
+func test_saml_verify_fails_closed() {
+    assert_eq_int(saml_verify("", ""), 0, "empty input does not verify")
+    assert_eq_int(saml_verify("not xml at all", "notacert"), 0, "garbage does not verify")
+    assert_eq_int(saml_verify("<a></a>", ""), 0, "well-formed but unsigned does not verify")
+    assert_eq_int(saml_verify("<a><ds:Signature xmlns:ds=\"urn:x\"></ds:Signature></a>", "x"),
+        0, "a Signature element alone does not verify")
+}
+
+func main() {
+    test_is_space()
+    test_entity_decoding()
+    test_undecoded_forms_are_left_alone()
+    test_strip_ws_removes_all_whitespace()
+    test_parse_single_element()
+    test_parse_nesting_and_text()
+    test_parse_self_closing()
+    test_parse_attributes()
+    test_attribute_values_are_entity_decoded()
+    test_text_concatenates_across_children()
+    test_prolog_comment_and_doctype_are_skipped()
+    test_namespaced_names_are_kept_qualified()
+    test_find_local_ignores_prefix()
+    test_find_local_missing_returns_negative()
+    test_find_by_id()
+    test_prefix_and_local_on_unprefixed_names()
+    test_text_escaping()
+    test_attribute_escaping()
+    test_c14n_expands_self_closing_tags()
+    test_c14n_keeps_text_and_escapes_it()
+    test_c14n_of_nested_document()
+    test_c14n_attributes_are_sorted()
+    test_inherited_namespace_prefix_resolves()
+    test_signing_cert_extraction()
+    test_saml_verify_fails_closed()
+    test_summary()
+}

--- a/machweb_io_test.go
+++ b/machweb_io_test.go
@@ -33,7 +33,7 @@ func read_all(c) (s) {
 func TestMachwebReadRequestMultiSegment(t *testing.T) {
 	app := loopbackHelpers + `
 func main() {
-    port := 48231
+    port := 18231
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return ok_text("got[" + req.method + " " + req.path + "]=" + req.body) })
@@ -74,7 +74,7 @@ func handle(req) (res) {
     res = set_session(ok_text("saw=" + got), "secret", "sid", "user:7")
 }
 func main() {
-    port := 48235
+    port := 18235
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return handle(req) })
@@ -117,7 +117,7 @@ func handle(req) (res) {
     res = ok_text("title=" + title + " ok=" + str(ok) + " name=" + f.filename + " ct=" + f.ctype + " len=" + str(len(f.data)) + " hex=" + to_hex(f.data))
 }
 func main() {
-    port := 48236
+    port := 18236
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return handle(req) })
@@ -162,7 +162,7 @@ func handle(req) (res) {
 func main() {
     set_trust_proxy(1)
     set_secure_cookies(1)
-    port := 48238
+    port := 18238
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return handle(req) })
@@ -201,7 +201,7 @@ func TestMachwebMaxBody(t *testing.T) {
 	app := loopbackHelpers + `
 func main() {
     set_max_body(100)
-    port := 48239
+    port := 18239
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return ok_text("ok") })
@@ -244,7 +244,7 @@ func handle(req) (res) {
     res = ok_text("home")
 }
 func main() {
-    port := 48237
+    port := 18237
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return handle(req) })
@@ -282,7 +282,7 @@ func main() {
 func TestMachwebBinaryResponse(t *testing.T) {
 	app := loopbackHelpers + `
 func main() {
-    port := 48232
+    port := 18232
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return ok_bytes("application/octet-stream", from_hex("00ff0042")) })

--- a/operators_net_test.go
+++ b/operators_net_test.go
@@ -252,7 +252,7 @@ func TestNetworkingExampleCompiles(t *testing.T) {
 // accepts one connection, reads the request, writes a reply and exits. A Go
 // client drives it and verifies the bytes make the full round trip.
 func TestNetworkingRoundTrip(t *testing.T) {
-	const port = 47654
+	const port = 17654
 	fns := parseFuncs(t,
 		`func main() { s := listen(`+itoa(port)+`) conn := accept(s) read(conn) write(conn, "pong") close(conn) }`)
 	bin, err := os.CreateTemp("", "mfl-srv-*")
@@ -306,7 +306,7 @@ func TestNetworkingRoundTrip(t *testing.T) {
 // TestDialOutbound exercises client networking: a Go server listens, an MFL
 // program dials it with dial(host, port), writes a request, reads the reply.
 func TestDialOutbound(t *testing.T) {
-	const port = 47656
+	const port = 17656
 	ln, err := net.Listen("tcp", "127.0.0.1:"+itoa(port))
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -347,7 +347,7 @@ func TestDialOutbound(t *testing.T) {
 // server must be able to read back the client's remote IP via getpeername,
 // which is what lets a handler log or rate-limit by caller address.
 func TestPeerAddr(t *testing.T) {
-	const port = 47657
+	const port = 17657
 	fns := parseFuncs(t,
 		`func main() { s := listen(`+itoa(port)+`) conn := accept(s) print(peer_addr(conn)) close(conn) }`)
 	bin, err := os.CreateTemp("", "mfl-peeraddr-*")
@@ -401,7 +401,7 @@ func TestPeerAddr(t *testing.T) {
 // configured timeout instead of blocking forever, which is the whole point of
 // the builtin (bounding a slow/hostile client's hold on a connection).
 func TestSocketTimeout(t *testing.T) {
-	const port = 47658
+	const port = 17658
 	fns := parseFuncs(t,
 		`func main() { s := listen(`+itoa(port)+`) conn := accept(s) socket_timeout(conn, 200) r := read(conn) print("["+r+"]") close(conn) }`)
 	bin, err := os.CreateTemp("", "mfl-socktimeout-*")

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -39,7 +39,7 @@ func catch(srv) {
     }
 }
 func main() {
-    port := 48261
+    port := 18261
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go catch(srv)
@@ -86,7 +86,7 @@ func TestSMTPSendStartTLS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const port = 48262
+	const port = 18262
 	ln, err := net.Listen("tcp", "127.0.0.1:"+itoa(port))
 	if err != nil {
 		t.Fatal(err)

--- a/tls_bytes_test.go
+++ b/tls_bytes_test.go
@@ -16,7 +16,12 @@ import (
 // including an embedded NUL — proving the byte path doesn't truncate at NUL
 // the way a C-string-based tls_read/tls_write would.
 func TestTLSReadWriteBytesRoundTrip(t *testing.T) {
-	const port = 47662
+	// Ports are deliberately BELOW the ephemeral range (see
+	// /proc/sys/net/ipv4/ip_local_port_range, typically 32768-60999): a port
+	// inside it can be taken as the SOURCE port of any unrelated outbound
+	// connection, and then this server cannot bind and the test fails with
+	// "connection refused" for reasons that have nothing to do with the code.
+	const port = 17663
 	dir := t.TempDir()
 	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
 

--- a/tls_server_test.go
+++ b/tls_server_test.go
@@ -69,7 +69,12 @@ func genSelfSignedCert(t *testing.T, dir, cn string) (certPath, keyPath string) 
 // the code under test relaxing verification) drives it end-to-end: handshake,
 // write a request, read the response.
 func TestServerTLS(t *testing.T) {
-	const port = 47660
+	// Ports are deliberately BELOW the ephemeral range (see
+	// /proc/sys/net/ipv4/ip_local_port_range, typically 32768-60999): a port
+	// inside it can be taken as the SOURCE port of any unrelated outbound
+	// connection, and then this server cannot bind and the test fails with
+	// "connection refused" for reasons that have nothing to do with the code.
+	const port = 17660
 	dir := t.TempDir()
 	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
 
@@ -147,7 +152,12 @@ func TestServerTLS(t *testing.T) {
 // https_get's isn't (see #283's PR description for that manual verification —
 // tls_client_fd shares mfl_tls_dial_e's already-proven handshake code exactly).
 func TestSTARTTLS(t *testing.T) {
-	const port = 47661
+	// Ports are deliberately BELOW the ephemeral range (see
+	// /proc/sys/net/ipv4/ip_local_port_range, typically 32768-60999): a port
+	// inside it can be taken as the SOURCE port of any unrelated outbound
+	// connection, and then this server cannot bind and the test fails with
+	// "connection refused" for reasons that have nothing to do with the code.
+	const port = 17661
 	dir := t.TempDir()
 	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
@@ -212,7 +222,12 @@ func TestServeTLS(t *testing.T) {
 	if err != nil {
 		t.Skip("framework/machweb.src not found")
 	}
-	const port = 47662
+	// Ports are deliberately BELOW the ephemeral range (see
+	// /proc/sys/net/ipv4/ip_local_port_range, typically 32768-60999): a port
+	// inside it can be taken as the SOURCE port of any unrelated outbound
+	// connection, and then this server cannot bind and the test fails with
+	// "connection refused" for reasons that have nothing to do with the code.
+	const port = 17662
 	dir := t.TempDir()
 	certPath, keyPath := genSelfSignedCert(t, dir, "localhost")
 

--- a/wire_test.go
+++ b/wire_test.go
@@ -85,10 +85,10 @@ func serve_big(srv, n) {
 }
 func main() {
     n := 100000   // well over the 65535-byte single-read(2) cap
-    srv := listen(48235)
+    srv := listen(18235)
     go serve_big(srv, n)
     sleep(100)
-    c := dial("127.0.0.1", 48235)
+    c := dial("127.0.0.1", 18235)
     total := bytes("")
     reads := 0
     for {

--- a/ws_test.go
+++ b/ws_test.go
@@ -55,7 +55,7 @@ func read_some(c) (s) {
     }
 }
 func main() {
-    port := 48241
+    port := 18241
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return echo(req) })


### PR DESCRIPTION
First module from #593. **43 assertions, 24/24 functions (100%)**. Writing them turned up a shipped correctness bug and a latent test-infra bug.

## BSON int32 decoded negatives as large positives

`{"n":-5}` read back as `{"n":4294967291}`. `bs_le32` ORs four bytes together so the result is always unsigned; **int64 escapes this by accident** (its top byte shifts into the sign bit). `framework/mongo.src` decodes through this path, so any Mongo document with a negative int32 field was read wrong.

**The obvious fix is wrong, and the suite pins why.** `bs_le32` also reads document/string/binary lengths *and forms `bs_le64`'s low half*, where sign-extending would corrupt any 64-bit value whose low word has the top bit set — `0x00000000FFFFFFFF` would decode as `-1` instead of `4294967295`. So the sign lives in a new `bs_i32` used only at the int32 decode site, with a test for the 64-bit case a global fix would have broken:

```
int32 -5      -> {"n":-5}
int32 maxint  -> {"n":2147483647}
int64 2^32-1  -> {"n":4294967295}   <- the case a global fix breaks
int64 -5      -> {"n":-5}
```

## The TLS tests were never flaky — they were wrong

Three `connection refused` failures this session, which I twice called a flake. Real cause: hardcoded ports **47660/47661/47662 sit inside the Linux ephemeral range** (32768–60999), so any unrelated outbound connection can hold one as its *source* port and the MFL TLS server then cannot bind. Caught red-handed:

```
ESTAB  192.168.1.101:47662 -> 34.160.81.0:443
```

47662 was also used by **two** tests, which would collide if ever run concurrently. Moved to 17660–17663, below the range and distinct. Mechanism confirmed by occupying the port and reproducing the failure exactly.

## Suite design

Round-trip based (encode → decode → compare), **except** the little-endian helpers, which assert exact bytes — a big-endian mistake still round-trips through its own matching reader, so only literal bytes catch it. Datetime (`0x09`) has no encoder, so its decode branch is reached by hand-building the element; MongoDB returns dates constantly and it was untested.

Wired into `make mfl-test` / `mfl-cover` / `mfl-cov-floor` and CI, with bson's floor at **100%** rather than the shared 90% — it's fully covered, so hold it there.

Full suite green — `ok machin 162.645s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BSON decoding for signed 32-bit integers, including negative values in JSON output.

* **Tests**
  * Added comprehensive BSON, XML, SAML, and reactive framework test coverage.
  * Expanded automated checks and coverage validation for these components.
  * Updated networking, TLS, SMTP, WebSocket, and integration test ports to reduce conflicts with ephemeral ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->