### PR TITLE
feat: grow append in place where the alias analysis proves it safe (#578 steps 3+4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,11 @@ Zig `ReleaseFast` (min of 9 rounds, this machine):
 | Rust `-O3` | 289.7 ms | 720.1 ms | 142.9 ms | 3223.8 ms |
 | Zig fast | 292.9 ms | **702.8 ms** | **137.9 ms** | 3189.7 ms |
 
-**Wins 1 clearly, ties 2, loses 1.** Unboxed values, no interpreter, no VM.
-The sieve gap is *not* slice indexing — that loop ties Rust exactly (110 ms vs
-111 ms); it's `append`'s growth path ([#578](https://github.com/javimosch/machin/issues/578)).
+**Wins 1, ties 2, and the sieve now ties Rust too** (it still trails Zig by ~1.19×).
+Unboxed values, no interpreter, no VM. The sieve gap was never slice indexing —
+that loop always tied Rust; it was `append` copying into a fresh block on every
+growth, fixed in [#578](https://github.com/javimosch/machin/issues/578) by proving
+a slice unaliased and then growing it in place. The table above predates that fix.
 
 Where machin beats **Rust**: **binary size** — 14 kB stripped vs 335 kB, both dynamic.
 Read that as a fixed offset (Rust starts ~320 kB ahead), not a ratio: machin's hello

--- a/bench/native-speed/README.md
+++ b/bench/native-speed/README.md
@@ -54,39 +54,42 @@ is squarely in the **compiled-native performance class**, with no VM, no
 interpreter, unboxed values — and it gets there from source an AI agent writes
 about as cheaply as Python (see [`../rest-sqlite`](../rest-sqlite)).
 
-## The sieve gap is `append`, not indexing
+## The sieve gap was `append`, and it is now largely closed
 
-This README used to explain the sieve loss as *"its slice indexing/layout is
-less optimal than a Rust `Vec` or a Zig slice."* **That was wrong**, and
-phase-timing the kernel shows it plainly:
+This README used to explain the sieve loss as *"its slice indexing/layout is less
+optimal than a Rust `Vec` or a Zig slice."* **That was wrong.** Phase-timing showed
+slice indexing tying Rust exactly, with the whole gap in building the array:
 
-| phase | machin | Rust |
+| phase | machin (before) | Rust |
 |---|--:|--:|
 | build the 10M array by `append` | **70–83 ms** | **27–29 ms** |
-| **the sieve loop itself** | **110 ms** | **111 ms** |
+| the sieve loop itself | 110 ms | 111 ms |
 | the count loop | 5–7 ms | 3 ms |
 
-Slice indexing ties Rust exactly. The generated C for the hot loop is already
-what you would write by hand — direct pointer indexing, no bounds check, no
-indirection:
+`mfl_realloc` could only ever *copy* into a fresh arena block, because an arena
+frees nothing mid-life — so growing to 10M elements walked ~21 doublings, each
+allocating and memcpy'ing and never releasing the previous buffer. `Vec::push`
+hands the block to `realloc`, which extends it in place via `mremap`.
 
-```c
-while ((v_m <= v_n)) { ((int64_t*)(v_sieve).data)[v_m] = 0LL; v_m = (v_m + v_p); }
-```
+**Fixed in #578.** `machin alias` proves, fail-closed, that a local slice has no
+other live reference across an append; where it does, codegen grows the block in
+place instead. Measured on the CI runner (a quieter machine than this laptop),
+before and after, normalized against Rust because the runner drifted ~15% slower
+between sessions:
 
-The whole gap is `append`'s growth path: `mfl_realloc` can only ever *copy* into
-a fresh arena block, because an arena frees nothing mid-life. Growing to 10M
-elements walks ~21 doublings, each allocating and memcpy'ing, and never releasing
-the previous buffer — so it faults in roughly 2× the final array in fresh pages.
-`Vec::push` hands the block to `realloc`, which extends large blocks in place via
-`mremap` and copies nothing.
+| | machin | Rust | Zig | machin/Rust |
+|---|--:|--:|--:|--:|
+| before | 96.7 ms | 87.7 ms | 73.0 ms | **1.10×** |
+| after | 101.9 ms | 100.6 ms | 86.0 ms | **1.01×** |
 
-The tempting fix — hand the arena's most recent block straight to `realloc` — is
-**unsound in MFL and was rejected**, because slices share backing storage
-(`b := a` aliases, and so does passing a slice to a function). Today an
-abandoned block stays live, so every existing alias keeps reading valid memory;
-with in-place growth those aliases would become use-after-free. Tracked with the
-sound alternatives in **issue #578**.
+**The sieve now ties Rust.** It does *not* tie Zig, which is still ~1.19× faster
+on this kernel — down from 1.32×, but a real remaining gap and reported as one.
+
+The tempting version of this fix — hand any arena block straight to `realloc` — is
+**unsound**, because slices share backing storage (`b := a` aliases, and so does
+passing a slice to a function). That is why it is gated on a proof rather than
+done unconditionally, and why an adversarial suite runs under AddressSanitizer in
+CI.
 
 ## Fairness notes
 

--- a/codegen.go
+++ b/codegen.go
@@ -102,6 +102,7 @@ type cgen struct {
 	tramp        strings.Builder // goroutine trampolines
 	goID         int
 	jsonFns      strings.Builder      // generated per-type JSON serializers + parsers
+	unaliased    map[string]bool      // "inst\x00var" -> append may grow in place (#578)
 	cover        bool                 // emit function-entry coverage counters (#589)
 	covIdx       map[string]int       // source function name -> counter slot
 	covNames     []string             // counter slot -> source function name
@@ -401,6 +402,55 @@ static int64_t mfl_narrow(int64_t v, int64_t lo, int64_t hi, const char* label) 
     return v;
 }
 
+/* mfl_realloc_owned / mfl_append_owned — the in-place growth path (#578).
+   Emitted ONLY at append sites where 'machin alias' proved the slice has no other
+   live reference across the append (see alias.go). With that proof, moving the
+   array cannot invalidate anything, so the block can be handed to realloc()
+   instead of being copied into a fresh one and abandoned.
+
+   TWO GUARDS, because the static proof alone is not enough:
+
+   1. HEAD ONLY. The arena is a singly-linked list, so growing a mid-list block
+      would need its predecessor. Only the most recent allocation is grown in
+      place; anything else falls back to the copy path. That is not much of a
+      restriction in practice — a tight append loop allocates nothing in between,
+      which is exactly when this matters.
+
+   2. STRLEN CACHE INVALIDATION. mfl_strlen_cached keys on pointer identity, sound
+      only while the arena frees nothing mid-life. realloc hands an address back to
+      the allocator, where a later malloc may reuse it — so the cache must be
+      dropped on this path or a future substr() could read a stale length. */
+static void* mfl_realloc_owned(void* old, size_t sz) {
+    if (sz == 0) sz = 1;
+    if (old) {
+        if (!mfl_arena_cur) mfl_arena_cur = &mfl_main_arena;
+        mfl_blk* b = (mfl_blk*)old - 1;
+        if (mfl_arena_cur->head == b) {
+            size_t oldsz = b->size;
+            mfl_blk* nb = (mfl_blk*)realloc(b, sizeof(mfl_blk) + sz);
+            if (nb) {
+                nb->size = sz;
+                mfl_arena_cur->head = nb;
+                mfl_arena_cur->bytes = mfl_arena_cur->bytes - oldsz + sz;
+                mfl_strlen_cache_s = NULL; /* see guard 2 above */
+                return (void*)(nb + 1);
+            }
+            /* realloc failed: b is still valid, fall through to the copy path */
+        }
+    }
+    void* p = mfl_alloc(sz);
+    if (old) { size_t o = ((mfl_blk*)old - 1)->size; memcpy(p, old, o < sz ? o : sz); }
+    return p;
+}
+static mfl_slice mfl_append_owned(mfl_slice s, const void* elem, int64_t es) {
+    if (s.len >= s.cap) {
+        int64_t nc = s.cap ? s.cap * 2 : 4;
+        s.data = mfl_realloc_owned(s.data, nc * es); s.cap = nc;
+    }
+    memcpy((char*)s.data + s.len * es, elem, es);
+    s.len++;
+    return s;
+}
 static mfl_slice mfl_append(mfl_slice s, const void* elem, int64_t es) {
     if (s.len >= s.cap) {
         int64_t nc = s.cap ? s.cap * 2 : 4;
@@ -4240,6 +4290,15 @@ func (g *cgen) program(p *Program) (string, error) {
 	for _, name := range g.c.GlobalOrder() {
 		g.globals[name] = true
 	}
+	// Which local slices no other live reference observes. Computed once for the
+	// whole program; consulted only at self-append sites (see stmt()). An empty map
+	// means every append keeps today's copy-and-abandon behaviour.
+	g.unaliased = map[string]bool{}
+	for _, a := range analyzeSliceAliasing(p, g.c) {
+		if a.Unaliased && a.Appends > 0 {
+			g.unaliased[a.Fn+"\x00"+a.Var] = true
+		}
+	}
 	// Coverage slots come from the PARSED program, so a function nothing calls
 	// still occupies a slot and reports as a miss. Lambdas are excluded: they are
 	// lifted compiler artifacts, not functions anyone declared or can test by name.
@@ -4694,6 +4753,30 @@ func (g *cgen) function(inst string) error {
 	return nil
 }
 
+// ownedAppend renders `v = append(v, x)` through the in-place growth path when the
+// analysis proved v has no other live reference across this append (#578). Returns
+// ok=false for every other shape, so the caller falls back to normal emission.
+func (g *cgen) ownedAppend(st *AssignStmt) (string, bool, error) {
+	if !g.unaliased[g.curFn+"\x00"+st.Name] {
+		return "", false, nil
+	}
+	call, ok := st.Val.(*Call)
+	if !ok || call.Callee != "append" || call.Spread || len(call.Args) != 2 {
+		return "", false, nil
+	}
+	self, ok := call.Args[0].(*Ident)
+	if !ok || self.Name != st.Name {
+		return "", false, nil
+	}
+	val, err := g.expr(call.Args[1])
+	if err != nil {
+		return "", false, err
+	}
+	ct := g.c.ElemCType(g.curFn, call.Args[0])
+	return fmt.Sprintf("mfl_append_owned(%s, &((%s[1]){%s})[0], sizeof(%s))",
+		g.varRef(st.Name), ct, val, ct), true, nil
+}
+
 // emitNamedReturn writes a return of the function's named return locals.
 func (g *cgen) emitNamedReturn(inst string) {
 	names := g.c.RetNames(inst)
@@ -4765,6 +4848,17 @@ func (g *cgen) stmt(s Stmt, depth int) error {
 		}
 		g.buf.WriteString(e + ";\n")
 	case *AssignStmt:
+		// v = append(v, x) where the alias analysis proved v unaliased across this
+		// append: grow the block in place instead of copying into a fresh one.
+		// Everything else, including every append the analysis did not clear, keeps
+		// the copy-and-abandon path.
+		if e, ok, err := g.ownedAppend(st); err != nil {
+			return err
+		} else if ok {
+			fmt.Fprintf(&g.buf, "%s = %s;\n", g.varRef(st.Name), e)
+			g.emitProbe(st.Name, g.c.NodeKind(g.curFn, st.Val), depth)
+			return nil
+		}
 		e, err := g.expr(st.Val)
 		if err != nil {
 			return err

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -23,7 +23,7 @@ marketing, not evidence.
 | recursion (`fib 40`) | **26% faster** | **27% faster** | [native-speed](../bench/native-speed) |
 | float loop (mandelbrot) | tie | tie (1.03×) | [native-speed](../bench/native-speed) |
 | integer loop (`intsum 10⁹`) | tie (+3%) | tie (+3%) | [native-speed](../bench/native-speed) |
-| array build + sieve | **1.41× slower** | **1.46× slower** | [native-speed](../bench/native-speed) |
+| array build + sieve | **tie** (1.01×, was 1.41×) | 1.19× slower (was 1.46×) | [native-speed](../bench/native-speed) |
 | build time | **slower** (~100 ms vs ~57 ms) | **~3x faster** warm, ~35x cold (Zig 0.15.2) | [compile-speed](../bench/compile-speed) |
 | binary size floor, stripped, dynamic | **~320 kB smaller** (14 kB vs 335 kB) | tie (Zig 16 kB, and static) | [compile-speed](../bench/compile-speed) |
 | binary size, fully static | — | **~60× larger** (940 kB vs 16 kB) | [compile-speed](../bench/compile-speed) |
@@ -153,7 +153,7 @@ than Rust"*. Earlier is worth a lot — a bug caught at build time with a concre
 input costs minutes, and the same bug reaching production as a hung process costs
 far more — but it is a different claim, and it does not replace Rust's.
 
-### The sieve — 1.46× slower, and the published reason was wrong
+### The sieve — fixed, and the published reason had been wrong
 
 The benchmark long explained this as machin's "slice indexing/layout" being worse
 than a Rust `Vec`. Phase-timing disproves that:
@@ -168,11 +168,20 @@ Indexing ties exactly. The whole gap is `append`'s growth path: an arena frees
 nothing mid-life, so `mfl_realloc` can only ever allocate fresh and memcpy, never
 extend in place the way `Vec::push` does via `mremap`.
 
-The obvious fix — hand the arena's newest block straight to `realloc` — was
-implemented, tested, and **rejected as unsound**: MFL slices share backing storage
-(`b := a` aliases, and so does passing a slice to a function), so in-place growth
-would turn every existing alias into a use-after-free. Tracked with sound
-alternatives in [#578](https://github.com/javimosch/machin/issues/578).
+The obvious fix — hand the arena's newest block straight to `realloc` — is
+**unsound**: MFL slices share backing storage (`b := a` aliases, and so does
+passing a slice to a function), so unconditional in-place growth turns every
+existing alias into a use-after-free.
+
+**#578 fixed it properly.** `machin alias` proves, fail-closed, that a local slice
+has no other live reference across an append; only then does codegen grow the
+block in place. An adversarial suite of live-alias shapes runs under
+AddressSanitizer in CI, and was verified to catch the unsound version.
+
+Measured on the CI runner before and after, normalized against Rust because the
+runner drifted ~15% between sessions: **machin/Rust went 1.10× → 1.01×** on the
+sieve. It now ties Rust. It still trails **Zig** by ~1.19× (down from 1.32×) —
+a real remaining gap, reported as one.
 
 ## Verified on a second machine
 

--- a/guide.go
+++ b/guide.go
@@ -169,7 +169,7 @@ func machinGuide() guideCatalog {
 				},
 				{
 					Axis:      "native runtime speed",
-					Result:    "vs Rust -O3 / Zig ReleaseFast on 4 kernels with byte-identical output, timed interleaved (not language-by-language, which lets thermal drift penalize whoever runs last): wins recursive fib(40) by ~26%, ties a 10^9 integer-sum loop and a float-heavy mandelbrot within a few percent, trails an array-heavy sieve by ~1.46x. That last gap is NOT slice indexing — phase timing shows the sieve loop itself ties Rust exactly (110ms vs 111ms); the whole difference is building the 10M-element array by append, because a growing slice cannot be realloc'd in place (see issue #578)",
+					Result:    "vs Rust -O3 / Zig ReleaseFast on 4 kernels with byte-identical output, timed interleaved (not language-by-language, which lets thermal drift penalize whoever runs last): wins recursive fib(40) by ~26%, ties a 10^9 integer-sum loop and a float-heavy mandelbrot within a few percent, and the array-heavy sieve now TIES Rust (1.01x, was 1.41x) though it still trails Zig by ~1.19x. That gap was never slice indexing — phase timing showed the sieve loop itself tying Rust exactly (110ms vs 111ms); the whole difference was building the 10M-element array by append, which copied into a fresh block on every growth. FIXED in #578: `machin alias` proves fail-closed that a local slice has no other live reference across an append, and only then does codegen grow the block in place, guarded at runtime by an arena-head check. An adversarial suite of live-alias shapes runs under AddressSanitizer in CI and was verified to catch the unsound version of the same optimization",
 					Reproduce: "bench/native-speed: ./run.sh (needs machin, cc, rustc, zig, python3)",
 				},
 				{


### PR DESCRIPTION
Completes #578. The sieve — the last loss in `bench/native-speed` — now **ties Rust**.

## What changed

At a `v = append(v, x)` site where `machin alias` (#600) proved v has no other live reference across that append, the block is handed to `realloc` instead of copied into a fresh one and abandoned. **Every other append is untouched.**

Two runtime guards the static proof can't express:

1. **Head only** — the arena is singly-linked, so only its most recent allocation grows in place; anything else falls back. Barely a restriction: a tight append loop allocates nothing in between, which is exactly when it matters.
2. **Strlen-cache invalidation** — `mfl_strlen_cached` keys on pointer identity, sound only while the arena frees nothing mid-life. `realloc` hands an address back to the allocator, so the cache is dropped on this path. Missing it would have been a silent wrong-length bug in `substr()`, far from anything resembling `append`.

## Measured on the CI runner, not this laptop

| | machin | Rust | Zig | machin/Rust |
|---|--:|--:|--:|--:|
| before | 96.7 ms | 87.7 ms | 73.0 ms | **1.10×** |
| after | 101.9 ms | 100.6 ms | 86.0 ms | **1.01×** |

Absolute ms went *up* because the whole runner was ~15% slower that session — which is precisely why the ratio to a control is what's quoted. The laptop showed a bigger swing (1.46× → 1.06×) because slower memory makes the append penalty a larger share, but it was at 58–68% noise and isn't a publishable source.

**It does not tie Zig** — still ~1.19× behind (from 1.32×). Reported as a remaining gap rather than rounded away.

## Verification

- **ASan adversarial suite (#601) stays green** — every live-alias-across-append shape still reads correct data.
- **Emission checked both ways**: the sieve gets 1 owned call site; a program that aliases before appending gets 0.
- **Differential output**: 49 of 49 deterministic examples byte-identical. The 50th, `goroutines.mfl`, differs — but it's nondeterministic by nature (the *old* compiler gives three different outputs in three runs) and contains zero appends.
- Full suite green — `ok machin 249.496s`.

## Docs

Corrects the standing explanation everywhere: the sieve gap was **never slice indexing** — that loop always tied Rust. The README's kernel table is explicitly marked as predating the fix rather than left looking current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved array-building and sieve benchmark performance to effectively match Rust.
  - Optimized eligible slice appends through safe in-place growth while preserving existing behavior for other cases.

- **Documentation**
  - Updated benchmark results and performance explanations across the documentation.
  - Clarified the conditions and safety considerations for in-place append optimization.
  - Added coverage details for aliasing scenarios detected with AddressSanitizer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->