### PR TITLE
release: v0.136.0 — terminal raw mode on the windows target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.136.0
+
 **Terminal raw mode works on the windows target** (issue #517) — one of the
 three remaining gaps. `termios` has no Windows equivalent, so `raw_mode` clears
 `ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT` through `SetConsoleMode` — the two flags

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.135.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.136.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.135.0
+Version 0.136.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.135.0"
+const machinVersion = "0.136.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
One of #517's three remaining gaps. `termios` has no Windows equivalent, so `raw_mode` maps onto `SetConsoleMode` and `read_key` onto `_kbhit`/`_getch`, peeking a redirected stdin so it never blocks.

CI has no interactive console, but that is the case worth pinning: **off a tty both targets must agree**, and the `windows-run` job asserts byte-identical output from the `.exe` for the same two stdin shapes POSIX is pinned on.

**Does not close #517.** `XEdDSA` needs a mingw libsodium I cannot verify on a runner, and `regex` is a semantics problem — POSIX ERE is leftmost-longest, a backtracking engine leftmost-first, so the same program would answer differently per platform. Both stay rejected with their #517 message.

Also documented: a windows `.exe` writes **CRLF**, so `println` output is not byte-identical to a native build.

Version bumped in all four places. Full suite green, oracle 415/0, fixpoint PASS, `make version-check` satisfied by the one-commit grace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.136.0.
  * Documented improved Windows terminal raw-mode and redirected-input handling.
  * Documented cross-platform terminal compatibility testing and Windows output normalization.
  * Clarified continued Windows limitations for XEdDSA and regular expressions.
  * Updated displayed and embedded version information to 0.136.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->