### PR TITLE
test(router): unblock with a native stub — 9/9, completing #593

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           /tmp/machin-ci test framework/bson.src framework/tests/bson_test.src
           /tmp/machin-ci test framework/xml.src framework/tests/xml_test.src
           /tmp/machin-ci test framework/reactive.src framework/tests/reactive_test.src
+          /tmp/machin-ci test framework/reactive.src framework/router.src framework/tests/router_test.src
 
       # Coverage FLOOR, not a report: a ratchet set just under what the suites
       # measure today, so a regression fails here rather than being noticed later.

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ mfl-test: build
 	$(BIN) test framework/bson.src framework/tests/bson_test.src
 	$(BIN) test framework/xml.src framework/tests/xml_test.src
 	$(BIN) test framework/reactive.src framework/tests/reactive_test.src
+	$(BIN) test framework/reactive.src framework/router.src framework/tests/router_test.src
 
 # Same suites with function + statement coverage (#589), as a human-readable report.
 mfl-cover: build
@@ -39,6 +40,7 @@ mfl-cover: build
 	$(BIN) test --cover framework/bson.src framework/tests/bson_test.src
 	$(BIN) test --cover framework/xml.src framework/tests/xml_test.src
 	$(BIN) test --cover framework/reactive.src framework/tests/reactive_test.src
+	$(BIN) test --cover framework/reactive.src framework/router.src framework/tests/router_test.src
 
 # MFL coverage floors — a RATCHET, like cov-floor is for the Go side. Set just
 # under what the suites measure today (flags.src: 90.9% function, 82.1% statement
@@ -65,6 +67,11 @@ XML_FUNC_FLOOR ?= 100
 # property of the module, not a gap in the suite — raising this floor requires a
 # native stub or a wasm test path (#593), not more tests.
 REACTIVE_FUNC_FLOOR ?= 76
+# router.src is fully covered (9/9) via framework/tests/router_stub.c, which
+# supplies no-op natives for its wasm DOM imports. Its STATEMENT floor is lower
+# than the shared one because its composed program drags in all of reactive.src,
+# most of which this suite does not exercise.
+ROUTER_FUNC_FLOOR ?= 100
 
 mfl-cov-floor: build
 	@$(BIN) test --cover --json framework/flags.src framework/tests/flags_test.src 2>/dev/null \
@@ -79,6 +86,9 @@ mfl-cov-floor: build
 	@$(BIN) test --cover --json framework/reactive.src framework/tests/reactive_test.src 2>/dev/null \
 		| python3 tools/cov-floor.py --module framework/reactive.src \
 			--func $(REACTIVE_FUNC_FLOOR) --stmt $(MFL_STMT_FLOOR)
+	@$(BIN) test --cover --json framework/reactive.src framework/router.src framework/tests/router_test.src 2>/dev/null \
+		| python3 tools/cov-floor.py --module framework/router.src \
+			--func $(ROUTER_FUNC_FLOOR) --stmt 60
 
 # Statement coverage of the compiler. `make cover` prints the % and writes an
 # HTML report to coverage.html (open it to see which lines are unhit). The corpus

--- a/framework/tests/router_stub.c
+++ b/framework/tests/router_stub.c
@@ -1,0 +1,18 @@
+/* Test-only native definitions for router.src's `extern "env"` DOM imports.
+ *
+ * router.src is half a wasm binding: dom_html and nav_url are imports the browser
+ * host supplies. Natively they resolve to nothing, and `export func nav` is ALWAYS
+ * instantiated, so it drags them into the link whether a test calls them or not —
+ * which made the module impossible to build under `machin test` at all.
+ *
+ * These no-ops let the pure routing logic (route / path_index / link /
+ * current_route) be tested natively. They deliberately record nothing: asserting
+ * on DOM side effects would be testing this stub, not router.src.
+ */
+void dom_html(const char *id, const char *html) { (void)id; (void)html; }
+void nav_url(const char *path) { (void)path; }
+
+/* An extern block must declare at least one fn, and a block's cflags are only
+ * emitted when the block is used — so the suite calls this once to pull the stub
+ * into the build. */
+void router_stub_link(void) {}

--- a/framework/tests/router_test.src
+++ b/framework/tests/router_test.src
@@ -1,0 +1,193 @@
+// router_test — exercises framework/router.src's path logic in MFL, via
+// `machin test`. Run from the repo root (the stub path below is relative to it):
+//   machin test framework/reactive.src framework/router.src framework/tests/router_test.src
+// or `make mfl-test`, which is what CI runs.
+//
+// reactive.src comes first because router's signals are reactive's.
+//
+// WHY THE STUB. router.src is half a wasm binding: dom_html and nav_url are
+// `extern "env"` imports the browser host provides, and natively they resolve to
+// nothing. Worse, `export func nav` is ALWAYS instantiated, so it pulls
+// navigate -> nav_url into the link whether or not a test calls them — the module
+// could not be built under `machin test` at all. framework/tests/router_stub.c
+// supplies no-op natives so the pure routing logic can be reached. The stub
+// records nothing on purpose: asserting on DOM side effects would be testing the
+// stub, not router.src.
+
+var nav_runs = 0
+
+extern "router_stub" {
+    cflags "framework/tests/router_stub.c"
+    fn router_stub_link()
+}
+
+// NOTE ON STATE. router_init creates a fresh active-route SIGNAL but does NOT
+// reset the route table: route_paths/route_n accumulate for the life of the
+// process. A real app registers its routes once, so this is not a production bug —
+// but it means indices are only meaningful RELATIVE to what a test registered, and
+// a second router_init does not give you a clean slate. Every test below therefore
+// registers uniquely-named paths and compares against the indices route() returned.
+func test_route_registration_is_index_ordered() {
+    router_init(0)
+    a := route("/reg/a")
+    b := route("/reg/b")
+    c := route("/reg/c")
+    assert_eq_int(b, a + 1, "indices are consecutive")
+    assert_eq_int(c, b + 1, "and keep incrementing")
+}
+
+// The sharp edge itself, pinned: calling router_init again does not clear routes.
+func test_router_init_does_not_reset_the_route_table() {
+    router_init(0)
+    first := route("/reset/one")
+    router_init(0)
+    second := route("/reset/two")
+    assert_eq_int(second, first + 1, "the table carries over across router_init")
+}
+
+func test_path_index_finds_registered_paths() {
+    router_init(0)
+    a := route("/find/root")
+    b := route("/find/users")
+    c := route("/find/about")
+    assert_eq_int(path_index("/find/root"), a, "first")
+    assert_eq_int(path_index("/find/users"), b, "middle")
+    assert_eq_int(path_index("/find/about"), c, "last")
+}
+
+// PINNING A SHARP EDGE, not endorsing it. path_index has no not-found signal: an
+// unregistered path yields 0, so a typo'd or stale deep link silently lands on
+// whatever route was registered first rather than 404-ing. Changing that is a
+// product decision (navigate(-1) would index out of range), so it is tracked
+// separately rather than "fixed" inside a test suite.
+func test_unknown_path_falls_back_to_route_zero() {
+    router_init(0)
+    route("/unk/a")
+    route("/unk/b")
+    assert_eq_int(path_index("/nope"), 0, "unknown path yields 0, NOT -1")
+    assert_eq_int(path_index(""), 0, "empty path yields 0 too")
+}
+
+func test_path_matching_is_exact() {
+    router_init(0)
+    short := route("/exact/u")
+    long := route("/exact/u/new")
+    assert_eq_int(path_index("/exact/u"), short, "exact match wins over the longer path")
+    assert_eq_int(path_index("/exact/u/new"), long, "the longer path is its own route")
+    // A prefix-matching implementation would resolve "/pre/ab" to "/pre/a".
+    pa := route("/pre/a")
+    pab := route("/pre/ab")
+    assert_eq_int(path_index("/pre/ab"), pab, "/pre/ab is not matched as a prefix of /pre/a")
+    assert_eq_int(path_index("/pre/a"), pa, "and /pre/a still resolves to itself")
+}
+
+func test_current_route_reflects_navigation() {
+    router_init(0)
+    route("/nav/a")
+    route("/nav/b")
+    assert_eq_int(current_route(), 0, "starts at the initial index")
+    navigate(1)
+    assert_eq_int(current_route(), 1, "navigate moves the active route")
+    navigate(0)
+    assert_eq_int(current_route(), 0, "and back")
+}
+
+func test_router_init_sets_the_initial_route() {
+    router_init(2)
+    route("/init/a")
+    route("/init/b")
+    route("/init/c")
+    assert_eq_int(current_route(), 2, "the initial index is honoured, not forced to 0")
+}
+
+// current_route reads a signal, so a reaction that calls it must re-run on
+// navigation — that is what makes an outlet re-render.
+func test_navigation_wakes_a_reaction() {
+    router_init(0)
+    route("/wake/a")
+    route("/wake/b")
+    // Count in a plain global, NOT a signal. A reaction that both reads and writes
+    // the same signal dirties itself, and commit() re-runs to a fixpoint that never
+    // arrives — the process is OOM-killed rather than failing an assertion.
+    nav_runs = 0
+    reaction(func() { current_route()  nav_runs = nav_runs + 1 })
+    assert_eq_int(nav_runs, 1, "the reaction ran once when registered")
+    navigate(1)
+    assert_eq_int(nav_runs, 2, "navigating re-runs a reaction that read the route")
+    navigate(1)
+    assert_eq_int(nav_runs, 2, "navigating to the SAME route does not re-run it")
+}
+
+// outlet wires a render closure to a container through a reaction. The stub's
+// dom_html swallows the output, so what is asserted is the WIRING: the render
+// closure runs on registration and again on navigation.
+func test_outlet_renders_on_navigation() {
+    router_init(0)
+    route("/out/a")
+    route("/out/b")
+    nav_runs = 0
+    outlet("app", func() { nav_runs = nav_runs + 1  return "page " + str(current_route()) })
+    assert_eq_int(nav_runs, 1, "outlet renders once when mounted")
+    navigate(1)
+    assert_eq_int(nav_runs, 2, "and re-renders when the route changes")
+}
+
+// write_cstr fills a host buffer the way the browser host does: raw bytes then a
+// NUL terminator, which is what ptr_str reads back.
+func write_cstr(p, s) {
+    b := bytes(s)
+    i := 0
+    while i < len(b) {
+        poke_u8(p, i, byte_at(b, i))
+        i = i + 1
+    }
+    poke_u8(p, len(b), 0)
+}
+
+// The HOST INTERFACE, exercised natively. nav_buf/nav are the pair the browser
+// calls for a link click or popstate: allocate a buffer, write the path into wasm
+// memory, hand back the pointer. alloc/poke_u8/ptr_str/free all work natively, so
+// the whole round trip is testable without a browser — nav() frees the buffer, so
+// this must not free it again.
+func test_nav_from_a_host_buffer() {
+    router_init(0)
+    route("/host/a")
+    target := route("/host/b")
+    path := "/host/b"
+    p := nav_buf(len(path))
+    assert(p != 0, "nav_buf returns a usable buffer")
+    write_cstr(p, path)
+    nav(p)
+    assert_eq_int(current_route(), target, "the host's path string routed to the right index")
+}
+
+func test_link_markup() {
+    h := link("/users", "Users")
+    assert_eq_str(h, "<a href=\"/users\" data-nav=\"/users\">Users</a>",
+        "anchor carries both href and the data-nav hook the host intercepts")
+}
+
+func test_link_escapes_nothing_by_design() {
+    // Paths and labels are author-supplied constants in this router, not user
+    // input, so link does no escaping. Pinned so that if it ever renders untrusted
+    // text, the change is deliberate rather than assumed-safe.
+    h := link("/a", "<b>")
+    assert(contains(h, "<b>"), "label is emitted verbatim")
+}
+
+func main() {
+    router_stub_link()
+    test_route_registration_is_index_ordered()
+    test_router_init_does_not_reset_the_route_table()
+    test_path_index_finds_registered_paths()
+    test_unknown_path_falls_back_to_route_zero()
+    test_path_matching_is_exact()
+    test_current_route_reflects_navigation()
+    test_router_init_sets_the_initial_route()
+    test_navigation_wakes_a_reaction()
+    test_outlet_renders_on_navigation()
+    test_nav_from_a_host_buffer()
+    test_link_markup()
+    test_link_escapes_nothing_by_design()
+    test_summary()
+}

--- a/testcmd.go
+++ b/testcmd.go
@@ -239,7 +239,11 @@ func declOwners(files []string) map[string]string {
 			continue
 		}
 		for _, b := range blocks {
-			rest, ok := strings.CutPrefix(strings.TrimSpace(normalize(b)), "func ")
+			decl := strings.TrimSpace(normalize(b))
+			// `export func` is still a declaration this file owns — matching only
+			// "func " filed every exported function under "(unknown)".
+			decl = strings.TrimPrefix(decl, "export ")
+			rest, ok := strings.CutPrefix(decl, "func ")
 			if !ok {
 				continue
 			}


### PR DESCRIPTION
I called router "blocked, needs a design decision". It needed **six lines of C**.

`framework/tests/router_stub.c` supplies no-op natives for `dom_html`/`nav_url`, pulled in via an extern block's `cflags`. That's enough — `export func nav` is always instantiated and drags those imports into every native link, which is what made the module unbuildable under `machin test`.

**25 assertions, 9/9 functions, including the wasm host interface.** `nav_buf`/`nav` look browser-only, but `alloc`/`poke_u8`/`ptr_str`/`free` all work natively, so the full round trip is testable: allocate a buffer, write the path as the host would, call `nav`, assert the route changed. No browser, no wasm runtime.

## Two router defects found → #598

Pinned as *current* behaviour, not silently changed — routing semantics are a product decision:

- **`path_index` has no not-found signal.** An unregistered path returns **0**, so a typo'd deep link lands on route 0 instead of 404-ing. It can't just return -1: `nav()` does `navigate(path_index(path))`, and `navigate(-1)` would index out of range.
- **`router_init` does not reset the route table.** `route_paths`/`route_n` only grow. It bit this suite immediately — every test after the first saw shifted indices — which is why tests now register unique paths and assert against returned indices.

## And a bug in the coverage tool itself

`declOwners` matched only `"func "`, so every **`export func`** was filed under `(unknown)` and excluded from its module's denominator. Router reported 7/7 instead of 7/9, hiding two uncovered functions — exactly the silent-denominator failure #589's design notes warned about, in the code meant to prevent it.

## #593 complete

| module | coverage | floor |
|---|--:|--:|
| bson | 24/24 (100%) | 100 |
| xml | 31/31 (100%) | 100 |
| router | 9/9 (100%) | 100 |
| reactive | 13/17 (76.5%) | 76 |

reactive's ceiling is real: `bind`/`each`/`hydrate`/`mount` need a DOM, and stubbing them would test the stub.

Full suite green — `ok machin 195.875s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive router test coverage for route registration, matching, navigation, reactive updates, rendering, and link handling.
  * Added browser-function test stubs to support native router testing.
  * Added router tests to continuous integration and coverage checks.
  * Improved test coverage reporting for exported functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->