### PR TITLE
tools: a differential oracle for regex engines on the windows target (#517)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -48,3 +48,13 @@ python3 tools/tokmin.py examples
 The lesson it encodes: minimize tokens by removing what the tokenizer charges
 for (whitespace), not by shortening what it already packs into one token
 (common keywords).
+
+## regex-differential/
+
+A differential oracle between POSIX `<regex.h>` and a candidate regex engine,
+over the exact operations `regex_*` exposes. The windows target has no
+`<regex.h>` (#517), and a replacement that answers differently would make the
+same MFL program return different results per platform — so a candidate is
+measured against this before it is considered. See
+[`regex-differential/README.md`](regex-differential/README.md) for the numbers
+that closed PR #612.

--- a/tools/regex-differential/README.md
+++ b/tools/regex-differential/README.md
@@ -1,0 +1,39 @@
+# regex differential oracle
+
+Any candidate regex engine for the windows target (#517) must answer **exactly**
+what `<regex.h>` answers on native, or the same MFL program silently returns
+different results per platform. This measures that.
+
+```sh
+cp /path/to/candidate-engine.h remimu.h     # or edit the include
+cc -O1 -std=c11 -w diff.c -o diff && ./diff # exit 0 = zero divergences
+```
+
+## Why it exists
+
+PR #612 proposed vendoring [Remimu](https://github.com/wareya/Remimu), a
+backtracking engine, for the windows target while native kept POSIX ERE. The
+objection was semantic, so it was measured rather than argued. **13 of 50
+divergences**, in three classes:
+
+| class | example | native (POSIX) | Remimu |
+|---|---|---|---|
+| leftmost-**longest** vs leftmost-**first** | `b\|bc` on `abcd` | `bc` | `b` |
+| POSIX bracket classes unsupported | `[[:digit:]]+` on `x42y` | `42` | *no match* |
+| PCRE escapes POSIX treats as literals | `\d+` on `x42y` | *no match* | `42` |
+
+The first is the classic ERE/backtracking split: POSIX takes the longest
+alternative, a backtracking engine takes the first that succeeds. The second is
+worse than a different answer — a program filtering on `[[:digit:]]+` finds
+**nothing** on Windows. The third runs the other way: a pattern that works only
+on Windows.
+
+## The bar
+
+A replacement engine must be **leftmost-longest** and support POSIX bracket
+expressions. A DFA/TNFA implementation (musl's `regcomp`/`regexec`, TRE) meets
+that; a PCRE-style backtracker does not, whatever its other merits.
+
+The cheapest sound option is one engine on **every** target, so the two can't
+drift — but that changes native behaviour too, so it must clear this harness at
+zero divergences first.

--- a/tools/regex-differential/diff.c
+++ b/tools/regex-differential/diff.c
@@ -1,0 +1,142 @@
+/* Differential oracle: glibc POSIX ERE  vs  vendored Remimu, over the exact
+   operations machin's regex_* builtins expose. The question PR #612 turns on is
+   empirical -- POSIX ERE is leftmost-LONGEST, a backtracking engine is
+   leftmost-FIRST -- so measure how far apart they actually are rather than
+   argue about it. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <regex.h>
+
+#define REMIMU_LOG_ERROR(X) ((void)0)
+#define REMIMU_ASSERT(X) ((void)0)
+#include "remimu.h"   /* the candidate engine; not vendored in this repo */
+
+/* ---- POSIX side: what machin does today on native/wasm ---- */
+static int posix_match(const char* s, const char* pat) {
+    regex_t re;
+    if (regcomp(&re, pat, REG_EXTENDED | REG_NOSUB) != 0) return -1; /* -1 = bad pattern */
+    int r = regexec(&re, s, 0, NULL, 0);
+    regfree(&re);
+    return r == 0;
+}
+static int posix_find(const char* s, const char* pat, char* out, size_t outcap) {
+    regex_t re;
+    out[0] = 0;
+    if (regcomp(&re, pat, REG_EXTENDED) != 0) return -1;
+    regmatch_t m[1];
+    int found = 0;
+    if (regexec(&re, s, 1, m, 0) == 0 && m[0].rm_so >= 0) {
+        size_t len = (size_t)(m[0].rm_eo - m[0].rm_so);
+        if (len >= outcap) len = outcap - 1;
+        memcpy(out, s + m[0].rm_so, len);
+        out[len] = 0;
+        found = 1;
+    }
+    regfree(&re);
+    return found;
+}
+
+/* ---- Remimu side: exactly the loops PR #612 emits for the windows target ---- */
+static int remimu_match(const char* s, const char* pat) {
+    RegexToken tokens[1024];
+    int16_t token_count = 1024;
+    if (regex_parse(pat, tokens, &token_count, 0) != 0) return -1;
+    size_t n = strlen(s);
+    for (size_t i = 0; i <= n; i++) {
+        int64_t end = regex_match(tokens, s, i, 0, NULL, NULL);
+        if (end >= 0 && (size_t)end >= i) return 1;
+    }
+    return 0;
+}
+static int remimu_find(const char* s, const char* pat, char* out, size_t outcap) {
+    RegexToken tokens[1024];
+    int16_t token_count = 1024;
+    out[0] = 0;
+    if (regex_parse(pat, tokens, &token_count, 0) != 0) return -1;
+    size_t n = strlen(s);
+    for (size_t i = 0; i <= n; i++) {
+        int64_t end = regex_match(tokens, s, i, 0, NULL, NULL);
+        if (end >= 0 && (size_t)end >= i) {
+            size_t len = (size_t)end - i;
+            if (len >= outcap) len = outcap - 1;
+            memcpy(out, s + i, len);
+            out[len] = 0;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+typedef struct { const char* pat; const char* subj; } Case;
+
+int main(void) {
+    static const Case cases[] = {
+        /* --- patterns machin's own tests and examples actually use --- */
+        {"a", "a"}, {"[0-9]+", "abc"}, {"[0-9]+", "id 4821 x"},
+        {"(abc)(x)?", "abc"}, {"^[a-z]+@[a-z]+\\.[a-z]+$", "a@b.co"},
+        {"([0-9]+)-([0-9]+)-([0-9]+)", "2026-06-22"},
+        {"([a-z]+):([0-9]+):([a-z]+)", "carol:99:admin"},
+        {"[0-9]+", "5-9"}, {"#", "a#b"}, {"x", "abc"},
+
+        /* --- realistic field-extraction shapes --- */
+        {"[a-z]+", "hello world"}, {"[A-Za-z0-9_]+", "tok_42 rest"},
+        {"[0-9]{2,4}", "year 2026 x"}, {"^GET|^POST", "POST /x"},
+        {"https?://[a-z.]+", "see http://a.b end"},
+        {"[ \t]+", "a   b"}, {"\\.[a-z]+$", "file.tar.gz"},
+        {"(foo|foobar)", "foobar"},            /* the classic */
+        {"(a|ab)(c|bcd)", "abcd"},             /* POSIX picks the longest OVERALL */
+        {"a*", "aaa"}, {"a*", ""}, {"(a*)*", "aaa"},
+        {"[[:digit:]]+", "x42y"}, {"[[:alpha:]]+", "42abc"},
+        {"^$", ""}, {"^", "abc"}, {"$", "abc"},
+        {"a{2}", "aaa"}, {"a{2,}", "aaaa"}, {"(ab)+", "ababab"},
+        {"[^a]+", "aaabbb"}, {"a.c", "abc"}, {".*", "abc"},
+        {"x|", "abc"}, {"(|a)", "a"},
+
+        /* --- alternation orderings: where leftmost-longest and
+               leftmost-first are KNOWN to disagree --- */
+        {"b|bc", "abcd"}, {"bc|b", "abcd"},
+        {"a|ab", "ab"}, {"ab|a", "ab"},
+        {"one|onetwo", "onetwo"}, {"onetwo|one", "onetwo"},
+        {"[0-9]|[0-9][0-9]", "42"}, {"[0-9][0-9]|[0-9]", "42"},
+        {"x(a|ab)y?", "xaby"},
+        {"(a+|a+b)", "aab"},
+
+        /* --- the REVERSE direction: PCRE syntax remimu accepts but POSIX ERE
+               treats as a literal, so these would work only on Windows --- */
+        {"\\d+", "x42y"}, {"\\w+", "a_b!"}, {"\\s", "a b"},
+        {"[[:space:]]", "a b"}, {"[[:upper:]]+", "aBC"},
+    };
+    const int n = (int)(sizeof(cases) / sizeof(cases[0]));
+    int diffs = 0, agree = 0, badpat = 0;
+
+    printf("%-24s %-16s %-12s %-12s %s\n", "PATTERN", "SUBJECT", "POSIX-find", "REMIMU-find", "");
+    printf("---------------------------------------------------------------------------------\n");
+    for (int i = 0; i < n; i++) {
+        char pf[512], rf[512];
+        int pm = posix_match(cases[i].subj, cases[i].pat);
+        int rm = remimu_match(cases[i].subj, cases[i].pat);
+        int pfo = posix_find(cases[i].subj, cases[i].pat, pf, sizeof pf);
+        int rfo = remimu_find(cases[i].subj, cases[i].pat, rf, sizeof rf);
+
+        if (pm < 0 || rm < 0 || pfo < 0 || rfo < 0) {
+            /* pattern rejected by one or both -- report, don't count as agreement */
+            if ((pm < 0) != (rm < 0)) {
+                printf("PARSE  %-22s %-16s posix=%s remimu=%s\n", cases[i].pat, cases[i].subj,
+                       pm < 0 ? "reject" : "accept", rm < 0 ? "reject" : "accept");
+                diffs++;
+            } else {
+                badpat++;
+            }
+            continue;
+        }
+        int same = (pm == rm) && (strcmp(pf, rf) == 0);
+        if (same) { agree++; continue; }
+        diffs++;
+        printf("DIFF   %-22s %-16s [%s]%*s [%s]  match:%d/%d\n",
+               cases[i].pat, cases[i].subj, pf, (int)(10 - strlen(pf)), "", rf, pm, rm);
+    }
+    printf("---------------------------------------------------------------------------------\n");
+    printf("agree=%d  diverge=%d  both-reject=%d  total=%d\n", agree, diffs, badpat, n);
+    return diffs > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Groundwork for #517's regex gap, and the evidence that closes #612.

PR #612 proposed vendoring [Remimu](https://github.com/wareya/Remimu) — a backtracking engine — for the windows target while native kept POSIX ERE. My objection was semantic, so rather than argue it I measured it.

## 13 of 50 divergences, in three classes

| class | example | native (POSIX) | Remimu |
|---|---|---|---|
| leftmost-**longest** vs leftmost-**first** | `b\|bc` on `abcd` | `bc` | `b` |
| POSIX bracket classes unsupported | `[[:digit:]]+` on `x42y` | `42` | **no match** |
| PCRE escapes POSIX takes literally | `\d+` on `x42y` | **no match** | `42` |

Seven cases are the classic ERE/backtracking split — POSIX takes the longest alternative, a backtracker takes the first that succeeds. `(foo\|foobar)` on `foobar` returns `foobar` natively and `foo` on Windows.

The second class is **worse than a different answer**: Remimu is PCRE-flavoured (`\d`, `\s`, `\w`), so a program filtering on `[[:digit:]]+` finds *nothing at all* on Windows. I checked whether a parse flag enabled POSIX classes — it does not; `REMIMU_FLAG_DOT_NO_NEWLINES` is the only flag.

The third runs the other way: a pattern that works **only** on Windows, which would then break when the program is built natively.

## What this PR lands

The harness, so the bar is executable rather than an opinion. A candidate engine must be **leftmost-longest** *and* support **POSIX bracket expressions**, and must clear this at zero divergences. A DFA/TNFA implementation (musl's `regcomp`/`regexec`, TRE) meets that; a PCRE-style backtracker does not, whatever its other merits.

The engine itself is not vendored — drop a candidate header beside `diff.c` and build.

Note the cheapest *sound* option is one engine on **every** target, so the two cannot drift. That changes native behaviour too, which is exactly why it has to clear this harness first.