### PR TITLE
release: v0.133.0 — select on the windows target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+## v0.133.0
+
+**`select` works on the windows target** (PR #619, issue #517) — the third gap
+closed, and this one needed no code at all: the rejection was stale.
+
+machin's `select` is the CHANNEL select statement, not POSIX `select(2)`. It lowers
+to a poll over `tryrecv` with a 1 ms sleep and never touches an `fd_set`. The
+emitted C does carry `<sys/select.h>`, but inside `#ifndef _WIN32` — dead text on
+this target. Deleting one preflight entry was the whole fix.
+
+**The more important half is what now runs in CI.** The windows target has claimed
+goroutines and channels since the port landed, and nothing had ever executed one:
+both existing execution gates (SQLite, zlib) are single-threaded, so winpthreads
+was an untested claim sitting in `machin guide`. CI now cross-compiles a program
+that fans 8 goroutines into a channel *and* takes a select, and the
+`windows-latest` job runs it:
+
+```
+select=42 fanin=336
+```
+
+Deterministic by construction — the select polls until the worker's send lands and
+the fan-in reads exactly 8 values.
+
+The preflight test asserts the property that matters: no `FD_SET`, no `fd_set`, no
+`select(` in the emitted C, and the select really does lower to `tryrecv`. A first
+version asserted the raw text contained no `sys/select.h` and failed — correctly,
+since the guarded include is there. Checking for the include was checking the wrong
+thing; checking for its *use* is the invariant.
+
+Three #517 gaps remain — tty raw mode, XEdDSA (needs a mingw libsodium), and regex
+(POSIX `<regex.h>` has no Windows equivalent) — each still failing loudly at
+compile time with a message naming the subsystem.
+
 ## v0.132.0
 
 **`make([]T, n)` and `make([]T, len, cap)`** (PR #617, issue #584) — preallocation,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.132.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.133.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.132.0
+Version 0.133.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.132.0"
+const machinVersion = "0.133.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Third of six #517 gaps closed (PR #619), needing **no code**: machin's `select` is the channel select statement, not POSIX `select(2)`, and the rejection was stale.

**The substantive part is the test.** The windows target has claimed goroutines and channels since the port landed, and nothing had ever executed one — both existing gates (SQLite, zlib) are single-threaded, so winpthreads was an untested claim. CI now runs an 8-goroutine fan-in plus a select on a real windows runner:

```
select=42 fanin=336
```

Three gaps remain: tty raw mode, XEdDSA, regex — each failing loudly at compile time.

Full suite green — `ok machin 196.632s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the v0.133.0 changelog entry.
  - Updated the README, language specification, and embedded guide to version 0.133.0.
  - Documented Windows support for `select`, including its current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->