### PR TITLE
release: v0.131.0 — zlib on the windows target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+## v0.131.0
+
+**zlib works on the windows target** (PR #611, issue #517) — the second of six gaps
+closed, and like SQLite before it, a bundling problem rather than a port.
+
+machin's zlib glue is pure `z_stream` API with no POSIX in it, and zlib is
+portable C with its own Windows support. Windows has no system libz, and requiring
+a mingw one would push a dependency onto every program that calls
+`zlib_compress`, so `vendor/zlib` now carries the deflate/inflate subset —
+9 `.c` files plus headers, 333 kB gzipped:
+
+```
+adler32 crc32 deflate inflate inffast inftrees trees zutil compress
+```
+
+The `gz*` file API is deliberately excluded (machin exposes none of it, and it
+drags in stdio plumbing), as is `infback.c`. `gzguts.h` IS included — `zutil.c`
+includes it, which the first packaging attempt found the hard way as a
+cross-compile error.
+
+A tarball rather than SQLite's single gzipped amalgamation, because zlib has no
+amalgamation: it is a dozen translation units meant to be compiled separately, and
+concatenating them is a portability gamble for no benefit. The extractor refuses
+any archive entry containing a path separator.
+
+**Native builds are unchanged** — they still link the system `-lz`.
+
+**Verified by execution, not compilation.** CI cross-compiles a compress/decompress
+round trip and a `windows-latest` job runs it, asserting the payload survives:
+
+```
+47:47:hello hello hello hello compress me compress me
+```
+
+A test also pins the vendored archive's contents — exactly 9 `.c` files, the
+headers present, and none of `gzread`/`gzwrite`/`gzlib`/`infback` — because a
+silently truncated tarball would otherwise surface only as a link error inside a
+cross-compile, far from the change that caused it.
+
+Four #517 gaps remain: tty raw mode, `select`, XEdDSA (needs a mingw libsodium),
+and regex (POSIX `<regex.h>` has no Windows equivalent). Each still fails loudly at
+compile time with a message naming the subsystem. The two closed so far were both
+the "vendor it" kind; the rest are genuine ports.
+
 ## v0.130.0
 
 **A BEHAVIOUR CHANGE in `framework/router.src`**, not a silent bug fix — read this

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.130.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.131.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.130.0
+Version 0.131.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.130.0"
+const machinVersion = "0.131.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Second of six #517 gaps closed (PR #611). Like SQLite, **a bundling problem rather than a port**.

`vendor/zlib` carries the deflate/inflate subset — 9 `.c` + headers, 333 kB gzipped — so no mingw libz is needed and no dependency is pushed onto users of `zlib_compress`. **Native builds unchanged** (still system `-lz`).

Verified by a `windows-latest` job running the cross-compiled binary:

```
47:47:hello hello hello hello compress me compress me
```

Four gaps remain — tty raw mode, `select`, XEdDSA, regex — each still failing loudly at compile time. The two closed were both the "vendor it" kind; the rest are genuine ports.

Full suite green — `ok machin 234.473s`.