### PR TITLE
fix(router): return -1 for unknown paths and reset the route table on init

### DIFF
--- a/framework/router.src
+++ b/framework/router.src
@@ -31,9 +31,12 @@ var route_now = 0           // signal id: the active route index
 var route_paths = []string{}
 var route_n = 0
 
-// router_init creates the active-route signal (call first, with the initial index).
+// router_init creates the active-route signal (call first, with the initial index)
+// and resets the route table so each call starts from a clean slate.
 func router_init(initial) {
     route_now = signal(initial)
+    route_paths = []string{}
+    route_n = 0
 }
 
 // route registers a path and returns its index (call once per page, in order).
@@ -43,11 +46,13 @@ func route(path) (i) {
     route_n = route_n + 1
 }
 
+// path_index resolves a path to its registered index, or -1 if unknown.
+// The first match wins; navigate() treats -1 as a no-op.
 func path_index(path) (i) {
-    i = 0
+    i = 0 - 1
     j := 0
     while j < route_n {
-        if route_paths[j] == path { i = j }
+        if route_paths[j] == path { i = j  return }
         j = j + 1
     }
 }
@@ -58,6 +63,7 @@ func current_route() (i) { i = get(route_now) }
 
 // navigate switches to a route index and syncs the address bar.
 func navigate(i) {
+    if i < 0 { return }
     set(route_now, i)
     nav_url(route_paths[i])
 }

--- a/framework/tests/router_test.src
+++ b/framework/tests/router_test.src
@@ -21,12 +21,9 @@ extern "router_stub" {
     fn router_stub_link()
 }
 
-// NOTE ON STATE. router_init creates a fresh active-route SIGNAL but does NOT
-// reset the route table: route_paths/route_n accumulate for the life of the
-// process. A real app registers its routes once, so this is not a production bug —
-// but it means indices are only meaningful RELATIVE to what a test registered, and
-// a second router_init does not give you a clean slate. Every test below therefore
-// registers uniquely-named paths and compares against the indices route() returned.
+// NOTE ON STATE. router_init resets the route table, so each test starts from a
+// clean slate. Tests can rely on absolute indices for the routes they register in
+// a single call.
 func test_route_registration_is_index_ordered() {
     router_init(0)
     a := route("/reg/a")
@@ -36,13 +33,13 @@ func test_route_registration_is_index_ordered() {
     assert_eq_int(c, b + 1, "and keep incrementing")
 }
 
-// The sharp edge itself, pinned: calling router_init again does not clear routes.
-func test_router_init_does_not_reset_the_route_table() {
+func test_router_init_resets_the_route_table() {
     router_init(0)
     first := route("/reset/one")
     router_init(0)
     second := route("/reset/two")
-    assert_eq_int(second, first + 1, "the table carries over across router_init")
+    assert_eq_int(second, 0, "a second router_init starts the table at 0")
+    assert_eq_int(second, first, "indices after reset match a fresh table")
 }
 
 func test_path_index_finds_registered_paths() {
@@ -55,17 +52,23 @@ func test_path_index_finds_registered_paths() {
     assert_eq_int(path_index("/find/about"), c, "last")
 }
 
-// PINNING A SHARP EDGE, not endorsing it. path_index has no not-found signal: an
-// unregistered path yields 0, so a typo'd or stale deep link silently lands on
-// whatever route was registered first rather than 404-ing. Changing that is a
-// product decision (navigate(-1) would index out of range), so it is tracked
-// separately rather than "fixed" inside a test suite.
-func test_unknown_path_falls_back_to_route_zero() {
+func test_unknown_path_returns_not_found() {
     router_init(0)
     route("/unk/a")
     route("/unk/b")
-    assert_eq_int(path_index("/nope"), 0, "unknown path yields 0, NOT -1")
-    assert_eq_int(path_index(""), 0, "empty path yields 0 too")
+    assert_eq_int(path_index("/nope"), 0 - 1, "unknown path yields -1")
+    assert_eq_int(path_index(""), 0 - 1, "empty path yields -1 too")
+}
+
+// nav() uses path_index, so an unknown host path leaves the current route alone.
+func test_nav_ignores_unknown_path() {
+    router_init(0)
+    route("/nav/a")
+    route("/nav/b")
+    p := nav_buf(len("/nope"))
+    write_cstr(p, "/nope")
+    nav(p)
+    assert_eq_int(current_route(), 0, "unknown path does not change the active route")
 }
 
 func test_path_matching_is_exact() {
@@ -79,6 +82,13 @@ func test_path_matching_is_exact() {
     pab := route("/pre/ab")
     assert_eq_int(path_index("/pre/ab"), pab, "/pre/ab is not matched as a prefix of /pre/a")
     assert_eq_int(path_index("/pre/a"), pa, "and /pre/a still resolves to itself")
+}
+
+func test_path_index_first_match_wins() {
+    router_init(0)
+    first := route("/dup/a")
+    route("/dup/a")
+    assert_eq_int(path_index("/dup/a"), first, "first registration wins when routes are duplicated")
 }
 
 func test_current_route_reflects_navigation() {
@@ -178,14 +188,16 @@ func test_link_escapes_nothing_by_design() {
 func main() {
     router_stub_link()
     test_route_registration_is_index_ordered()
-    test_router_init_does_not_reset_the_route_table()
+    test_router_init_resets_the_route_table()
     test_path_index_finds_registered_paths()
-    test_unknown_path_falls_back_to_route_zero()
+    test_unknown_path_returns_not_found()
     test_path_matching_is_exact()
+    test_path_index_first_match_wins()
     test_current_route_reflects_navigation()
     test_router_init_sets_the_initial_route()
     test_navigation_wakes_a_reaction()
     test_outlet_renders_on_navigation()
+    test_nav_ignores_unknown_path()
     test_nav_from_a_host_buffer()
     test_link_markup()
     test_link_escapes_nothing_by_design()

--- a/reactive_test.go
+++ b/reactive_test.go
@@ -212,9 +212,8 @@ func main() {
 	}
 }
 
-// path_index resolves a path to its registered index (and defaults to 0 for an
-// unknown path); navigate(path_index(p)) is the by-path entry the host uses for
-// link clicks and popstate.
+// path_index resolves a path to its registered index and returns -1 for an
+// unknown path; navigate() ignores -1 so an unrecognised path is a no-op.
 func TestRouterPathIndex(t *testing.T) {
 	rv, err := os.ReadFile("framework/reactive.src")
 	if err != nil {
@@ -257,7 +256,7 @@ func main() {
 	for _, want := range []string{
 		"idx /users=1",
 		"idx /settings=2",
-		"idx /missing=0", // unknown path defaults to the first route
+		"idx /missing=-1", // unknown path returns not-found
 		"OUT 2\nURL /settings",
 		"OUT 0\nURL /",
 	} {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix open GitHub issues. Small PRs, conventional commits.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #590 (am/am-7b5889-dkjzkfzyn4r9-799cb52e): [needs work] fix(windows): enable raw_mode/read_key on the Windows target via conio
    touches: SPEC.md, build.go, codegen.go, guide.go, windows_target_test.go
- PR #585 (am/am-7b5889-dkjnye272rgj-6b99e560): [needs work] fix(windows): bundle SQLite amalgamation for --target windows
    touches: build.go, codegen.go, guide.go, windows_target_test.go
- PR #584 (am/am-7b5889-dkjfvfst437e-d72f729d): [needs work] feat(slice): add make([]T, n) and make([]T, len, cap)
    touches: README.md, SPEC.md, ast.go, bench/native-speed/README.md, bench/native-speed/machin/sieve.src, codegen.go, docs/LANGUAGE.md, examples/complex/slice_prealloc.mfl, guide.go, makeslice_test.go, parser.go, parsetest.go (+4 more)
- PR #583 (am/am-7b5889-dkj8t8dwx2ph-cec70d48): feat(slice): make([]T, n) and make([]T, len, cap) — fixes #578
    touches: README.md, SPEC.md, ast.go, bench/native-speed/machin/sieve.src, codegen.go, docs/LANGUAGE.md, guide.go, makeslice_test.go, parser.go, parsetest.go, render.go, transform.go (+1 more)
- PR #582 (am/am-7b5889-dkj1a1zi5nb0-c57763ed): feat: sort / sort_by builtins (#580)
    touches: SPEC.md, codegen.go, docs/LANGUAGE.md, guide.go, sort_test.go, types.go
- PR #577 (am/am-7b5889-dkidr8jtcv78-d28a4fc8): [needs work] fix(windows): enable XEdDSA (xeddsa_sign/verify) on the Windows target
    touches: build.go, codegen.go, guide.go, main.go, windows_target_test.go


**Branch:** `am/am-7b5889-dklhbvwd7rqy-4a1acae2`

**Diff:**
```
framework/router.src            | 12 +++++++---
 framework/tests/router_test.src | 50 +++++++++++++++++++++++++----------------
 reactive_test.go                |  7 +++---
 3 files changed, 43 insertions(+), 26 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Router reinitialization now clears previously registered routes.
  * Unknown paths no longer fall back to the first route.
  * Navigation safely ignores unrecognized paths.
  * Duplicate routes consistently resolve to the first registered match.

* **Tests**
  * Added coverage for route resets, unknown paths, safe navigation, and duplicate-route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->