### PR TITLE
release: v0.129.0 — SQLite on the windows target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## Unreleased
 
+## v0.129.0
+
+**SQLite works on the windows target** (PR #604, issue #517) — and unlike the last
+two Windows releases, that claim is backed by a machine that ran it.
+
+It needed bundling, not porting. machin's SQLite glue is pure `sqlite3` API with
+zero POSIX in it, and the amalgamation carries its own Win32 VFS, so the same
+vendored source the native `--static` build compiles in works unchanged for
+`x86_64-windows-gnu`. No external library, no DLL, nothing for a user to install.
+
+```
+machin build app.mfl --target windows -o app.exe
+```
+
+**Verified by execution.** CI cross-compiles a SQLite program on Linux, uploads
+the `.exe`, and a `windows-latest` job runs it and asserts the query result:
+
+```
+output: [{"id":1,"name":"windows"}]
+```
+
+That job exists because of this repo's own history: the windows target was broken
+across two releases while CI happily compiled it (#549), and the pre-existing
+smoke step only checked that the file was non-empty. A PE that links is not
+evidence of a PE that works.
+
+**The issue's bookkeeping was wrong and is corrected.** Its title says four gaps;
+the preflight had six — `select` and zlib had been added since without updating
+it. Five remain: tty raw mode, `select`, XEdDSA (needs a mingw libsodium), regex
+(POSIX `<regex.h>` has no Windows equivalent), and zlib (needs a mingw libz).
+
+Each still fails loudly at compile time with a #517 message naming the subsystem,
+which is exactly why they are safe to leave open — nobody is silently broken.
+
+The preflight test that asserted SQLite is *rejected* was the gap encoded as a
+rule; it is now a positive test, with regex and XEdDSA taking its place among the
+rejection cases.
+
+**Three more test ports moved out of the ephemeral range**, and one cross-file
+collision fixed. v0.127.1 swept the hardcoded ports that could be stolen by an
+unrelated outbound connection (Linux ephemeral range 32768-60999), but that sweep
+matched on `port = NNNNN` and missed ports passed as bare arguments inside MFL
+source strings — `serve_mock(48310, …)` in the Redis test, plus the SSO and wire
+tests. A full-suite run caught the Redis one; the fix this time greps the NUMBERS
+rather than the syntax, and additionally checks no two test files share a port.
+
 ## v0.128.0
 
 The last loss in `bench/native-speed` is gone: **the array-heavy sieve now ties

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.128.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.129.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.128.0
+Version 0.129.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.128.0"
+const machinVersion = "0.129.0"
 
 // ---- the source-of-truth feature catalog ----
 //

--- a/redis_test.go
+++ b/redis_test.go
@@ -41,9 +41,9 @@ func serve_mock(port, replies) {
 }
 func main() {
     replies := []string{"+OK\r\n", "$5\r\nhello\r\n", "$-1\r\n", ":7\r\n", "*2\r\n$1\r\na\r\n$3\r\nbbb\r\n"}
-    go serve_mock(48310, replies)
+    go serve_mock(18310, replies)
     sleep(80)
-    redis_connect("127.0.0.1", 48310)
+    redis_connect("127.0.0.1", 18310)
     println("set=" + str(redis_set("k", "v")))           // +OK -> ok 1
     g, ok := redis_get("k")
     println("get=" + g + ":" + str(ok))                  // $5 hello -> "hello":1

--- a/sso_test.go
+++ b/sso_test.go
@@ -36,9 +36,9 @@ func mock(req) (res) {
     }
 }
 func main() {
-    go serve(48306, func(req) { return mock(req) })
+    go serve(18306, func(req) { return mock(req) })
     sleep(120)
-    p := OAuthProvider{auth_url: "http://localhost:48306/auth", token_url: "http://localhost:48306/token", userinfo_url: "http://localhost:48306/userinfo", client_id: "cid", client_secret: "sec", redirect_uri: "http://app/cb", scope: "openid email"}
+    p := OAuthProvider{auth_url: "http://localhost:18306/auth", token_url: "http://localhost:18306/token", userinfo_url: "http://localhost:18306/userinfo", client_id: "cid", client_secret: "sec", redirect_uri: "http://app/cb", scope: "openid email"}
     println("login=" + sso_login_url(p, "st8"))
     secret := "shh"
     state := "deadbeef"
@@ -65,7 +65,7 @@ func main() {
 		t.Fatalf("run: %v", err)
 	}
 	for _, want := range []string{
-		"login=http://localhost:48306/auth?response_type=code&client_id=cid", // url built
+		"login=http://localhost:18306/auth?response_type=code&client_id=cid", // url built
 		"redirect_uri=http%3A%2F%2Fapp%2Fcb",                                 // url-encoded
 		`ok=1 email="ada@x.com"`,                                             // exchange + userinfo succeeded
 		"csrf_ok=0",                                                          // state mismatch blocked

--- a/wire_test.go
+++ b/wire_test.go
@@ -42,10 +42,10 @@ func TestReadBytesBinarySocket(t *testing.T) {
 	prog := progFromSrc(t, `
 func serve_one(srv) { conn := accept(srv)  write_bytes(conn, from_hex("00ff0042"))  close(conn) }
 func main() {
-    srv := listen(48234)
+    srv := listen(18234)
     go serve_one(srv)
     sleep(50)
-    c := dial("127.0.0.1", 48234)
+    c := dial("127.0.0.1", 18234)
     rb := read_bytes(c)
     println("len=" + str(len(rb)) + " b0=" + str(byte_at(rb,0)) + " b1=" + str(byte_at(rb,1)) + " b3=" + str(byte_at(rb,3)))
     close(c)
@@ -85,10 +85,10 @@ func serve_big(srv, n) {
 }
 func main() {
     n := 100000   // well over the 65535-byte single-read(2) cap
-    srv := listen(18235)
+    srv := listen(18501)
     go serve_big(srv, n)
     sleep(100)
-    c := dial("127.0.0.1", 18235)
+    c := dial("127.0.0.1", 18501)
     total := bytes("")
     reads := 0
     for {


### PR DESCRIPTION
Ships **#604**: SQLite works on the windows target, using the same bundled amalgamation the native `--static` build compiles in. It carries its own Win32 VFS — no external library, no DLL.

**Verified by execution.** CI cross-compiles on Linux and a `windows-latest` job runs the `.exe`:

```
output: [{"id":1,"name":"windows"}]
```

That gate exists because this target was broken across two releases while CI happily compiled it (#549).

Five #517 gaps remain (tty raw mode, `select`, XEdDSA, regex, zlib), each still failing loudly at compile time with a message naming the subsystem.

## Also: the ephemeral-port sweep finished

v0.127.1 moved the hardcoded test ports an unrelated outbound connection can steal. That sweep matched on `port = NNNNN` and **missed three** passed as bare arguments inside MFL source strings — `serve_mock(48310, …)` in the Redis test, plus SSO and wire. A full-suite run caught the Redis one: third sighting of this bug class, second time my own sweep was the incomplete part.

This time it greps the **numbers** in the range rather than a syntax pattern, and also checks no two test files share a port — which found a pre-existing cross-file collision on 48235.

Full suite green — `ok machin 209.861s`.