### PR TITLE
fix(router): guard navigate's upper bound too (follow-up to #606)

### DIFF
--- a/framework/router.src
+++ b/framework/router.src
@@ -64,6 +64,12 @@ func current_route() (i) { i = get(route_now) }
 // navigate switches to a route index and syncs the address bar.
 func navigate(i) {
     if i < 0 { return }
+    // Upper bound too: navigate is public API an app calls with an index of its
+    // own, and route_paths[i] past the end reads out of bounds. #606 guarded the
+    // -1 that path_index now returns; this covers a stale or off-by-one index,
+    // which panics with "index out of range [99] with length 2" under --safe and
+    // reads garbage without it.
+    if i >= route_n { return }
     set(route_now, i)
     nav_url(route_paths[i])
 }

--- a/framework/tests/router_test.src
+++ b/framework/tests/router_test.src
@@ -171,6 +171,37 @@ func test_nav_from_a_host_buffer() {
     assert_eq_int(current_route(), target, "the host's path string routed to the right index")
 }
 
+// navigate must ignore BOTH ends. #606 guarded the -1 that path_index returns;
+// the upper bound matters because navigate is public API an app calls with an
+// index of its own — a stale or off-by-one one used to read past the table
+// ("index out of range [99] with length 2" under --safe).
+func test_navigate_ignores_out_of_range_indices() {
+    router_init(0)
+    route("/g/a")
+    b := route("/g/b")
+    navigate(b)
+    assert_eq_int(current_route(), b, "navigated normally")
+    navigate(-1)
+    assert_eq_int(current_route(), b, "a negative index changes nothing")
+    navigate(99)
+    assert_eq_int(current_route(), b, "an index past the table changes nothing")
+    navigate(route_n)
+    assert_eq_int(current_route(), b, "exactly one past the end changes nothing")
+}
+
+// The host entry point inherits the guard: an unregistered path is inert.
+func test_nav_with_an_unknown_path_is_inert() {
+    router_init(0)
+    route("/known/a")
+    target := route("/known/b")
+    navigate(target)
+    path := "/not/registered"
+    p := nav_buf(len(path))
+    write_cstr(p, path)
+    nav(p)
+    assert_eq_int(current_route(), target, "an unregistered path leaves the route alone")
+}
+
 func test_link_markup() {
     h := link("/users", "Users")
     assert_eq_str(h, "<a href=\"/users\" data-nav=\"/users\">Users</a>",
@@ -199,6 +230,8 @@ func main() {
     test_outlet_renders_on_navigation()
     test_nav_ignores_unknown_path()
     test_nav_from_a_host_buffer()
+    test_navigate_ignores_out_of_range_indices()
+    test_nav_with_an_unknown_path_is_inert()
     test_link_markup()
     test_link_escapes_nothing_by_design()
     test_summary()

--- a/plugins/machin/skills/machin-web/SKILL.md
+++ b/plugins/machin/skills/machin-web/SKILL.md
@@ -161,7 +161,11 @@ the router too. The active route is a signal (an int index): `router_init(0)`,
 `current_route()` reads the active index, and `outlet(id, render)` re-renders the
 active page (a reaction over a `dom_html` host import) and syncs the address bar.
 `page()` switches on `current_route()` and must be a **pure render** (read signals,
-never `set` — that loops). The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
+never `set` — that loops). `path_index(path)` returns **-1** for an unregistered
+path, so a `page()` can render a real 404 instead of silently showing route 0;
+`navigate` ignores an out-of-range index (either end), so an unknown link is inert
+rather than a crash. `router_init` also **clears** the route table, so calling it
+again gives a clean slate. The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
 clicks to `nav(path)` (path in via `ptr_str`) + `popstate`, and a catch-all server
 serves the shell for any path (deep-links). See [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router).
 

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -161,7 +161,11 @@ the router too. The active route is a signal (an int index): `router_init(0)`,
 `current_route()` reads the active index, and `outlet(id, render)` re-renders the
 active page (a reaction over a `dom_html` host import) and syncs the address bar.
 `page()` switches on `current_route()` and must be a **pure render** (read signals,
-never `set` — that loops). The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
+never `set` — that loops). `path_index(path)` returns **-1** for an unregistered
+path, so a `page()` can render a real 404 instead of silently showing route 0;
+`navigate` ignores an out-of-range index (either end), so an unknown link is inert
+rather than a crash. `router_init` also **clears** the route table, so calling it
+again gives a clean slate. The host adds `dom_html`/`nav_url`, forwards `[data-nav]`
 clicks to `nav(path)` (path in via `ptr_str`) + `popstate`, and a catch-all server
 serves the shell for any path (deep-links). See [machin-web-demo-router](https://github.com/javimosch/machin-web-demo-router).
 


### PR DESCRIPTION
#606 landed the two #598 fixes concurrently with my own branch — I closed #607 as the duplicate rather than force-merging it. This is the gap it left.

## The remaining hole

`navigate(i)` guards `i < 0` (the -1 `path_index` now returns) but **not the upper bound**. `navigate` is public API an app calls with an index of its own, so a stale or off-by-one index still read past the table. Reproduced on `main` before fixing:

```
panic: index out of range [99] with length 2
```

Under `--safe` that's a panic; **without it, a silent garbage read**.

Now inert at both ends, with a test covering -1, a large index, and exactly one past the end (`route_n`).

## Also

The `machin-web` skill note #606 didn't add: app authors can render a real 404 on -1, an unknown link is inert rather than a crash, and `router_init` gives a clean slate. Re-synced to `plugins/`.

Router stays **9/9**, now 33 assertions. Full suite green — `ok machin 235.468s`.