### PR TITLE
fix(router): unknown paths are distinguishable, and router_init actually resets (#598)

### DIFF
--- a/framework/router.src
+++ b/framework/router.src
@@ -6,7 +6,7 @@
 //
 // Usage in a component:
 //   export func start() {
-//       router_init(0)                     // active route is a signal
+//       router_init(0)                     // active route is a signal; also clears routes
 //       route("/")  route("/users")        // register paths, in index order
 //       mount("app", nav_bar() + "<div id=outlet></div>")
 //       outlet("outlet", func() { return page() })   // page() switches on current_route()
@@ -31,8 +31,13 @@ var route_now = 0           // signal id: the active route index
 var route_paths = []string{}
 var route_n = 0
 
-// router_init creates the active-route signal (call first, with the initial index).
+// router_init creates the active-route signal AND clears the route table (call
+// first, with the initial index). It resets: previously it only made the signal,
+// so a second router_init left the old paths in place and indices kept climbing —
+// which made its name a lie and broke any test or app that set up twice (#598).
 func router_init(initial) {
+    route_paths = []string{}
+    route_n = 0
     route_now = signal(initial)
 }
 
@@ -43,11 +48,20 @@ func route(path) (i) {
     route_n = route_n + 1
 }
 
+// path_index returns a registered path's index, or -1 when the path is unknown.
+//
+// It used to return 0 for an unregistered path, with no not-found signal at all —
+// so a typo'd or stale deep link silently rendered whatever route was registered
+// first, usually home, while the address bar showed the bad URL. Callers can now
+// tell "matched route 0" from "no such route" (#598).
+//
+// FIRST match wins. Without the break the loop kept scanning and returned the LAST
+// match, so a duplicate registration silently shadowed the original.
 func path_index(path) (i) {
-    i = 0
+    i = 0 - 1
     j := 0
     while j < route_n {
-        if route_paths[j] == path { i = j }
+        if route_paths[j] == path { i = j  break }
         j = j + 1
     }
 }
@@ -56,8 +70,14 @@ func path_index(path) (i) {
 // re-renders on navigation.
 func current_route() (i) { i = get(route_now) }
 
-// navigate switches to a route index and syncs the address bar.
+// navigate switches to a route index and syncs the address bar. An out-of-range
+// index is IGNORED: path_index now returns -1 for an unknown path, and
+// route_paths[-1] would read out of bounds. An unrecognised link is inert — the
+// current route and the address bar are both left alone — which is the least
+// surprising of the options and never crashes.
 func navigate(i) {
+    if i < 0 { return }
+    if i >= route_n { return }
     set(route_now, i)
     nav_url(route_paths[i])
 }

--- a/framework/tests/router_test.src
+++ b/framework/tests/router_test.src
@@ -36,13 +36,16 @@ func test_route_registration_is_index_ordered() {
     assert_eq_int(c, b + 1, "and keep incrementing")
 }
 
-// The sharp edge itself, pinned: calling router_init again does not clear routes.
-func test_router_init_does_not_reset_the_route_table() {
+// router_init RESETS the table (#598). It previously only created the signal, so
+// a second call left the old paths in place and indices kept climbing.
+func test_router_init_resets_the_route_table() {
     router_init(0)
-    first := route("/reset/one")
+    route("/reset/one")
+    route("/reset/two")
     router_init(0)
-    second := route("/reset/two")
-    assert_eq_int(second, first + 1, "the table carries over across router_init")
+    fresh := route("/reset/three")
+    assert_eq_int(fresh, 0, "a second router_init starts indices from 0 again")
+    assert_eq_int(path_index("/reset/one"), -1, "and the old paths are gone")
 }
 
 func test_path_index_finds_registered_paths() {
@@ -55,17 +58,40 @@ func test_path_index_finds_registered_paths() {
     assert_eq_int(path_index("/find/about"), c, "last")
 }
 
-// PINNING A SHARP EDGE, not endorsing it. path_index has no not-found signal: an
-// unregistered path yields 0, so a typo'd or stale deep link silently lands on
-// whatever route was registered first rather than 404-ing. Changing that is a
-// product decision (navigate(-1) would index out of range), so it is tracked
-// separately rather than "fixed" inside a test suite.
-func test_unknown_path_falls_back_to_route_zero() {
+// An unknown path is now DISTINGUISHABLE from route 0 (#598). It used to return 0,
+// so a typo'd deep link silently rendered home while the address bar showed the
+// bad URL, and no caller could tell the difference.
+func test_unknown_path_returns_negative_one() {
     router_init(0)
     route("/unk/a")
     route("/unk/b")
-    assert_eq_int(path_index("/nope"), 0, "unknown path yields 0, NOT -1")
-    assert_eq_int(path_index(""), 0, "empty path yields 0 too")
+    assert_eq_int(path_index("/nope"), -1, "unknown path is -1, not 0")
+    assert_eq_int(path_index(""), -1, "empty path too")
+    assert_eq_int(path_index("/unk/a"), 0, "and route 0 still reports 0 — the two are now distinct")
+}
+
+// First registration wins. Without the early exit the loop returned the LAST
+// match, so a duplicate silently shadowed the original.
+func test_duplicate_registration_first_wins() {
+    router_init(0)
+    first := route("/dup")
+    route("/other")
+    route("/dup")
+    assert_eq_int(path_index("/dup"), first, "the first registration wins")
+}
+
+// navigate must IGNORE an out-of-range index rather than indexing route_paths[-1].
+// An unrecognised link is inert: current route and address bar both unchanged.
+func test_navigate_ignores_unknown_routes() {
+    router_init(0)
+    route("/g/a")
+    b := route("/g/b")
+    navigate(b)
+    assert_eq_int(current_route(), b, "navigated normally")
+    navigate(-1)
+    assert_eq_int(current_route(), b, "a -1 index changes nothing")
+    navigate(99)
+    assert_eq_int(current_route(), b, "an out-of-range index changes nothing")
 }
 
 func test_path_matching_is_exact() {
@@ -161,6 +187,20 @@ func test_nav_from_a_host_buffer() {
     assert_eq_int(current_route(), target, "the host's path string routed to the right index")
 }
 
+// The host calls nav() for a link click; an unknown path must not move the route
+// and must not read out of bounds.
+func test_nav_with_an_unknown_path_is_inert() {
+    router_init(0)
+    route("/known/a")
+    target := route("/known/b")
+    navigate(target)
+    path := "/not/registered"
+    p := nav_buf(len(path))
+    write_cstr(p, path)
+    nav(p)
+    assert_eq_int(current_route(), target, "an unregistered path leaves the route alone")
+}
+
 func test_link_markup() {
     h := link("/users", "Users")
     assert_eq_str(h, "<a href=\"/users\" data-nav=\"/users\">Users</a>",
@@ -178,15 +218,18 @@ func test_link_escapes_nothing_by_design() {
 func main() {
     router_stub_link()
     test_route_registration_is_index_ordered()
-    test_router_init_does_not_reset_the_route_table()
+    test_router_init_resets_the_route_table()
     test_path_index_finds_registered_paths()
-    test_unknown_path_falls_back_to_route_zero()
+    test_unknown_path_returns_negative_one()
+    test_duplicate_registration_first_wins()
+    test_navigate_ignores_unknown_routes()
     test_path_matching_is_exact()
     test_current_route_reflects_navigation()
     test_router_init_sets_the_initial_route()
     test_navigation_wakes_a_reaction()
     test_outlet_renders_on_navigation()
     test_nav_from_a_host_buffer()
+    test_nav_with_an_unknown_path_is_inert()
     test_link_markup()
     test_link_escapes_nothing_by_design()
     test_summary()

--- a/plugins/machin/skills/machin-web/SKILL.md
+++ b/plugins/machin/skills/machin-web/SKILL.md
@@ -161,7 +161,11 @@ the router too. The active route is a signal (an int index): `router_init(0)`,
 `current_route()` reads the active index, and `outlet(id, render)` re-renders the
 active page (a reaction over a `dom_html` host import) and syncs the address bar.
 `page()` switches on `current_route()` and must be a **pure render** (read signals,
-never `set` — that loops). The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
+never `set` — that loops). `path_index(path)` returns **-1** for an unregistered
+path, so a `page()` can render a real 404 instead of silently showing route 0; an
+unknown path passed to `nav()` is inert (route and address bar unchanged) rather
+than a crash. `router_init` also **clears** the route table, so it is safe to call
+again. The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
 clicks to `nav(path)` (path in via `ptr_str`) + `popstate`, and a catch-all server
 serves the shell for any path (deep-links). See [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router).
 

--- a/reactive_test.go
+++ b/reactive_test.go
@@ -257,7 +257,7 @@ func main() {
 	for _, want := range []string{
 		"idx /users=1",
 		"idx /settings=2",
-		"idx /missing=0", // unknown path defaults to the first route
+		"idx /missing=-1", // -1, not 0: an unknown path is now distinguishable from route 0 (#598)
 		"OUT 2\nURL /settings",
 		"OUT 0\nURL /",
 	} {

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -161,7 +161,11 @@ the router too. The active route is a signal (an int index): `router_init(0)`,
 `current_route()` reads the active index, and `outlet(id, render)` re-renders the
 active page (a reaction over a `dom_html` host import) and syncs the address bar.
 `page()` switches on `current_route()` and must be a **pure render** (read signals,
-never `set` — that loops). The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
+never `set` — that loops). `path_index(path)` returns **-1** for an unregistered
+path, so a `page()` can render a real 404 instead of silently showing route 0; an
+unknown path passed to `nav()` is inert (route and address bar unchanged) rather
+than a crash. `router_init` also **clears** the route table, so it is safe to call
+again. The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
 clicks to `nav(path)` (path in via `ptr_str`) + `popstate`, and a catch-all server
 serves the shell for any path (deep-links). See [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router).
 


### PR DESCRIPTION
Closes #598. Both edges were found writing router's MFL suite and deliberately left as **product decisions** rather than fixed inside a test. Deciding them now.

## `path_index` returns -1 for an unknown path

It returned **0**, with no not-found signal at all — so a typo'd or stale deep link silently rendered whatever route was registered first (usually home) while the address bar showed the bad URL. No caller could tell *"matched route 0"* from *"no such route"*. They can now, which is what lets an app render a real 404.

`navigate()` is why it couldn't simply return -1: it does `navigate(path_index(path))`, and `route_paths[-1]` reads out of bounds. So **`navigate` now ignores an out-of-range index** — an unrecognised link is inert, current route and address bar unchanged. Least surprising option, and it never crashes. `nav()`, the host entry point for a link click, inherits that.

## First registration wins

`path_index` had no early exit, so it returned the **last** match and a duplicate registration silently shadowed the original. Noted while filing #598; fixed with a `break`.

## `router_init` clears the route table

It only created the signal, so `route_paths`/`route_n` grew for the life of the process and a second `router_init` gave no clean slate — making its name a lie. It bit router's own suite immediately: every test after the first saw shifted indices. Its documented contract is *"call first"*, so resetting is what the name always implied.

## Tests

Three pinned the old behaviour and are **flipped, not deleted** — including one in `reactive_test.go` whose expectation carried a now-contradictory trailing comment. New coverage for each guarantee: -1 vs route 0 distinct, duplicate registration, `navigate` ignoring out-of-range, and `nav()` with an unknown path leaving the route alone.

**32 assertions, router still 9/9.** No other `.src` or example depends on the old semantics (checked). The `machin-web` skill now tells app authors they can 404 on -1, re-synced to `plugins/`.

Full suite green — `ok machin 181.259s`.