### PR TITLE
fix(test): emit empty uncovered arrays in --cover JSON, not null

### DIFF
--- a/cover_test.go
+++ b/cover_test.go
@@ -271,3 +271,28 @@ func main() {
 		t.Fatalf("double's only statement ran; it must not be listed: %v", sc.Uncovered)
 	}
 }
+
+// A fully covered file must still emit an empty [] for Uncovered, not null.
+// Null is a shape bug for consumers that expect an array; `null` also makes it
+// impossible to tell "no uncovered functions" from "this field is missing".
+func TestCoverUncoveredListsAreEmptyNotNull(t *testing.T) {
+	dir := t.TempDir()
+	f := writeSrc(t, dir, "t.src", `func main() {
+    test_summary()
+}`)
+	res, _, err := runMFLTests([]string{f}, true)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Coverage == nil {
+		t.Fatal("no coverage report")
+	}
+	for _, fc := range res.Coverage.Files {
+		if fc.Uncovered == nil {
+			t.Fatalf("file %q: Uncovered is nil, want []", fc.File)
+		}
+	}
+	if sc := res.Coverage.Statements; sc != nil && sc.Uncovered == nil {
+		t.Fatal("statement coverage Uncovered is nil, want []")
+	}
+}

--- a/testcmd.go
+++ b/testcmd.go
@@ -182,7 +182,7 @@ func readCoverage(path string, prog *Program, files []string) (*Coverage, error)
 		}
 		fc, seen := byFile[file]
 		if !seen {
-			fc = &FileCoverage{File: file}
+			fc = &FileCoverage{File: file, Uncovered: []string{}}
 			byFile[file] = fc
 			order = append(order, file)
 		}
@@ -202,7 +202,7 @@ func readCoverage(path string, prog *Program, files []string) (*Coverage, error)
 		cov.Pct = float64(cov.Covered) / float64(cov.Total) * 100
 	}
 	if len(stmtTotal) > 0 {
-		sc := &StmtCoverage{Kind: "statement"}
+		sc := &StmtCoverage{Kind: "statement", Uncovered: []string{}}
 		for _, fn := range prog.Funcs {
 			if fn.IsLambda {
 				continue


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix open GitHub issues. Small PRs, conventional commits.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #615 (am/am-7b5889-dklv41dt8dc9-029b2dae): fix(cli): advertise machin test --cover in usage and header
    touches: main.go, testcmd.go, testcmd_test.go
- PR #614 (am/am-7b5889-dklmckt36py7-882e31aa): [needs work] fix(cli): advertise machin test --cover in usage and header
    touches: main.go, testcmd.go, testcmd_test.go
- PR #612 (am/am-7b5889-dklkh77633dn-8db405bc): feat(windows): regex works on the windows target, verified by running it (#517)
    touches: build.go, codegen.go, guide.go, vendor/regex/README.md, vendor/regex/remimu.h, windows_target_test.go
- PR #590 (am/am-7b5889-dkjzkfzyn4r9-799cb52e): [needs work] fix(windows): enable raw_mode/read_key on the Windows target via conio
    touches: SPEC.md, build.go, codegen.go, guide.go, windows_target_test.go
- PR #585 (am/am-7b5889-dkjnye272rgj-6b99e560): [needs work] fix(windows): bundle SQLite amalgamation for --target windows
    touches: build.go, codegen.go, guide.go, windows_target_test.go
- PR #584 (am/am-7b5889-dkjfvfst437e-d72f729d): [needs work] feat(slice): add make([]T, n) and make([]T, len, cap)
    touches: README.md, SPEC.md, ast.go, bench/native-speed/README.md, bench/native-speed/machin/sieve.src, codegen.go, docs/LANGUAGE.md, examples/complex/slice_prealloc.mfl, guide.go, makeslice_test.go, parser.go, parsetest.go (+4 more)
- PR #583 (am/am-7b5889-dkj8t8dwx2ph-cec70d48): feat(slice): make([]T, n) and make([]T, len, cap) — fixes #578
    touches: README.md, SPEC.md, ast.go, bench/native-speed/machin/sieve.src, codegen.go, docs/LANGUAGE.md, guide.go, makeslice_test.go, parser.go, parsetest.go, render.go, transform.go (+1 more)
- PR #582 (am/am-7b5889-dkj1a1zi5nb0-c57763ed): feat: sort / sort_by builtins (#580)
    touches: SPEC.md, codegen.go, docs/LANGUAGE.md, guide.go, sort_test.go, types.go


**Branch:** `am/am-7b5889-dklw4sg0httd-c3ec111c`

**Diff:**
```
cover_test.go | 25 +++++++++++++++++++++++++
 testcmd.go    |  4 ++--
 2 files changed, 27 insertions(+), 2 deletions(-)
```
