### PR TITLE
typecheck: two error messages that named nothing (#637, #638)

### DIFF
--- a/fieldmismatch_msg_test.go
+++ b/fieldmismatch_msg_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A type mismatch resolved through a STRUCT FIELD used to report
+//
+//	type mismatch: float vs int
+//
+// with no file, no line, no name, in a compiler that annotates local-variable
+// mismatches beautifully ("type mismatch for 'kk' in \"main\": num vs struct").
+// The reason is that field uses are deferred: `resolveDeferred` unions the
+// field-use slot with the field's declared type long after the statement that
+// produced it, and that path never called the annotator.
+//
+// It matters most in exactly the case where it said least — a large program,
+// where there is no small region to scan and the only recourse is to bisect by
+// deleting code until the message goes away.
+
+// TestFieldMismatchNamesFieldAndStruct is the reported repro reduced: `best` is
+// inferred float from `0.0 - 1` and then assigned an int, and the collision
+// surfaces when the result is stored into an int field.
+func TestFieldMismatchNamesFieldAndStruct(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type P struct { x float  st int }`,
+		`func look(f, e) (best) {
+			best = 0.0 - 1
+			j := 0
+			while j < 3 { if e.x > f.x { best = j } j = j + 1 }
+		}`,
+		`func main() { a := P{1.0, 0} b := P{2.0, 0} a.st = look(a, b) println(str(a.st)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	msg := err.Error()
+	for _, want := range []string{"field 'st'", "of P", "float vs int"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestFieldMismatchNamesTheSource: naming the field says what was expected;
+// naming the variable that supplied the value says where it came from. Between
+// them there is nothing left to bisect.
+func TestFieldMismatchNamesTheSource(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type P struct { st int }`,
+		`func look() (best) { best = 1.5 }`,
+		`func main() { a := P{0} a.st = look() println(str(a.st)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "'best'") {
+		t.Fatalf("message %q does not name the value's source", msg)
+	}
+	if !strings.Contains(msg, `"main"`) {
+		t.Fatalf("message %q does not say where the assignment is", msg)
+	}
+	if strings.Contains(msg, "$") {
+		t.Fatalf("message %q leaks a specialization suffix", msg)
+	}
+}
+
+// TestFieldMismatchOnRead: reading a field into an incompatible variable is
+// annotated too, not only assignment into one.
+func TestFieldMismatchOnRead(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type P struct { st int }`,
+		`func main() { a := P{1} s := "x" s = a.st println(s) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil {
+		t.Fatal("expected a type mismatch")
+	}
+	if !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("unexpected message: %v", err)
+	}
+}
+
+// TestFieldAssignValidStillChecks: the ordinary path is untouched.
+func TestFieldAssignValidStillChecks(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type P struct { st int }`,
+		`func look() (best) { best = 3 }`,
+		`func main() { a := P{0} a.st = look() println(str(a.st)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+}
+
+// TestLocalMismatchAnnotationUnchanged guards the message this one was modelled
+// on: local-variable mismatches already named the variable and the function,
+// and that must keep working.
+func TestLocalMismatchAnnotationUnchanged(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { v := 1 v = "two" println(v) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil || !strings.Contains(err.Error(), "type mismatch for") {
+		t.Fatalf("local annotation changed: %v", err)
+	}
+}
+
+// TestMissingFieldErrorUnchanged: the neighbouring error in the same loop must
+// not have been disturbed.
+func TestMissingFieldErrorUnchanged(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type P struct { st int }`,
+		`func main() { a := P{1} println(str(a.nope)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil || !strings.Contains(err.Error(), "has no field") {
+		t.Fatalf("unexpected message: %v", err)
+	}
+}

--- a/multiassign_arity_msg_test.go
+++ b/multiassign_arity_msg_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Using a one-value function as if it returned two used to report
+//
+//	2 variables but a single value on the right
+//
+// which names neither the callee, its arity, nor the function the mistake is
+// in — so in a large program every multi-assignment in the build is a
+// candidate and the only way to find it is to bisect by deleting code.
+//
+// The mirror-image mistake has always produced an excellent message
+// ("grab returns 2 values; use a multi-assignment (a, b := grab(...))"), and
+// the compiler has exactly the same information in hand for this direction.
+// These tests pin the improved wording so it cannot quietly regress to the
+// anonymous form.
+
+// TestMultiAssignFromSingleReturnNamesCallee: the callee and its real arity
+// appear in the message.
+func TestMultiAssignFromSingleReturnNamesCallee(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func one(n) (v) { v = n + 1 }`,
+		`func main() { a, b := one(3) println(str(a) + str(b)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil {
+		t.Fatal("expected an arity error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"one returns 1 value", "2 variables on the left", `"main"`} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// TestMultiAssignNamesEnclosingFunction: the mistake is reported against the
+// function it is in, not the one being called, and without the "$N"
+// specialization suffix that means nothing to a reader.
+func TestMultiAssignNamesEnclosingFunction(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type S struct { k int }`,
+		`func one(s) (v) { v = s.k }`,
+		`func mid(s) (p, q) { p, q = one(s) }`,
+		`func main() { s := S{1} a, b := mid(s) println(str(a + b)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil {
+		t.Fatal("expected an arity error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"mid"`) {
+		t.Fatalf("message %q does not name the enclosing function", msg)
+	}
+	if strings.Contains(msg, "$") {
+		t.Fatalf("message %q leaks a specialization suffix", msg)
+	}
+}
+
+// TestMultiAssignFromNonCall: a right-hand side that is not a call at all still
+// gets a message that says so, rather than a bare count.
+func TestMultiAssignFromNonCall(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func main() { a, b := 3 + 4 println(str(a) + str(b)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil {
+		t.Fatal("expected an arity error")
+	}
+	if !strings.Contains(err.Error(), "right-hand side is a single value") {
+		t.Fatalf("unexpected message: %v", err)
+	}
+}
+
+// TestMultiAssignMirrorCaseUnchanged: the message this one was modelled on must
+// keep working — it is the reference for the whole shape.
+func TestMultiAssignMirrorCaseUnchanged(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`type R struct { n int }`,
+		`func grab(r) (v, w) { v = r.n  w = r.n + 1 }`,
+		`func main() { r := R{1} c := grab(r) println(str(c)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil || !strings.Contains(err.Error(), "use a multi-assignment") {
+		t.Fatalf("mirror-case message changed: %v", err)
+	}
+}
+
+// TestMultiAssignWrongCountNamesBoth: a genuine 2-vs-3 mismatch keeps naming
+// the callee and now also names where it happened.
+func TestMultiAssignWrongCountNamesBoth(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func two() (a, b) { a = 1  b = 2 }`,
+		`func main() { x, y, z := two() println(str(x + y + z)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = Check(prog)
+	if err == nil {
+		t.Fatal("expected an arity error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "two returns 2 values but 3 are assigned") || !strings.Contains(msg, `"main"`) {
+		t.Fatalf("unexpected message: %v", msg)
+	}
+}
+
+// TestMultiAssignValidStillWorks: the ordinary case must be untouched.
+func TestMultiAssignValidStillWorks(t *testing.T) {
+	prog, err := ParseProgram([]string{
+		`func two() (a, b) { a = 1  b = 2 }`,
+		`func main() { x, y := two() println(str(x + y)) }`,
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := Check(prog); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -211,6 +211,10 @@ type fieldUse struct {
 	base   int
 	field  string
 	result int
+	// in is the function the field was touched in, kept solely so a type
+	// mismatch on it can say where. `resolveDeferred` runs long after the
+	// statement it came from, so there is nothing else left to name.
+	in string
 }
 
 func newSlot(c *Checker, k Kind) int {
@@ -1025,7 +1029,7 @@ func (c *Checker) resolveDeferred() error {
 				return err
 			}
 			if _, err := c.union(fu.result, fs); err != nil {
-				return err
+				return c.annotateField(err, name, fu)
 			}
 			fieldDone[i] = true
 			progressed = true
@@ -1240,6 +1244,35 @@ func (c *Checker) annotateMismatch(err error, a, b int, src Expr) error {
 	return fmt.Errorf("type mismatch for %s: %s%s", who, detail, causeSuffix(src))
 }
 
+// annotateField names the struct field a deferred type mismatch was resolved
+// through. `resolveDeferred` unions a field-use slot with the field's declared
+// type long after the statement that produced it, so `annotateMismatch` has no
+// variable to point at and the error came out as a bare "type mismatch: float
+// vs int" — no file, no line, no name, in a compiler that reports local
+// variable mismatches beautifully. The struct, the field and the function are
+// all in hand at that point.
+//
+// If the value side does resolve to a variable, say that too: "field 'st' of P"
+// tells you what was expected and "from 'best' in \"look\"" tells you what
+// supplied it, and between them there is nothing left to bisect.
+func (c *Checker) annotateField(err error, structName string, fu fieldUse) error {
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "type mismatch: ") {
+		return err
+	}
+	detail := strings.TrimPrefix(msg, "type mismatch: ")
+	where := ""
+	if fu.in != "" {
+		where = fmt.Sprintf(" (in %q)", fu.in)
+	}
+	from := ""
+	if who, _ := c.slotVar(fu.result); who != "" {
+		from = " — from " + who
+	}
+	return fmt.Errorf("type mismatch for field '%s' of %s: %s%s%s",
+		fu.field, structName, detail, from, where)
+}
+
 // causeSuffix formats the conflicting expression for an error message.
 func causeSuffix(src Expr) string {
 	if cause := mismatchCause(src); cause != "" {
@@ -1411,7 +1444,7 @@ func (c *Checker) genStmt(fn *FuncDecl, s Stmt) error {
 		if err != nil {
 			return err
 		}
-		c.fieldUses = append(c.fieldUses, fieldUse{base: xs, field: st.Target.Name, result: vs})
+		c.fieldUses = append(c.fieldUses, fieldUse{base: xs, field: st.Target.Name, result: vs, in: srcFnName(fn.Name)})
 		return nil
 	case *SendStmt:
 		cs, err := c.genExpr(fn, st.Ch)
@@ -1719,7 +1752,7 @@ func (c *Checker) genExprInner(fn *FuncDecl, e Expr) (int, error) {
 			return 0, err
 		}
 		res := newSlot(c, KVar)
-		c.fieldUses = append(c.fieldUses, fieldUse{base: xs, field: ex.Name, result: res})
+		c.fieldUses = append(c.fieldUses, fieldUse{base: xs, field: ex.Name, result: res, in: srcFnName(fn.Name)})
 		return res, nil
 	}
 	return 0, fmt.Errorf("typecheck: unknown expression %T", e)

--- a/types.go
+++ b/types.go
@@ -579,6 +579,48 @@ func funcArity(fn *FuncDecl) int {
 	return returnArity(fn.Body)
 }
 
+// describeSingleRHS says what the right-hand side of a multi-assignment
+// actually yields, by name where there is a name to give. The mirror-image
+// mistake — using a multi-return function as if it returned one — has always
+// produced an excellent message ("grab returns 2 values; use a
+// multi-assignment"), and this is that message's twin: the compiler knows the
+// callee and its arity at this point and used to discard both.
+func describeSingleRHS(c *Checker, rhs Expr) string {
+	call, ok := rhs.(*Call)
+	if !ok {
+		return "the right-hand side is a single value"
+	}
+	if srcFn, isUser := c.funcs[call.Callee]; isUser {
+		return fmt.Sprintf("%s returns %s", call.Callee, pluralVals(funcArity(srcFn)))
+	}
+	return fmt.Sprintf("%s yields a single value", call.Callee)
+}
+
+func pluralVars(n int) string {
+	if n == 1 {
+		return "1 variable on the left"
+	}
+	return fmt.Sprintf("%d variables on the left", n)
+}
+
+// srcFnName is a function's declared name: instantiated clones carry a "$N"
+// suffix that is an implementation detail of specialization and means nothing
+// to the person reading the error. `slotVar` already does this via instFn; a
+// message built from a *FuncDecl has to do it by hand.
+func srcFnName(name string) string {
+	if i := strings.IndexByte(name, '$'); i >= 0 {
+		return name[:i]
+	}
+	return name
+}
+
+func pluralVals(n int) string {
+	if n == 1 {
+		return "1 value"
+	}
+	return fmt.Sprintf("%d values", n)
+}
+
 // instantiate creates a fresh specialization of a function (new parameter,
 // return, and local slots) and generates its body's constraints. A recursive
 // call reuses the in-progress instance (monomorphic recursion). The caller
@@ -1829,7 +1871,8 @@ func (c *Checker) genMultiAssign(fn *FuncDecl, st *MultiAssign) error {
 				c.callInst[fn.Name][call] = inst
 				rets := c.funcRets[inst]
 				if len(rets) != len(st.Names) {
-					return fmt.Errorf("%s returns %d values but %d are assigned", call.Callee, len(rets), len(st.Names))
+					return fmt.Errorf("%s returns %d values but %d are assigned (in %q)",
+						call.Callee, len(rets), len(st.Names), srcFnName(fn.Name))
 				}
 				for i := range rets {
 					c.addPair(nameSlots[i], rets[i])
@@ -1838,7 +1881,8 @@ func (c *Checker) genMultiAssign(fn *FuncDecl, st *MultiAssign) error {
 			}
 		}
 		if len(st.Names) != 1 {
-			return fmt.Errorf("%d variables but a single value on the right", len(st.Names))
+			return fmt.Errorf("%s: %s (in %q)", describeSingleRHS(c, st.Rhs[0]),
+				pluralVars(len(st.Names)), srcFnName(fn.Name))
 		}
 		vs, err := c.genExpr(fn, st.Rhs[0])
 		if err != nil {


### PR DESCRIPTION
Two messages from the same family — unlocated typecheck errors — found while
building MFL games, where each cost roughly half an hour of bisecting by
deleting code until the error moved.

Both fixes are the same idea: **the compiler already knows the answer at the
point it gives up, and was discarding it.**

## #638 — multi-assign arity

```
$ machin build m.src -o m
before: 2 variables but a single value on the right
after:  one returns 1 value: 2 variables on the left (in "main")
```

The mirror-image mistake has always produced an excellent message —
`grab returns 2 values; use a multi-assignment (a, b := grab(...))` — and this
direction had the same information available. `srcFnName` strips the `$N`
specialization suffix, which is an implementation detail of instantiation.

## #637 — mismatches resolved through a struct field

```
$ machin build i.src -o i
before: type mismatch: float vs int
after:  type mismatch for field 'st' of P: float vs int — from 'best' in "look" (in "main")
```

Field uses are deferred: `resolveDeferred` unions the field-use slot with the
field's declared type long after the statement that produced it, and that path
never called `annotateMismatch`. `fieldUse` now carries the function it was
written in, because nothing else survives to that point.

The real bug behind that repro was one character: `best := 0.0 - 1` where
`0 - 1` was meant.

## Scope

`types.go` only — no codegen, so the self-host gates do not apply. Twelve tests
across two files, including guards on the two messages these were modelled on
(the mirror-case arity error and the local-variable annotation) and on the
`has no field` error emitted from the same loop.

Gates: `go vet ./...`, `go test .` and `make examples` all green.

## Where this came from

Nine MFL game repos, ~57k lines, ~1,400 assertions — the dogfooding AGENTS.md
asks for. Filed as #637, #638 and #639 before touching anything; #639 (no
`copy()` builtin, struct assignment shares slices) is the remaining one and is
a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type mismatch messages with clearer field, struct, variable, and function context.
  - Enhanced multi-assignment errors to identify the relevant function, value counts, and right-hand-side details.
  - Clarified messages for single-value and multi-value assignment mistakes.
  - Preserved existing behavior for valid assignments and established missing-field and local mismatch diagnostics.

- **Tests**
  - Added coverage for field-related mismatches, field reads and assignments, missing fields, and multi-assignment arity errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->