### PR TITLE
fix(selfhost): restore Go parity (6 unported codegen changes) and gate it in CI (#625, #626)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,39 @@ jobs:
           git fetch --tags --quiet
           make version-check
 
+      # The README leads with "compiles itself — fixpoint". Nothing enforced that
+      # claim until now: every selfhost/verify-*.sh was manual-only, and BOTH the
+      # embedded prelude and the codegen had silently drifted from the Go
+      # reference for an unknown number of commits (#625, #626).
+
+      - name: Selfhost prelude is regenerated (#626)
+        run: |
+          python3 selfhost/gen-prelude.py
+          if ! git diff --quiet selfhost/cgprelude.src; then
+            echo "::error::selfhost/cgprelude.src is stale — the C runtime changed without re-running selfhost/gen-prelude.py. The self-hosted compiler embeds its OWN copy of the runtime, so a stale prelude means it builds programs against an OLDER runtime than the Go compiler does. Run: python3 selfhost/gen-prelude.py"
+            git diff --stat selfhost/cgprelude.src
+            exit 1
+          fi
+          echo "prelude matches the Go runtime"
+
+      - name: Selfhost codegen oracle-diff (#625)
+        run: |
+          out=$(bash selfhost/verify-cgen.sh 2>&1)
+          echo "$out" | tail -20
+          echo "$out" | grep -q "FAIL 0" || {
+            echo "::error::the self-hosted compiler emits different C than the Go reference. Either port the codegen change to selfhost/, or the two compilers build observably different programs."
+            exit 1
+          }
+
+      - name: Selfhost fixpoint (#625)
+        run: |
+          out=$(bash selfhost/verify-fixpoint.sh 2>&1)
+          echo "$out" | tail -12
+          echo "$out" | grep -q "SELF-HOSTING FIXPOINT: PASS" || {
+            echo "::error::the self-hosting fixpoint FAILED — the compiler no longer reproduces itself byte-for-byte, or its codegen diverged from the Go reference"
+            exit 1
+          }
+
       - name: Run every example (integration smoke test)
         run: ./examples/run.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+**The self-hosted compiler had silently drifted, and nothing was checking**
+(issues #625, #626) — the README leads with *"compiles itself — fixpoint"*, but
+no workflow ran any of the twelve `selfhost/verify-*.sh` gates. They were all
+manual-only. Two of them had been failing for an unknown number of commits.
+
+Six codegen changes had landed in the Go compiler and never been ported, so the
+two compilers built **observably different programs** from the same source:
+
+| unported | effect on a self-hosted build |
+|---|---|
+| `mfl_s` NULL guard on `len` (string) | `strlen(NULL)` **segfaults** instead of returning 0 |
+| short-circuit `&&` / `||` (#437) | both operands evaluated — `i < len(xs) && xs[i] == 0` reads out of bounds |
+| `mfl_js_null` guard in parsers (#533) | every field after a JSON `null` silently dropped |
+| `mfl_sb` string builder in `json()` (#520) | `json()` quadratic instead of linear |
+| `mfl_append_owned` (#578) | every `append` copies; never grows in place |
+| `LL` suffix on int literals | a literal wider than 32 bits typed as `int` |
+
+All six are now ported, including the full unaliased-slice analysis as
+[`selfhost/alias.src`](selfhost/alias.src). The codegen oracle goes from
+**384/415 to 415/415**, and `verify-fixpoint.sh` passes for the first time in
+this arc. `selfhost/cgprelude.src` — the embedded copy of the C runtime — had
+also gone stale in four blocks.
+
+Three CI gates now enforce all of it: the prelude must be regenerated, the
+codegen oracle must be clean, and the fixpoint must hold. Each was
+mutation-tested — reverting any one of the six fixes turns its gate red.
+
 **`wss_open` accepts custom headers** (issue #622) — a WebSocket upgrade is an
 HTTP/1.1 request, so servers authenticate it. Until now MFL could not send an
 `Authorization` header on the handshake, which made any such endpoint (the

--- a/selfhost/BOOTSTRAP.md
+++ b/selfhost/BOOTSTRAP.md
@@ -323,6 +323,12 @@ What was ported (the compute-heavy frontend/codegen were already self-hosted):
   `--emit-c` (+ the `--program`/`--full` oracle modes), composing every `selfhost/`
   module. The shared compile pipeline lives in `compile.src` (also used by the oracle
   driver `cgmain.src`).
+- **unaliased-slice analysis** (`alias.src`) — the port of `alias.go` (#578): which local
+  slices `append` may grow in place. Fail-closed, same as the reference; an unmodelled
+  node kind disqualifies every candidate. It is here because *the two compilers must
+  agree*: while it was missing, the self-hosted compiler emitted the copying
+  `mfl_append` where Go emitted `mfl_append_owned`, so both compilers built observably
+  different programs from the same source (#625).
 - **feature-gated runtime prelude** (`gen-prelude.py` → `cgprelude.src`) — the prelude is
   split into blocks (core + tls/wss/math/noise/regex/sqlite/crypto/xeddsa), recovered by
   subtraction from the Go compiler, and emitted **gated by `g_uses_*` flags** set per

--- a/selfhost/alias.src
+++ b/selfhost/alias.src
@@ -1,0 +1,329 @@
+// Unaliased-slice analysis — the self-hosted port of alias.go (#578), so that
+// `append` lowers to mfl_append_owned here exactly where the reference compiler
+// lowers it. Until this existed the two compilers emitted DIFFERENT C for the
+// same program: Go grew the array in place, the self-hosted compiler always
+// copied (#625).
+//
+// Answers one question per local slice variable: does any OTHER live reference
+// observe this slice's backing array? If not, append may grow it in place
+// instead of allocating a fresh block and copying.
+//
+// FAIL-CLOSED BY CONSTRUCTION, same posture as the reference. Every operation on
+// a candidate must be on an explicit whitelist of forms that provably cannot
+// leak a reference to the backing array; anything else — including a node kind
+// this analysis does not recognise — disqualifies the variable. The cost of a
+// case nobody thought of is a missed optimization, never a dangling pointer.
+//
+// Flow sensitivity is what makes it useful rather than merely sound: the
+// dominant shape is "build it, then use it", where the aliasing use comes AFTER
+// the last append and cannot observe a moved array. Top-level statements run in
+// order, so an aliasing use at a strictly greater top-level index provably runs
+// after every append. Events inside a nested block carry that block's top-level
+// index, so an alias and an append in the SAME loop collide and disqualify.
+
+var g_al_names = []string{}   // candidate slice variables in the function being scanned
+var g_al_isparam = []int{}    // 1 if that candidate is a parameter
+var g_al_appat = []int{}      // highest top-level index holding an append (-2 = none)
+var g_al_alias = []int{}      // lowest top-level index holding an aliasing use (-2 = none)
+var g_al_apps = []int{}       // self-append sites
+var g_al_top = 0              // top-level statement index being scanned
+var g_al_ok = []string{}      // qualifying "iid|name" keys, the analysis's whole output
+
+func al_add(name, isparam) {
+    i := str_index(g_al_names, name)
+    if i >= 0 {
+        if isparam == 1 { g_al_isparam[i] = 1 }
+        return
+    }
+    g_al_names = append(g_al_names, name)
+    g_al_isparam = append(g_al_isparam, isparam)
+    g_al_appat = append(g_al_appat, -2)
+    g_al_alias = append(g_al_alias, -2)
+    g_al_apps = append(g_al_apps, 0)
+}
+
+// al_disq records an ALIASING USE at the current top-level index. Whether it
+// actually disqualifies is decided later, against where the appends are.
+func al_disq(name) {
+    i := str_index(g_al_names, name)
+    if i < 0 { return }
+    if g_al_alias[i] == -2 { g_al_alias[i] = g_al_top  return }
+    if g_al_top < g_al_alias[i] { g_al_alias[i] = g_al_top }
+}
+
+func al_note_append(name) {
+    i := str_index(g_al_names, name)
+    if i < 0 { return }
+    g_al_apps[i] = g_al_apps[i] + 1
+    if g_al_appat[i] == -2 { g_al_appat[i] = g_al_top  return }
+    if g_al_top > g_al_appat[i] { g_al_appat[i] = g_al_top }
+}
+
+// the fail-closed hammer: an unmodelled form could do anything with any of them
+func al_disq_all() {
+    i := 0
+    for i < len(g_al_names) { al_disq(g_al_names[i])  i = i + 1 }
+}
+
+func al_is_cand(idx) (yes) {
+    yes = 0
+    n := nodes[idx]
+    if n.kind != K_ID { return yes }
+    if str_index(g_al_names, n.s) >= 0 { yes = 1 }
+}
+
+// al_scan_expr walks an expression allowing ONLY the read forms that cannot leak
+// a reference to a candidate's backing array. A bare mention copies the slice
+// header, which is exactly what creates an alias, so it disqualifies.
+func al_scan_expr(iid, idx) {
+    if idx < 0 { return }
+    n := nodes[idx]
+    k := n.kind
+    if k == K_INT || k == K_FLOAT || k == K_STR || k == K_BOOL || k == K_NIL { return }
+    if k == K_MAKECHAN || k == K_MAKEMAP { return }
+    if k == K_ID { al_disq(n.s)  return }
+    if k == K_INDEX {
+        // v[i] yields an ELEMENT. For a struct or nested-slice element that is a
+        // copy of the element, not a pointer into the outer array, so the outer
+        // array may still move.
+        if al_is_cand(n.a) == 0 { al_scan_expr(iid, n.a) }
+        al_scan_expr(iid, n.b)
+        return
+    }
+    if k == K_CALL {
+        if n.s == "len" {
+            if len(n.kids) == 1 {
+                if al_is_cand(n.kids[0]) == 1 { return }   // reads the header field only
+            }
+        }
+        for _, a := range n.kids { al_scan_expr(iid, a) }
+        return
+    }
+    if k == K_CALLV {
+        al_scan_expr(iid, n.a)
+        for _, a := range n.kids { al_scan_expr(iid, a) }
+        return
+    }
+    if k == K_BIN { al_scan_expr(iid, n.a)  al_scan_expr(iid, n.b)  return }
+    if k == K_UNARY { al_scan_expr(iid, n.a)  return }
+    if k == K_FIELD { al_scan_expr(iid, n.a)  return }
+    if k == K_SLICE { for _, e := range n.kids { al_scan_expr(iid, e) }  return }
+    if k == K_STRUCT { for _, e := range n.kids { al_scan_expr(iid, e) }  return }
+    if k == K_RECV { al_scan_expr(iid, n.a)  return }
+    if k == K_FUNCLIT {
+        // a captured variable is shared by reference with the closure, which may
+        // outlive this frame. The lambda instance's leading params ARE its
+        // captures (#308 Phase 2), which is the same set the reference compiler
+        // sees on a lifted MakeClosure.
+        lid := funclit_inst(iid, idx)
+        if lid < 0 { al_disq_all()  return }
+        li := g_insts[lid]
+        j := 0
+        for j < li.ncap {
+            al_disq(li.pnames[j])
+            j = j + 1
+        }
+        return
+    }
+    al_disq_all()
+}
+
+func al_scan_stmts(iid, kids) {
+    for _, s := range kids { al_scan_stmt(iid, s) }
+}
+
+func al_scan_stmt(iid, idx) {
+    if idx < 0 { return }
+    n := nodes[idx]
+    k := n.kind
+    if k == K_ASSIGN {
+        vn := nodes[n.a]
+        // the one shape that keeps a candidate alive: v = append(v, ...)
+        if vn.kind == K_CALL {
+            if vn.s == "append" {
+                if len(vn.kids) >= 1 {
+                    a0 := nodes[vn.kids[0]]
+                    if a0.kind == K_ID && a0.s == n.s && str_index(g_al_names, n.s) >= 0 {
+                        // a spread append is not modelled
+                        if vn.ival == 1 { al_disq(n.s) } else { al_note_append(n.s) }
+                        j := 1
+                        for j < len(vn.kids) {
+                            al_scan_expr(iid, vn.kids[j])   // appending a candidate stores ITS header
+                            j = j + 1
+                        }
+                        return
+                    }
+                }
+            }
+        }
+        // initialization from a slice literal keeps it a candidate
+        if vn.kind == K_SLICE && str_index(g_al_names, n.s) >= 0 {
+            for _, e := range vn.kids { al_scan_expr(iid, e) }
+            return
+        }
+        // any other assignment INTO a candidate makes it share whatever it was given
+        if str_index(g_al_names, n.s) >= 0 { al_disq(n.s) }
+        al_scan_expr(iid, n.a)
+        return
+    }
+    if k == K_MULTI {
+        for _, nm := range n.names { al_disq(nm) }
+        for _, r := range n.kids { al_scan_expr(iid, r) }
+        return
+    }
+    if k == K_IDXASSIGN {
+        ixn := nodes[n.a]
+        // v[i] = e writes THROUGH the array; no reference escapes
+        if al_is_cand(ixn.a) == 0 { al_scan_expr(iid, ixn.a) }
+        al_scan_expr(iid, ixn.b)
+        al_scan_expr(iid, n.b)
+        return
+    }
+    if k == K_FLDASSIGN {
+        // v[i].f = e — the base is an index over the candidate
+        fdn := nodes[n.a]
+        bn := nodes[fdn.a]
+        if bn.kind == K_INDEX {
+            if al_is_cand(bn.a) == 1 {
+                al_scan_expr(iid, bn.b)
+                al_scan_expr(iid, n.b)
+                return
+            }
+        }
+        al_scan_expr(iid, fdn.a)
+        al_scan_expr(iid, n.b)
+        return
+    }
+    if k == K_EXPRSTMT { al_scan_expr(iid, n.a)  return }
+    if k == K_RETURN {
+        for _, v := range n.kids { al_scan_expr(iid, v) }   // hands the array to the caller
+        return
+    }
+    if k == K_IF {
+        al_scan_expr(iid, n.a)
+        al_scan_stmts(iid, n.kids)
+        al_scan_stmts(iid, n.kids2)
+        return
+    }
+    if k == K_WHILE {
+        al_scan_expr(iid, n.a)
+        al_scan_stmts(iid, n.kids)
+        return
+    }
+    if k == K_RANGE {
+        if al_is_cand(n.a) == 0 { al_scan_expr(iid, n.a) }   // ranges by value
+        al_scan_stmts(iid, n.kids)
+        return
+    }
+    if k == K_SEND {
+        // the runtime deep-copies values crossing a channel, so a send arguably
+        // does not alias. Disqualified anyway for v1, matching the reference.
+        al_scan_expr(iid, n.a)
+        vn := nodes[n.b]
+        if vn.kind == K_ID { al_disq(vn.s) } else { al_scan_expr(iid, n.b) }
+        return
+    }
+    if k == K_GO {
+        cn := nodes[n.a]
+        for _, a := range cn.kids { al_scan_expr(iid, a) }
+        return
+    }
+    if k == K_ARENA { al_scan_stmts(iid, n.kids)  return }
+    if k == K_SELECT {
+        for _, ci := range n.kids {
+            cn := nodes[ci]
+            al_scan_expr(iid, cn.a)
+            if cn.ival == 1 { al_scan_expr(iid, cn.b) }
+            al_scan_stmts(iid, cn.kids)
+        }
+        al_scan_stmts(iid, n.kids2)
+        return
+    }
+    if k == K_BREAK || k == K_CONTINUE { return }
+    al_disq_all()
+}
+
+// al_compute runs the analysis over every representative instantiation and
+// records the qualifying (instance, variable) pairs. Called once per program,
+// before any function body is emitted.
+func al_compute() {
+    g_al_ok = []string{}
+    ri := 0
+    for ri < len(g_reps) {
+        iid := g_reps[ri]
+        ri = ri + 1
+        ins := g_insts[iid]
+        g_al_names = []string{}
+        g_al_isparam = []int{}
+        g_al_appat = []int{}
+        g_al_alias = []int{}
+        g_al_apps = []int{}
+        // parameters are candidates too — not because they can ever qualify, but
+        // so a function that appends to one is refused explicitly
+        i := 0
+        for i < len(ins.pnames) {
+            if kind_of(ins.pslots[i]) == 7 { al_add(ins.pnames[i], 1) }
+            i = i + 1
+        }
+        i = 0
+        for i < len(ins.lnames) {
+            if kind_of(ins.lslots[i]) == 7 { al_add(ins.lnames[i], 0) }
+            i = i + 1
+        }
+        if len(g_al_names) == 0 { continue }
+        // a parameter is a slice the CALLER already holds, so the alias exists
+        // before the body runs — index -1, ahead of every append
+        g_al_top = -1
+        i = 0
+        for i < len(g_al_names) {
+            if g_al_isparam[i] == 1 { al_disq(g_al_names[i]) }
+            i = i + 1
+        }
+        root := func_root(ins.src)
+        if root < 0 { continue }
+        kids := nodes[root].kids
+        i = 0
+        for i < len(kids) {
+            g_al_top = i
+            al_scan_stmt(iid, kids[i])
+            i = i + 1
+        }
+        // an aliasing use only matters if it can observe an array that a LATER
+        // append moves. Equal indices mean both sit inside the same top-level
+        // statement, where order cannot be established.
+        i = 0
+        for i < len(g_al_names) {
+            unsafe := 0
+            if g_al_alias[i] != -2 {
+                if g_al_appat[i] == -2 {
+                    unsafe = 1
+                } else {
+                    if g_al_alias[i] <= g_al_appat[i] { unsafe = 1 }
+                }
+            }
+            if unsafe == 0 && g_al_apps[i] > 0 {
+                g_al_ok = append(g_al_ok, str(iid) + "|" + g_al_names[i])
+            }
+            i = i + 1
+        }
+    }
+}
+
+// al_owned_append renders `v = append(v, x)` through the in-place growth path
+// when v is provably unaliased. "" means fall back to the copying append.
+func al_owned_append(iid, idx) (out) {
+    out = ""
+    n := nodes[idx]
+    if str_index(g_al_ok, str(iid) + "|" + n.s) < 0 { return out }
+    vn := nodes[n.a]
+    if vn.kind != K_CALL { return out }
+    if vn.s != "append" { return out }
+    if vn.ival == 1 { return out }
+    if len(vn.kids) != 2 { return out }
+    a0 := nodes[vn.kids[0]]
+    if a0.kind != K_ID { return out }
+    if a0.s != n.s { return out }
+    val := cg_expr(iid, vn.kids[1])
+    ct := elem_ctype(iid, vn.kids[0])
+    out = "mfl_append_owned(" + var_ref(iid, n.s) + ", &((" + ct + "[1]){" + val + "})[0], sizeof(" + ct + "))"
+}

--- a/selfhost/cgagg.src
+++ b/selfhost/cgagg.src
@@ -130,7 +130,9 @@ func json_serializer(t) (name) {
         elem := substr(t, 2, len(t))
         es := json_serializer(elem)
         ect := ctype_name(elem)
-        body = "char* out = mfl_dup(\"[\");\n    for (int64_t i = 0; i < v.len; i++) {\n        if (i) out = mfl_cat(out, \",\");\n        out = mfl_cat(out, " + es + "(((" + ect + "*)v.data)[i]));\n    }\n    return mfl_cat(out, \"]\");"
+        // a string builder, not repeated mfl_cat: concatenating per element made
+        // json() O(n^2) on big values (#520)
+        body = "mfl_sb sb; mfl_sb_init(&sb); mfl_sb_puts(&sb, \"[\");\n    for (int64_t i = 0; i < v.len; i++) {\n        if (i) mfl_sb_puts(&sb, \",\");\n        mfl_sb_puts(&sb, " + es + "(((" + ect + "*)v.data)[i]));\n    }\n    mfl_sb_puts(&sb, \"]\");\n    return mfl_sb_done(&sb);"
     }
     if body == "" && has_prefix(t, "map[") {
         kt, vt := split_map_type(t)
@@ -140,22 +142,23 @@ func json_serializer(t) (name) {
         keyjson := "mfl_json_str(mfl_str_i(_k))"
         getcall := "mfl_map_get(v, _k, NULL, &_val);"
         if kt == "string" { keyjson = "mfl_json_str(_k)"  getcall = "mfl_map_get(v, 0, _k, &_val);" }
-        body = "mfl_slice _ks = mfl_map_keys(v);\n    char* out = mfl_dup(\"{\");\n    for (int64_t i = 0; i < _ks.len; i++) {\n        if (i) out = mfl_cat(out, \",\");\n        " + kct + " _k = ((" + kct + "*)_ks.data)[i];\n        " + vct + " _val; " + getcall + "\n        out = mfl_cat(out, " + keyjson + ");\n        out = mfl_cat(out, \":\");\n        out = mfl_cat(out, " + vs + "(_val));\n    }\n    return mfl_cat(out, \"}\");"
+        body = "mfl_slice _ks = mfl_map_keys(v);\n    mfl_sb sb; mfl_sb_init(&sb); mfl_sb_puts(&sb, \"{\");\n    for (int64_t i = 0; i < _ks.len; i++) {\n        if (i) mfl_sb_puts(&sb, \",\");\n        " + kct + " _k = ((" + kct + "*)_ks.data)[i];\n        " + vct + " _val; " + getcall + "\n        mfl_sb_puts(&sb, " + keyjson + ");\n        mfl_sb_puts(&sb, \":\");\n        mfl_sb_puts(&sb, " + vs + "(_val));\n    }\n    mfl_sb_puts(&sb, \"}\");\n    return mfl_sb_done(&sb);"
     }
     if body == "" {
         di := struct_def_idx(t)
         d := g_structdefs[di]
-        b := "char* out = mfl_dup(\"{\");\n"
+        b := "mfl_sb sb; mfl_sb_init(&sb); mfl_sb_puts(&sb, \"{\");\n"
         j := 0
         for j < len(d.fnames) {
             fs := json_serializer(d.ftypes[j])
             prefix := "\"\\\"" + d.fnames[j] + "\\\":\""
             if j > 0 { prefix = "\",\\\"" + d.fnames[j] + "\\\":\"" }
-            b = b + "    out = mfl_cat(out, " + prefix + ");\n"
-            b = b + "    out = mfl_cat(out, " + fs + "(v.f_" + d.fnames[j] + "));\n"
+            b = b + "    mfl_sb_puts(&sb, " + prefix + ");\n"
+            b = b + "    mfl_sb_puts(&sb, " + fs + "(v.f_" + d.fnames[j] + "));\n"
             j = j + 1
         }
-        b = b + "    return mfl_cat(out, \"}\");"
+        b = b + "    mfl_sb_puts(&sb, \"}\");\n"
+        b = b + "    return mfl_sb_done(&sb);"
         body = b
     }
     jsonfn_emit("static char* " + name + "(" + ct + " v) {\n    " + body + "\n}\n")
@@ -179,7 +182,7 @@ func json_parser(t) (name) {
         elem := substr(t, 2, len(t))
         ep := json_parser(elem)
         ect := ctype_name(elem)
-        body = "mfl_slice s = {0};\n    mfl_js_ws(p);\n    if (**p == '[') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != ']') {\n            while (1) {\n                " + ect + " _e = " + ep + "(p);\n                s = mfl_append(s, &_e, sizeof(" + ect + "));\n                if (mfl_js_more(p)) continue;\n                break;\n            }\n        }\n        mfl_js_ws(p); if (**p == ']') (*p)++;\n    }\n    return s;"
+        body = "mfl_slice s = {0};\n    if (mfl_js_null(p)) return s;\n    mfl_js_ws(p);\n    if (**p == '[') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != ']') {\n            while (1) {\n                " + ect + " _e = " + ep + "(p);\n                s = mfl_append(s, &_e, sizeof(" + ect + "));\n                if (mfl_js_more(p)) continue;\n                break;\n            }\n        }\n        mfl_js_ws(p); if (**p == ']') (*p)++;\n    }\n    return s;"
     }
     if body == "" && has_prefix(t, "map[") {
         kt, vt := split_map_type(t)
@@ -188,7 +191,7 @@ func json_parser(t) (name) {
         keyisstr := 0
         setcall := "mfl_map_set(m, strtoll(_k, 0, 10), 0, &_val);"
         if kt == "string" { keyisstr = 1  setcall = "mfl_map_set(m, 0, _k, &_val);" }
-        body = "mfl_map* m = mfl_make_map(" + str(keyisstr) + ", sizeof(" + vct + "));\n    mfl_js_ws(p);\n    if (**p == '{') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != '}') {\n            while (1) {\n                char* _k = mfl_js_str(p); mfl_js_ws(p); if (**p == ':') (*p)++;\n                " + vct + " _val = " + vp + "(p);\n                " + setcall + "\n                if (mfl_js_more(p)) continue;\n                break;\n            }\n        }\n        mfl_js_ws(p); if (**p == '}') (*p)++;\n    }\n    return m;"
+        body = "mfl_map* m = mfl_make_map(" + str(keyisstr) + ", sizeof(" + vct + "));\n    if (mfl_js_null(p)) return m;\n    mfl_js_ws(p);\n    if (**p == '{') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != '}') {\n            while (1) {\n                char* _k = mfl_js_str(p); mfl_js_ws(p); if (**p == ':') (*p)++;\n                " + vct + " _val = " + vp + "(p);\n                " + setcall + "\n                if (mfl_js_more(p)) continue;\n                break;\n            }\n        }\n        mfl_js_ws(p); if (**p == '}') (*p)++;\n    }\n    return m;"
     }
     if body == "" {
         di := struct_def_idx(t)
@@ -198,7 +201,7 @@ func json_parser(t) (name) {
         b := ct + " out = {0};\n"
         szi := string_zero_inits(t)
         if len(szi) > 0 { b = ct + " out = {" + join(szi, ", ") + "};\n" }
-        b = b + "    mfl_js_ws(p);\n    if (**p == '{') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != '}') {\n            while (1) {\n                char* _k = mfl_js_str(p); mfl_js_ws(p); if (**p == ':') (*p)++;\n"
+        b = b + "    if (mfl_js_null(p)) return out;\n    mfl_js_ws(p);\n    if (**p == '{') {\n        (*p)++; mfl_js_ws(p);\n        if (**p != '}') {\n            while (1) {\n                char* _k = mfl_js_str(p); mfl_js_ws(p); if (**p == ':') (*p)++;\n"
         j := 0
         for j < len(d.fnames) {
             fp := json_parser(d.ftypes[j])

--- a/selfhost/cgbuiltin.src
+++ b/selfhost/cgbuiltin.src
@@ -180,7 +180,8 @@ func cg_builtin(iid, call_idx, callee, names) (out) {
         k := node_kind(iid, argn[0])
         if k == 7 || k == 12 { out = "((" + names[0] + ").len)"  return out }
         if k == 10 { out = "mfl_map_len(" + names[0] + ")"  return out }
-        out = "((int64_t)strlen(" + names[0] + "))"
+        // mfl_s guards a NULL char*: strlen(NULL) is a segfault, len("") is 0
+        out = "((int64_t)strlen(mfl_s(" + names[0] + ")))"
         return out
     }
     if callee == "str" {

--- a/selfhost/cgen.src
+++ b/selfhost/cgen.src
@@ -50,9 +50,10 @@ func c_quote(v) (out) {
         if c == 10 { parts = append(parts, "\\n") } else {
         if c == 9 { parts = append(parts, "\\t") } else {
         if c == 13 { parts = append(parts, "\\r") } else {
+        if c == 63 { parts = append(parts, "\\?") } else {   // '?': keeps adjacent ones from forming a trigraph
         if (c >= 32 && c < 127) || c >= 128 { parts = append(parts, substr(v, i, i + 1)) } else {
             parts = append(parts, "\\" + oct3(c))   // control byte (0-31, 127): octal escape
-        }}}}}}
+        }}}}}}}
         i = i + 1
     }
     parts = append(parts, "\"")
@@ -224,7 +225,9 @@ func c_float(lex) (s) {
 func cg_expr(iid, idx) (out) {
     n := nodes[idx]
     k := n.kind
-    if k == K_INT { out = str(n.ival)  return out }
+    // the LL suffix keeps a literal wider than 32 bits from being typed as int
+    // by the C compiler before it is used
+    if k == K_INT { out = str(n.ival) + "LL"  return out }
     if k == K_FLOAT { out = c_float(n.s)  return out }
     if k == K_STR { out = c_quote(n.s)  return out }
     if k == K_BOOL { if n.ival == 1 { out = "1" } else { out = "0" }  return out }
@@ -461,6 +464,15 @@ func binary_combine(iid, idx, l, r) (out) {
 
 func cg_binary(iid, idx) (out) {
     n := nodes[idx]
+    // #437: && and || must SHORT-CIRCUIT. seq_operands hoists BOTH operands into
+    // temporaries as soon as either has a side effect, which evaluates the right
+    // operand unconditionally — so `i < len(xs) && xs[i] == 0` would index out of
+    // bounds. C's && / || already sequence left-to-right with a sequence point
+    // between them, so emit them directly.
+    if n.s == "&&" || n.s == "||" {
+        out = "(" + cg_expr(iid, n.a) + " " + n.s + " " + cg_expr(iid, n.b) + ")"
+        return out
+    }
     idxs := []int{n.a, n.b}
     names, decls, wrapped := seq_operands(iid, idxs)
     combined := binary_combine(iid, idx, names[0], names[1])
@@ -487,7 +499,14 @@ func cg_stmt(iid, idx, depth) {
     }
     if k == K_MULTI { indent(depth)  cg_multi_assign(iid, idx, depth)  return }
     indent(depth)
-    if k == K_ASSIGN { cemit(var_ref(iid, n.s) + " = " + cg_expr(iid, n.a) + ";\n")  return }
+    if k == K_ASSIGN {
+        // #578: grow in place where the alias analysis proves nothing else
+        // observes the backing array
+        owned := al_owned_append(iid, idx)
+        if owned != "" { cemit(var_ref(iid, n.s) + " = " + owned + ";\n")  return }
+        cemit(var_ref(iid, n.s) + " = " + cg_expr(iid, n.a) + ";\n")
+        return
+    }
     if k == K_RETURN {
         if len(n.kids) == 0 { emit_named_return(iid)  return }
         if len(n.kids) == 1 { cemit("return (" + cg_expr(iid, n.kids[0]) + ");\n")  return }

--- a/selfhost/cgprog.src
+++ b/selfhost/cgprog.src
@@ -138,6 +138,7 @@ var g_glob_inits = []int{}   // global-init expr node indices (parallel to g_glo
 func cg_program() {
     compute_reps()
     cg_nslot_init()   // O(1) node->slot direct index (sized to the node count)
+    al_compute()      // #578: which local slices append may grow in place
 
     // -1. function bodies are generated FIRST, into a temp buffer, so everything they
     //     lazily trigger as a side effect — goroutine trampolines (g_tramp) AND, #293,
@@ -232,6 +233,9 @@ func cg_program() {
     cemit("static int mfl_rr_prog_boundary(void) { return " + str(rr_boundary) + "; }\n")
     // 7. native entry point (only when the program defines main)
     if func_root("main") >= 0 {
-        cemit("int main(int argc, char** argv) { signal(SIGPIPE, SIG_IGN); mfl_argc = argc; mfl_argv = argv; mfl_rr_init(); mfl_main(); mfl_rr_finish(); return 0; }\n")
+        // SIGPIPE does not exist on Windows (#517), so the signal() call is guarded
+        cemit("int main(int argc, char** argv) {\n")
+        cemit("#ifndef _WIN32\n    signal(SIGPIPE, SIG_IGN);\n#endif\n")
+        cemit("    mfl_argc = argc; mfl_argv = argv; mfl_rr_init(); mfl_main(); mfl_rr_finish(); return 0; }\n")
     }
 }

--- a/selfhost/demo/README.md
+++ b/selfhost/demo/README.md
@@ -8,7 +8,7 @@ outputs are byte-for-byte identical — then a note that it runs as fast as the 
 ```bash
 # from repo root: build the toolchain, then record
 GOMAXPROCS=4 ./bin/machin encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
-  selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+  selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src \
   selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/cgmain.src > compiler.mfl
 ./bin/machin build compiler.mfl -o mfl-cgen
 # copy the 10 hand-written sources into ./src/, place compiler.mfl + mfl-cgen alongside record-demo.sh, then:

--- a/selfhost/verify-arena-selfhost.sh
+++ b/selfhost/verify-arena-selfhost.sh
@@ -11,7 +11,7 @@ pass=0; fail=0
 echo "building Go machin (oracle) + MFL arena pass…"
 GOMAXPROCS=4 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
-    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src \
     selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src \
     selfhost/arena.src selfhost/arenamain.src > "$T/sh.mfl" || { echo "encode failed"; exit 1; }
 $N "$MACHIN" build "$T/sh.mfl" -o selfhost/mfl-arena || { echo "build failed"; exit 1; }

--- a/selfhost/verify-cgen.sh
+++ b/selfhost/verify-cgen.sh
@@ -11,7 +11,7 @@ N="nice -n 15"
 echo "building Go machin (oracle) + MFL codegen…"
 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
-    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src selfhost/cgmain.src > /tmp/sh-cgen.mfl
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src selfhost/cgmain.src > /tmp/sh-cgen.mfl
 $N "$MACHIN" build /tmp/sh-cgen.mfl -o selfhost/mfl-cgen
 
 T=$(mktemp -d); pass=0; fail=0

--- a/selfhost/verify-closures.sh
+++ b/selfhost/verify-closures.sh
@@ -22,7 +22,7 @@ CCFLAGS="-O2 -fno-strict-aliasing -std=c11 -pthread -w"
 echo "building Go machin (oracle) + MFL codegen…"
 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
-    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src selfhost/cgmain.src > /tmp/shc-cgen.mfl
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src selfhost/cgmain.src > /tmp/shc-cgen.mfl
 $N "$MACHIN" build /tmp/shc-cgen.mfl -o selfhost/mfl-cgen
 
 T=$(mktemp -d); pass=0; fail=0

--- a/selfhost/verify-deadlock-selfhost.sh
+++ b/selfhost/verify-deadlock-selfhost.sh
@@ -12,7 +12,7 @@ pass=0; fail=0
 echo "building Go machin (oracle) + MFL deadlock pass…"
 GOMAXPROCS=4 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
-    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src \
     selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src \
     selfhost/deadlock.src selfhost/deadlockmain.src > "$T/sh.mfl" || { echo "encode failed"; exit 1; }
 $N "$MACHIN" build "$T/sh.mfl" -o selfhost/mfl-deadlock || { echo "build failed"; exit 1; }

--- a/selfhost/verify-falsify.sh
+++ b/selfhost/verify-falsify.sh
@@ -19,7 +19,7 @@ pass=0; fail=0
 echo "building Go machin (oracle) + MFL falsify pass…"
 GOMAXPROCS=4 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
-    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src \
     selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src \
     selfhost/falsify.src selfhost/falsifymain.src > "$T/sh-falsify.mfl" || { echo "encode failed"; exit 1; }
 $N "$MACHIN" build "$T/sh-falsify.mfl" -o selfhost/mfl-falsify || { echo "build failed"; exit 1; }

--- a/selfhost/verify-fixpoint.sh
+++ b/selfhost/verify-fixpoint.sh
@@ -14,7 +14,7 @@ export GOMAXPROCS="${GOMAXPROCS:-4}"
 N="nice -n 15"
 T=$(mktemp -d)
 SRCS="selfhost/lex.src selfhost/parse.src selfhost/check.src selfhost/checkgen.src \
-selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src selfhost/cgffi.src \
+selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src selfhost/cgffi.src \
 selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src selfhost/cgmain.src"
 
 echo "building Go machin + the MFL compiler (mfl-cgen)…"

--- a/selfhost/verify-nogo.sh
+++ b/selfhost/verify-nogo.sh
@@ -15,7 +15,7 @@ MACHIN="${MACHIN:-./bin/machin}"
 export GOMAXPROCS="${GOMAXPROCS:-4}"
 N="nice -n 15"
 SRCS="selfhost/lex.src selfhost/parse.src selfhost/check.src selfhost/checkgen.src \
-selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src selfhost/cgffi.src \
+selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src selfhost/cgffi.src \
 selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src selfhost/encode.src \
 selfhost/build.src selfhost/machin.src"
 T=$(mktemp -d); fail=0

--- a/selfhost/verify-race.sh
+++ b/selfhost/verify-race.sh
@@ -12,7 +12,7 @@ pass=0; fail=0
 echo "building Go machin (oracle) + MFL race pass…"
 $N go build -trimpath -o bin/machin . || { echo "go build failed"; exit 1; }
 $N "$MACHIN" encode selfhost/lex.src selfhost/parse.src selfhost/check.src \
-    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/cgagg.src \
+    selfhost/checkgen.src selfhost/cgen.src selfhost/cgbuiltin.src selfhost/alias.src selfhost/cgagg.src \
     selfhost/cgffi.src selfhost/cgprelude.src selfhost/cgprog.src selfhost/compile.src \
     selfhost/racecheck.src selfhost/racemain.src > "$T/sh-race.mfl" || { echo "encode failed"; exit 1; }
 $N "$MACHIN" build "$T/sh-race.mfl" -o selfhost/mfl-race || { echo "build failed"; exit 1; }


### PR DESCRIPTION
Closes #625. Closes #626.

The README leads with **"compiles itself — fixpoint"**. Nothing was checking that claim: none of the twelve `selfhost/verify-*.sh` gates ran in any workflow, and two had been failing for an unknown number of commits.

## What had drifted

Six codegen changes landed in the Go compiler and were never ported, so the two compilers built **observably different programs** from the same source. Four are correctness bugs in self-hosted builds, not cosmetic drift:

| unported | effect on a self-hosted build |
|---|---|
| `mfl_s` NULL guard on `len(string)` | `strlen(NULL)` **segfaults** instead of returning 0 |
| short-circuit `&&` / `\|\|` (#437) | both operands evaluated — `i < len(xs) && xs[i] == 0` **reads out of bounds** |
| `mfl_js_null` guard (#533) | every field after a JSON `null` **silently dropped** |
| `mfl_sb` builder in `json()` (#520) | `json()` quadratic instead of linear |
| `mfl_append_owned` (#578) | every `append` copies; never grows in place |
| `LL` suffix on int literals | a literal wider than 32 bits typed as `int` |

Plus `?` → `\?` in C string literals (adjacent ones would form a trigraph) and the `main()` `SIGPIPE` guard (#517).

Worth stating plainly: **#625 as I filed it understated this.** I described one failing cross-check. The real state was 31 of 415 corpus cases mismatching across six distinct causes, three of which can crash or corrupt a program.

## The alias analysis

`mfl_append_owned` needed the whole unaliased-slice analysis ported — now [`selfhost/alias.src`](selfhost/alias.src), fail-closed exactly like `alias.go`, including flow sensitivity and the closure-capture case. A lambda instance's leading params **are** its captures (#308 Phase 2), which is the same set the reference sees on a lifted `MakeClosure` — so the two agree rather than selfhost merely being stricter.

## Verification

Oracle **384/415 → 415/415**. `verify-fixpoint.sh` passes including step 4.

```
verify-parse      PASS      verify-closures          PASS 9/0
verify-check      211/0     verify-race              PASS 22/0
verify-check2     305/0     verify-arena-selfhost    16/0
verify-check3     276/0     verify-deadlock-selfhost 10/0
verify-check4     131/7     verify-falsify           52/0
verify-nogo       PASS      verify-cgen              415/0
```

`check4`'s 7 failures are **pre-existing** — clean `main` is 129/7, this branch is 131/7 (two more passing, none new). Full Go suite green.

## The gates

Three new CI steps: prelude regenerated (#626), oracle clean, fixpoint holds. Cheap — 0.08s / 19s / 11s.

**Each was mutation-tested.** Reverting the `?` fix takes the oracle to 413/2 and turns its gate red. For the prelude gate my first test proved nothing — `gen-prelude.py` overwrote the corruption before the diff ran — so I retested it the way it actually fires, against a stale **committed** prelude, where it correctly fails. That is the same failure mode as an ASan step that skips: a gate that cannot go red is worse than no gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved compiler handling of slice appends, including safer in-place growth when possible.
  * Improved generated code correctness for short-circuit expressions, integer literals, string escaping, and platform-specific signal handling.
  * JSON parsing now safely handles `null` values for slices, maps, and structs.
  * String length checks now correctly handle empty or null strings.
  * JSON serialization is more efficient for arrays, maps, and structs.

* **Reliability**
  * Added automated checks to verify generated code, regeneration, and self-hosting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->