### PR TITLE
release: v0.134.0 — wss_open headers, and the self-hosting claim is finally verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.134.0
+
 **The self-hosted compiler had silently drifted, and nothing was checking**
 (issues #625, #626) — the README leads with *"compiles itself — fixpoint"*, but
 no workflow ran any of the twelve `selfhost/verify-*.sh` gates. They were all

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.133.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.134.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.133.0
+Version 0.134.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.133.0"
+const machinVersion = "0.134.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Two things ship here.

**`wss_open` takes optional header lines** (#622) — MFL can now reach a WebSocket endpoint that authenticates the HTTP upgrade. CRLF in a header value is refused rather than sanitized.

**The self-hosted compiler is back in parity with the reference** (#625, #626). Six codegen changes had landed in Go and never been ported — four of them correctness bugs in self-hosted builds: `strlen(NULL)`, lost `&&` short-circuiting, dropped JSON fields after a `null`, and always-copying `append`. Oracle **384/415 → 415/415**.

This is the first tag where **"compiles itself — fixpoint" is machine-verified rather than asserted**. Three CI gates now run the prelude regeneration, the codegen oracle and the fixpoint on every push; before this they were manual-only, and two had been failing for an unknown number of commits.

Version bumped in all four places (README badge, SPEC, `guide.go`, CHANGELOG). Full suite green (`ok machin 210.297s`), fixpoint PASS, `make version-check` satisfied by the one-commit grace.

Tag goes on the squashed commit once this merges and main is green.