### PR TITLE
docs: write down the self-hosting gates a codegen change must clear

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,30 @@ node type: `transform.go` (lifter, `collectDeclared`, `freeIdents`), `types.go`
 and a note in `SPEC.md`, `README.md`, and `docs/LANGUAGE.md`, plus the relevant
 idiom/gotcha in the `machin guide` catalog (`guide.go`).
 
+### Touching codegen? Port it to `selfhost/` too
+
+**There are two compilers**, and CI now requires them to emit the *same C*. A
+change to `codegen.go` that is not mirrored in `selfhost/` turns the build red:
+
+| gate | what it checks | fix when it fails |
+|---|---|---|
+| prelude regenerated | `selfhost/cgprelude.src` matches the Go C runtime | `python3 selfhost/gen-prelude.py` and commit the result |
+| codegen oracle | `selfhost/verify-cgen.sh` — 415 programs, byte-diffed against the Go compiler | port the emit change into `selfhost/cg*.src` |
+| fixpoint | `selfhost/verify-fixpoint.sh` — the compiler still reproduces itself, and matches the reference | usually falls out of fixing the two above |
+
+This is not bureaucracy. Before these gates existed, **six** codegen changes had
+silently failed to land in the self-hosted compiler, and four of them were
+correctness bugs in self-hosted builds — `strlen(NULL)`, lost `&&`
+short-circuiting, JSON fields dropped after a `null`, always-copying `append`
+(#625, #626). The two compilers had been building observably different programs
+for an unknown number of commits, and the README's "compiles itself" badge was
+asserting something nothing checked.
+
+Changing the **C runtime** (any `*Runtime` string in `codegen.go`) means
+regenerating the prelude; changing an **emitter** means editing the matching
+`selfhost/cg*.src`. Run all three locally before pushing — together they take
+about 30 seconds.
+
 ### Branch → PR → merge
 
 Feature work goes on a branch, then a PR, then squash-merge + delete the branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+**Docs: the self-hosting gates are now written down.** v0.134.0 made CI enforce
+that the Go compiler and the self-hosted one emit identical C, but nothing told
+a contributor that — so a `codegen.go` change would hit three unexplained red
+gates.
+
+- `CONTRIBUTING.md` and `AGENTS.md` now state the rule plainly: **touch codegen,
+  port it to `selfhost/`**, with the three commands and when each applies
+  (a `*Runtime` string means regenerating the prelude; an emitter means editing
+  the matching `cg*.src`).
+- `selfhost/BOOTSTRAP.md` records what happened when nothing enforced this: six
+  unported changes, four of them correctness bugs in self-hosted builds, and an
+  oracle sitting at 384/415.
+- The README's self-hosting claim now says CI checks it on every push, rather
+  than describing a milestone someone once reached.
+
+No code change.
+
+
 ## v0.137.0
 
 **Tooling only — the compiler is unchanged from v0.136.0.** The binaries for this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,22 @@ make test    # go test ./...
 Tests must pass before a PR. `make examples` (or `./examples/run.sh`) is a
 good sanity check that nothing regressed at runtime.
 
+**If you touched `codegen.go`, also run the self-hosting gates** — machin has
+two compilers (the Go one and the one written in machin under `selfhost/`), and
+CI requires them to emit identical C:
+
+```bash
+python3 selfhost/gen-prelude.py      # regenerate the embedded C runtime, commit any diff
+bash selfhost/verify-cgen.sh         # 415 programs, byte-diffed vs the Go compiler
+bash selfhost/verify-fixpoint.sh     # the compiler still reproduces itself
+```
+
+About 30 seconds in total. A codegen change that lands in only one compiler
+makes the two build observably different programs — which is exactly how four
+correctness bugs (including a `strlen(NULL)` crash and lost `&&`
+short-circuiting) reached self-hosted builds unnoticed before these gates
+existed.
+
 See [AGENTS.md](AGENTS.md) for the fuller dev workflow and standing
 constraints (in particular: the `.mfl` source of truth is canonical plain
 text, not base64).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ A language **shaped for AI agents to write and edit cheaply**: zero type annotat
 > **byte-for-byte** — a genuine compiler **fixpoint** — at ~0.9× the original's speed. A
 > language mature enough to build itself from scratch, verified to the byte. Every stage
 > was built against a byte-diff oracle, which flushed out three real compiler bugs along
-> the way. See [`selfhost/`](selfhost/) and [`BOOTSTRAP.md`](selfhost/BOOTSTRAP.md).
+> the way. **CI enforces it on every push** — the fixpoint, a 415-program codegen
+> oracle diffed against the reference compiler, and the embedded runtime being in
+> sync — so this is a checked claim, not a milestone someone once reached. See
+> [`selfhost/`](selfhost/) and [`BOOTSTRAP.md`](selfhost/BOOTSTRAP.md).
 
 <p align="center">
   <img src="docs/machin-demo.gif" alt="machin: write a REST+SQLite service, compile to a tiny native binary, run it" width="760">

--- a/selfhost/BOOTSTRAP.md
+++ b/selfhost/BOOTSTRAP.md
@@ -351,3 +351,37 @@ checks, compiles, links, and runs machin — including its own source — plus c
 Corpus `--emit-c` parity: **PASS 23, FAIL 0**, with 9 UNSUPPORTED — the remaining codegen
 skips (channels-with-structs / `select` / closures), a separate codegen effort. Other
 follow-ups: `--static` (SQLite amalgamation bundling), the wasm target, `guide`/`skill`.
+
+## ⚠️ Parity is enforced by CI, and was not always (#625, #626)
+
+Every gate here was **manual-only** until v0.134.0 — no workflow ran a single
+`verify-*.sh`. Two of them had been failing for an unknown number of commits, and
+**six** codegen changes had landed in the Go compiler and never been ported. Four
+were correctness bugs in self-hosted builds, not cosmetic drift:
+
+| unported | effect on a self-hosted build |
+|---|---|
+| `mfl_s` NULL guard on `len(string)` | `strlen(NULL)` **segfaults** instead of returning 0 |
+| short-circuit `&&` / `\|\|` (#437) | both operands evaluated — `i < len(xs) && xs[i] == 0` reads out of bounds |
+| `mfl_js_null` guard (#533) | every field after a JSON `null` silently dropped |
+| `mfl_sb` builder in `json()` (#520) | `json()` quadratic instead of linear |
+| `mfl_append_owned` (#578) | every `append` copies; never grows in place |
+| `LL` suffix on int literals | a literal wider than 32 bits typed as `int` |
+
+The codegen oracle read **384/415** at that point. It reads 415/415 now, and three
+CI steps hold it there on every push:
+
+```bash
+python3 selfhost/gen-prelude.py && git diff --exit-code selfhost/cgprelude.src
+bash selfhost/verify-cgen.sh        # expects "FAIL 0"
+bash selfhost/verify-fixpoint.sh    # expects "SELF-HOSTING FIXPOINT: PASS"
+```
+
+**If you change `codegen.go`, run these before pushing** (~30 s total). A change to
+any `*Runtime` string means regenerating the prelude — the self-hosted compiler
+embeds its *own* copy of the C runtime, so a stale prelude silently builds
+programs against an older runtime than the Go compiler does. A change to an
+emitter means editing the matching `cg*.src`.
+
+The lesson generalises past this repo: a headline claim that nothing executes is
+a claim that quietly stops being true.


### PR DESCRIPTION
v0.134.0 made CI enforce that the Go compiler and the self-hosted one emit identical C. **Nothing told a contributor that** — a `codegen.go` change would hit three unexplained red gates with no instructions anywhere in the repo.

- **`CONTRIBUTING.md`** and **`AGENTS.md`** now state the rule and the three commands, plus which applies when: a `*Runtime` string means regenerating the prelude; an emitter means editing the matching `cg*.src`.
- **`selfhost/BOOTSTRAP.md`** records what happened while nothing enforced it — six unported changes, four of them correctness bugs in self-hosted builds, oracle at 384/415. Worth writing down because the failure mode is *invisible*: the self-hosted compiler compiles and runs perfectly well against a stale runtime.
- **`README.md`**'s fixpoint claim now says CI checks it on every push. It was true before, but unchecked — which is how it quietly stopped being true.

## On `docs/` specifically

Audited it and changed nothing, because nothing was stale:

- `BENCHMARKS.md` already carries the corrected sieve numbers (1.01× tie vs Rust, 1.19× vs Zig)
- `record-replay.md` is still accurate — the new two-argument `wss_open` goes through the same record/replay wrappers
- `NORTH-STAR-*.md`, `LANGUAGE.md` tty rows: unaffected, none claimed tty was unsupported on Windows

The gap was contributor-facing process docs, not reference material.

No code change.