### PR TITLE
release: v0.137.0 — regex differential oracle (tooling only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+## v0.137.0
+
+**Tooling only — the compiler is unchanged from v0.136.0.** The binaries for this
+tag are functionally identical; only `machin guide` reports a different version.
+
+Adds [`tools/regex-differential/`](tools/regex-differential/), a differential
+oracle between POSIX `<regex.h>` and a candidate regex engine, over the exact
+operations `regex_*` exposes. It exists because #517's regex gap turns on an
+empirical question, and PR #612 was closed by measuring it rather than arguing:
+**13 of 50 divergences**, in three classes.
+
+| class | example | native (POSIX) | Remimu |
+|---|---|---|---|
+| leftmost-**longest** vs leftmost-**first** | `b\|bc` on `abcd` | `bc` | `b` |
+| POSIX bracket classes unsupported | `[[:digit:]]+` on `x42y` | `42` | *no match* |
+| PCRE escapes POSIX takes literally | `\d+` on `x42y` | *no match* | `42` |
+
+The middle one is worse than a different answer: a program filtering on
+`[[:digit:]]+` finds nothing at all on Windows. The bar for any future candidate
+is now executable — leftmost-longest, POSIX bracket expressions, zero
+divergences.
+
 ## v0.136.0
 
 **Terminal raw mode works on the windows target** (issue #517) — one of the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.136.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.137.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
   <img src="https://img.shields.io/badge/go-1.22-00ADD8" alt="Go">
   <img src="https://img.shields.io/badge/backend-C%20%E2%86%92%20native-orange" alt="Native">

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.136.0
+Version 0.137.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one

--- a/guide.go
+++ b/guide.go
@@ -28,7 +28,7 @@ var skillDeploy string
 
 // machinVersion is the single version string for the toolchain. Bump it when
 // cutting a release (alongside README badge / SPEC / CHANGELOG).
-const machinVersion = "0.136.0"
+const machinVersion = "0.137.0"
 
 // ---- the source-of-truth feature catalog ----
 //


### PR DESCRIPTION
**The compiler is unchanged from v0.136.0.** This tag's binaries are functionally identical; only `machin guide` reports a different version. Stating that in the notes rather than letting a version bump imply a code change.

The only commit since the last tag is `ab320c8`, three files under `tools/`, none of them compiled into the binary.

Adds [`tools/regex-differential/`](tools/regex-differential/) — the oracle that closed PR #612 by measuring the claim instead of arguing it: **13 of 50 divergences** between POSIX ERE and a backtracking engine, including `[[:digit:]]+` matching *nothing at all* on Windows. The bar for any future candidate engine is now executable: leftmost-longest, POSIX bracket expressions, zero divergences.

Version bumped in all four places. Full suite green, fixpoint PASS, `make version-check` satisfied by the one-commit grace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project, specification, and embedded toolchain version to 0.137.0.
  * Added release notes describing regex differential testing results and future acceptance criteria.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->