### PR TITLE
fix(cli): advertise machin test --cover in usage and header

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ usage:
   machin build|run <file.mfl> --safe  insert bounds / div-zero / overflow checks
   machin build|run <file.mfl> --race-safe  refuse to build if a data race is inferred
   machin check <src...>|--stdin      lex+parse+typecheck only (no cc); add --json for machine-readable diagnostics
-  machin test [--json] <src...>      run MFL test files (framework/test.src: assert/assert_eq_int/assert_eq_str)
+  machin test [--json] [--cover] <src...>  run MFL test files (framework/test.src: assert/assert_eq_int/assert_eq_str; --cover adds function/statement coverage)
   machin encode <src>                mint canonical MFL from loose Go-like text (framework/*.src resolve from the binary)
   machin framework list|<name>|--vendor   the embedded framework modules (machweb, db drivers, …)
   machin pack  <file.mfl>            emit the dense base64 form (distribution)

--- a/testcmd.go
+++ b/testcmd.go
@@ -1,6 +1,6 @@
 package main
 
-// `machin test [--json] <src...>` — Stage A of #236 (native MFL test runner).
+// `machin test [--json] [--cover] <src...>` — Stage A of #236 (native MFL test runner).
 // Composes framework/test.src ahead of the given sources (same multi-file
 // compose `machin encode` already does — so testing a framework module means
 // passing it alongside its test file: `machin test framework/flags.src
@@ -8,8 +8,8 @@ package main
 // it, and reports the "TEST_SUMMARY passed=N failed=M" line framework/test.src's
 // test_summary() prints. Sugar over the same compose->build->run path
 // `machin encode`/`machin build` already use — a way to write and run
-// framework/app tests in MFL, without the Go harness (RunCaptured). Not a new
-// measurement: run separate `machin test` invocations for separate suites.
+// framework/app tests in MFL, without the Go harness (RunCaptured). --cover
+// adds function/statement coverage (#589); otherwise the tally is the only output.
 
 import (
 	"encoding/json"

--- a/testcmd_test.go
+++ b/testcmd_test.go
@@ -134,6 +134,45 @@ func TestCmdTestWithJSONOutput(t *testing.T) {
 	}
 }
 
+func TestCmdTestWithCoverFlag(t *testing.T) {
+	dir := t.TempDir()
+	f := writeSrc(t, dir, "t.src", `func main() {
+    assert(1 + 1 == 2, "addition")
+    test_summary()
+}`)
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = cmdTest([]string{"--json", "--cover", f})
+	w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	var res TestRunResult
+	if err := json.Unmarshal(buf[:n], &res); err != nil {
+		t.Fatalf("JSON decode: %v", err)
+	}
+	if res.Coverage == nil {
+		t.Fatal("JSON output with --cover should include coverage")
+	}
+	if res.Coverage.Kind != "function" {
+		t.Fatalf("coverage kind should be 'function', got %q", res.Coverage.Kind)
+	}
+	if res.Coverage.Total == 0 {
+		t.Fatal("coverage total should be > 0")
+	}
+	if res.Coverage.Statements == nil || res.Coverage.Statements.Kind != "statement" {
+		t.Fatal("JSON output with --cover should include statement coverage")
+	}
+}
+
 func TestCmdTestJSONFlagPosition(t *testing.T) {
 	dir := t.TempDir()
 	f := writeSrc(t, dir, "t.src", `func main() {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix open GitHub issues. Small PRs, conventional commits.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #614 (am/am-7b5889-dklmckt36py7-882e31aa): [needs work] fix(cli): advertise machin test --cover in usage and header
    touches: main.go, testcmd.go, testcmd_test.go
- PR #612 (am/am-7b5889-dklkh77633dn-8db405bc): feat(windows): regex works on the windows target, verified by running it (#517)
    touches: build.go, codegen.go, guide.go, vendor/regex/README.md, vendor/regex/remimu.h, windows_target_test.go
- PR #590 (am/am-7b5889-dkjzkfzyn4r9-799cb52e): [needs work] fix(windows): enable raw_mode/read_key on the Windows target via conio
    touches: SPEC.md, build.go, codegen.go, guide.go, windows_target_test.go
- PR #585 (am/am-7b5889-dkjnye272rgj-6b99e560): [needs work] fix(windows): bundle SQLite amalgamation for --target windows
    touches: build.go, codegen.go, guide.go, windows_target_test.go
- PR #584 (am/am-7b5889-dkjfvfst437e-d72f729d): [needs work] feat(slice): add make([]T, n) and make([]T, len, cap)
    touches: README.md, SPEC.md, ast.go, bench/native-speed/README.md, bench/native-speed/machin/sieve.src, codegen.go, docs/LANGUAGE.md, examples/complex/slice_prealloc.mfl, guide.go, makeslice_test.go, parser.go, parsetest.go (+4 more)
- PR #583 (am/am-7b5889-dkj8t8dwx2ph-cec70d48): feat(slice): make([]T, n) and make([]T, len, cap) — fixes #578
    touches: README.md, SPEC.md, ast.go, bench/native-speed/machin/sieve.src, codegen.go, docs/LANGUAGE.md, guide.go, makeslice_test.go, parser.go, parsetest.go, render.go, transform.go (+1 more)
- PR #582 (am/am-7b5889-dkj1a1zi5nb0-c57763ed): feat: sort / sort_by builtins (#580)
    touches: SPEC.md, codegen.go, docs/LANGUAGE.md, guide.go, sort_test.go, types.go
- PR #577 (am/am-7b5889-dkidr8jtcv78-d28a4fc8): [needs work] fix(windows): enable XEdDSA (xeddsa_sign/verify) on the Windows target
    touches: build.go, codegen.go, guide.go, main.go, windows_target_test.go


**Branch:** `am/am-7b5889-dklv41dt8dc9-029b2dae`

**Diff:**
```
main.go         |  2 +-
 testcmd.go      |  6 +++---
 testcmd_test.go | 39 +++++++++++++++++++++++++++++++++++++++
 3 files changed, 43 insertions(+), 4 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `machin test` usage information to document the optional `--cover` flag.
  * Clarified that coverage reports include function and statement coverage data.

* **Tests**
  * Added coverage validation for JSON test output, including populated function and statement coverage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->