### PR TITLE
release: v0.127.1 — BSON int32 decode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+## v0.127.1
+
+A BSON decode fix, found by writing the tests for it. `framework/*.src` is
+embedded in the binary, so a release is the only way the fix reaches anyone.
+
+**BSON int32 decoded every negative value as a large positive** (PR #596, issue
+#593). `{"n":-5}` read back as `{"n":4294967291}`. `bs_le32` ORs four bytes
+together, so its result is always unsigned; int64 escapes the same bug by accident,
+because its top byte shifts into the sign bit. `framework/mongo.src` decodes
+documents through this path, so any Mongo document carrying a negative int32 field
+was read wrong.
+
+The obvious fix — sign-extend `bs_le32` — is **wrong**, and there is now a test
+pinning why. That function also reads document/string/binary lengths *and forms
+`bs_le64`'s low half*, where sign extension corrupts any 64-bit value whose low
+word has the top bit set: `0x00000000FFFFFFFF` would decode as `-1` instead of
+`4294967295`. The sign therefore lives in a new `bs_i32` used only at the int32
+decode site.
+
+**MFL test suites for three framework modules** (#593), all running in
+`make mfl-test` and CI, each gated by its own coverage floor:
+
+| module | assertions | function coverage |
+|---|--:|--:|
+| `bson.src` | 43 | 24/24 (100%) |
+| `xml.src` | 75 | 31/31 (100%) |
+| `reactive.src` | 45 | 13/17 (76.5%) |
+
+reactive's ceiling is the module's own: `bind`/`each`/`hydrate`/`mount` call the
+`extern "env"` DOM imports, which have no native definition, so calling one makes
+the test program fail to LINK rather than fail an assertion. `router.src` is
+excluded entirely for the same reason plus `export func nav`, which is *always*
+instantiated and drags the extern in whether a test touches it or not.
+
+**The TLS/SMTP test "flakes" were a real bug, now fixed.** Three `connection
+refused` failures across recent work, twice dismissed as flakes, had one cause:
+18 hardcoded test ports sat inside the Linux ephemeral range (32768-60999), so any
+unrelated outbound connection could hold one as its *source* port and the server
+under test could then not bind. Caught in the act:
+
+```
+ESTAB  192.168.1.101:47662 -> 34.160.81.0:443
+```
+
+Two of them were also shared by different tests. All moved below 32768 and
+de-duplicated; the mechanism was confirmed by occupying a port and reproducing the
+failure exactly.
+
 ## v0.127.0
 
 `machin test` gained coverage, and the repo started actually running its own MFL

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.127.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.127.1-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.127.0
+Version 0.127.1
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.127.0"
+const machinVersion = "0.127.1"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
`framework/*.src` is embedded in the binary, so a release is the only way this reaches anyone.

## The fix

**BSON int32 decoded every negative as a large positive** — `{"n":-5}` read back as `{"n":4294967291}`, on the path `framework/mongo.src` uses. `bs_le32` ORs four bytes together so its result is always unsigned; int64 escapes the same bug by accident (its top byte shifts into the sign bit).

The obvious fix — sign-extend `bs_le32` — is **wrong**, and there's now a test pinning why: it also reads lengths *and forms `bs_le64`'s low half*, where sign extension makes `0x00000000FFFFFFFF` decode as `-1` instead of `4294967295`.

## Also shipping

MFL test suites for three framework modules (#593), each gated by its own floor:

| module | assertions | coverage |
|---|--:|--:|
| bson | 43 | 24/24 (100%) |
| xml | 75 | 31/31 (100%) |
| reactive | 45 | 13/17 (76.5%, DOM ceiling) |

And the fix for **18 hardcoded test ports inside the Linux ephemeral range** — the real cause of the TLS/SMTP failures twice dismissed as flakes.

Version bumped in all four places. Full suite green — `ok machin 188.102s`.