### PR TITLE
docs(skill): cite machin-tinystats as a WebSocket hub example

### DIFF
--- a/plugins/machin/skills/machin-web/SKILL.md
+++ b/plugins/machin/skills/machin-web/SKILL.md
@@ -86,7 +86,10 @@ func main() { serve(48080, func(req) { return handle(req) }) }
   `ws_send_bytes(c.fd, b)` send. A connection that also receives broadcasts wants **two
   goroutines** — the handler loop reads, a spawned `go writer(c.fd, ch)` drains an outbound
   channel (read + write are independent on the fd). Fan-out is the same hub-goroutine
-  pattern as SSE. See [machin-rooms](https://github.com/javimosch/machin-rooms).
+  pattern as SSE. See [machin-rooms](https://github.com/javimosch/machin-rooms) and
+  [machin-tinystats](https://github.com/javimosch/machin-tinystats) (a 71 KB metrics
+  dashboard: HTTP + WS + hub broadcast + a `getState chan chan string` for REST endpoints
+  that need the current state synchronously without waiting for the next broadcast).
 - **A database:** machin has SQLite builtins — `sqlite_open(path)` / `sqlite_exec(db,
   sql)` / `sqlite_exec(db, sql, []string params)` (`?`-bind, injection-safe) /
   `sqlite_query(db, sql[, params]) -> string` (a **JSON-array-of-rows string**) /

--- a/skills/machin-web/SKILL.md
+++ b/skills/machin-web/SKILL.md
@@ -86,7 +86,10 @@ func main() { serve(48080, func(req) { return handle(req) }) }
   `ws_send_bytes(c.fd, b)` send. A connection that also receives broadcasts wants **two
   goroutines** — the handler loop reads, a spawned `go writer(c.fd, ch)` drains an outbound
   channel (read + write are independent on the fd). Fan-out is the same hub-goroutine
-  pattern as SSE. See [machin-rooms](https://github.com/javimosch/machin-rooms).
+  pattern as SSE. See [machin-rooms](https://github.com/javimosch/machin-rooms) and
+  [machin-tinystats](https://github.com/javimosch/machin-tinystats) (a 71 KB metrics
+  dashboard: HTTP + WS + hub broadcast + a `getState chan chan string` for REST endpoints
+  that need the current state synchronously without waiting for the next broadcast).
 - **A database:** machin has SQLite builtins — `sqlite_open(path)` / `sqlite_exec(db,
   sql)` / `sqlite_exec(db, sql, []string params)` (`?`-bind, injection-safe) /
   `sqlite_query(db, sql[, params]) -> string` (a **JSON-array-of-rows string**) /


### PR DESCRIPTION
Adds a second reference alongside `machin-rooms` in the `machin-web` skill's WebSocket section: a 71 KB metrics dashboard combining HTTP + WS + hub broadcast, plus the `getState chan chan string` pattern for REST endpoints that need current state synchronously rather than waiting for the next broadcast.

Written by another session and left uncommitted in the working tree; committing as-is. Plugin mirror is byte-identical, so `TestPluginSkillsInSync` stays green.