### PR TITLE
release: v0.135.0 — http_request refuses CR/LF in header lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.135.0
+
 **`http_request` refuses CR/LF in header lines** (issue #627) — the same
 exposure `wss_open` closed in v0.134.0, in the builtin that is far more widely
 used.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.134.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.135.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.134.0
+Version 0.135.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.134.0"
+const machinVersion = "0.135.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
Closes the request-splitting exposure (#627) in the builtin far more widely used than `wss_open`, whose equivalent shipped in v0.134.0.

A header value the caller interpolated (`"Authorization: Bearer " + token`) could **forge additional headers** or, with a doubled CRLF, **smuggle an entire second request**. Now refused rather than sanitized, and visibly: `err` becomes `"header"` and nothing is sent.

An **empty** header line — which used to emit a bare CRLF and discard every header after it — is now skipped.

Version bumped in all four places. Full suite green, oracle 415/0, fixpoint PASS, `make version-check` satisfied by the one-commit grace. Tag goes on the squashed commit once main is green.