### PR TITLE
release: v0.130.0 — router semantics: unknown paths are distinguishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+## v0.130.0
+
+**A BEHAVIOUR CHANGE in `framework/router.src`**, not a silent bug fix — read this
+if you ship a machin web app (PRs #606, #609, issue #598).
+
+**`path_index(path)` now returns -1 for an unregistered path.** It returned **0**,
+with no not-found signal at all, so a typo'd or stale deep link silently rendered
+whatever route was registered first — usually home — while the address bar showed
+the bad URL. No caller could tell "matched route 0" from "no such route".
+
+*If you relied on the old fallback*, an unknown path is now inert rather than
+landing on route 0. That is the point: you can render a real 404 by checking for
+-1. Nothing crashes either way.
+
+**`navigate(i)` ignores an out-of-range index at BOTH ends.** It has to: with
+`path_index` returning -1, `route_paths[-1]` would read out of bounds. #606 guarded
+the negative side; #609 added the upper bound, because `navigate` is public API an
+app calls with an index of its own and a stale or off-by-one one still read past
+the table:
+
+```
+panic: index out of range [99] with length 2
+```
+
+Under `--safe` that was a panic; without it, a silent garbage read.
+
+**`router_init(initial)` now clears the route table.** It only created the active
+signal, so `route_paths`/`route_n` grew for the life of the process and a second
+call gave no clean slate — which made the name a lie. Its documented contract was
+already "call first", so resetting is what it always implied.
+
+**First registration wins.** `path_index` had no early exit, so it returned the
+LAST match and a duplicate registration silently shadowed the original.
+
+All four came out of writing router's MFL test suite (#593), where they were
+deliberately pinned as current behaviour rather than "fixed" inside a test, since
+routing semantics are a product decision. The suite now asserts the new
+guarantees: -1 distinct from route 0, duplicate registration, `navigate` inert at
+both ends, and `nav()` leaving the route alone for an unknown path. 33 assertions,
+router at 9/9 function coverage.
+
+The `machin-web` skill documents all of it, so an agent building a router app gets
+the 404 idiom rather than rediscovering the old fallback.
+
 ## v0.129.0
 
 **SQLite works on the windows target** (PR #604, issue #517) — and unlike the last

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.129.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.130.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.129.0
+Version 0.130.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.129.0"
+const machinVersion = "0.130.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
**A behaviour change in `framework/router.src`**, flagged as one rather than filed under fixes.

| | before | after |
|---|---|---|
| `path_index` on an unknown path | **0** (silently home) | **-1** |
| `navigate` with a bad index | read out of bounds | inert, both ends |
| `router_init` called twice | table kept growing | clears the table |
| duplicate path registration | **last** wins | **first** wins |

If you relied on unknown-path-lands-on-route-0, links to unregistered paths are now inert. That's the point — checking for -1 lets an app render a real 404, which it previously could not do at all.

The upper-bound guard (#609) matters on its own: `navigate` is public API an app calls with its own index, and a stale one used to panic under `--safe` (`index out of range [99] with length 2`) or read garbage without it.

All four came out of writing router's MFL suite (#593), where they were pinned as current behaviour rather than fixed inside a test — routing semantics being a product decision. 33 assertions now, router at 9/9.

Full suite green — `ok machin 192.848s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.130.0, including updated router behavior and expanded testing guidance.
  * Updated the README, language specification, and embedded guide to version 0.130.0.
  * Clarified that unknown paths return `-1`, invalid navigation indices are ignored, route initialization resets existing routes, and duplicate routes retain the first registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->