### PR TITLE
test: de-flake the websocket round-trip, and stop losing the evidence

### DIFF
--- a/build.go
+++ b/build.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -481,5 +482,19 @@ func RunCaptured(prog *Program) (string, error) {
 		return "", err
 	}
 	out, err := exec.Command(bin.Name()).Output()
+	// THE CHILD'S STDERR IS PART OF THE FAILURE, and Output() already collected
+	// it — into ExitError.Stderr, where nothing ever looked. Printing the error
+	// with %v yields a bare "signal: aborted (core dumped)": no glibc message,
+	// no deadlock report, no sanitizer trace, no "bind: Address already in
+	// use". For a flake, where reproducing it is the one thing you cannot do,
+	// that is the difference between a diagnosis and a shrug.
+	//
+	// Note this deliberately does NOT set cmd.Stderr: Output already captures
+	// stderr into ExitError.Stderr, and setting it replaces that with a second
+	// pipe this function would have to drain itself, for no gain.
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && len(ee.Stderr) > 0 {
+		err = fmt.Errorf("%w; stderr:\n%s", err, strings.TrimRight(string(ee.Stderr), "\n"))
+	}
 	return string(out), err
 }

--- a/cgentest.go
+++ b/cgentest.go
@@ -38,8 +38,14 @@ func cmdCGenTest(args []string) error {
 		fmt.Println("(check-error)")
 		return nil
 	}
+	// EVERY memo, or the first program to use the feature panics on a nil map
+	// rather than emitting C. This path is what the codegen oracle runs, so a
+	// missing one is a crash waiting for someone to add a program that uses
+	// sort_by or copy to the corpus.
 	g := &cgen{c: c, target: targetNative, bodyOnly: true,
-		jsonMemo: map[string]string{}, parseMemo: map[string]string{}, chanJSONMemo: map[string][2]string{}}
+		jsonMemo: map[string]string{}, parseMemo: map[string]string{},
+		sortMemo: map[string]string{}, copyMemo: map[string]string{},
+		chanJSONMemo: map[string][2]string{}}
 	src, err := g.program(prog)
 	if err != nil {
 		fmt.Println("(codegen-error)")

--- a/cgentest_memos_test.go
+++ b/cgentest_memos_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `machin cgentest` builds its cgen by hand rather than through the normal
+// path, so every memo map has to be initialized there explicitly. A missing one
+// is not a wrong answer — it is a nil-map assignment, which panics the moment
+// the first program uses that feature.
+//
+// This is the path the codegen oracle runs over its corpus, so the crash waits
+// silently until someone adds a program using the feature to the corpus.
+
+func cgentestOut(t *testing.T, src string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "machin")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Skipf("cannot build the compiler here: %v\n%s", err, out)
+	}
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "p.src")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mfl, err := exec.Command(bin, "encode", srcPath).Output()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	mflPath := filepath.Join(dir, "p.mfl")
+	if err := os.WriteFile(mflPath, mfl, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(bin, "cgentest", "--program", mflPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("cgentest: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+// copy() emits a per-type deep copier through copyMemo.
+func TestCGenTestEmitsCopy(t *testing.T) {
+	out := cgentestOut(t, `type Box struct { v []int }
+func main() { a := Box{}  a.v = []int{1}  b := copy(a)  println(str(len(b.v))) }`)
+	if strings.Contains(out, "panic") {
+		t.Fatalf("cgentest panicked:\n%s", out)
+	}
+	if !strings.Contains(out, "mfl_copy_v") {
+		t.Fatalf("no deep copier emitted:\n%s", out)
+	}
+}
+
+// A `go` statement must check pthread_create. Ignoring its result means that
+// when the system is out of threads — a loaded CI box, a low RLIMIT_NPROC —
+// the goroutine silently never runs. Measured on the old emitter with
+// RLIMIT_NPROC set just above the current thread count: ZERO of 200 goroutines
+// ran, the program printed "main finished", and it exited 0. A program that
+// did none of its work and reported success is the shape every "flaky" test
+// eventually turns out to be.
+//
+// (`t` is also left uninitialized on failure, and detaching it is undefined
+// behaviour, which is its own reason not to do this.)
+func TestGoStatementChecksPthreadCreate(t *testing.T) {
+	out := cgentestOut(t, `func work(n) { println(str(n)) }
+func main() { go work(1)  sleep(10) }`)
+	if !strings.Contains(out, "pthread_create") {
+		t.Fatalf("no spawn emitted:\n%s", out)
+	}
+	if !strings.Contains(out, "if (pthread_create(") {
+		t.Fatalf("pthread_create's result is not checked:\n%s", out)
+	}
+	if !strings.Contains(out, "go: pthread_create") {
+		t.Fatalf("a failed spawn does not name itself:\n%s", out)
+	}
+}
+
+// sort_by emits a comparator through sortMemo — the same shape, and it was
+// already missing before copy was added.
+func TestCGenTestEmitsSortBy(t *testing.T) {
+	out := cgentestOut(t, `func main() {
+    xs := []int{3, 1, 2}
+    ys := sort_by(xs, func(a, b) { return a < b })
+    println(str(ys[0]))
+}`)
+	if strings.Contains(out, "panic") {
+		t.Fatalf("cgentest panicked:\n%s", out)
+	}
+	if !strings.Contains(out, "mfl_ltby") {
+		t.Fatalf("no comparator emitted:\n%s", out)
+	}
+}

--- a/codegen.go
+++ b/codegen.go
@@ -5688,7 +5688,17 @@ func (g *cgen) goStmt(st *GoStmt) error {
 		}
 		g.buf.WriteString("        }\n")
 	}
-	fmt.Fprintf(&g.buf, "        pthread_t t; pthread_create(&t, NULL, mfl_go_run_%d, s); pthread_detach(t);\n", id)
+	// CHECK THE SPAWN. Ignoring pthread_create's result means that when the
+	// system is out of threads (EAGAIN — a real possibility under a loaded CI
+	// box or a low RLIMIT_NPROC) the goroutine silently never runs, and the
+	// program waits forever for work nobody is doing. Worse, `t` is then
+	// uninitialized and detaching it is undefined behaviour. Failing loudly
+	// turns an unreproducible hang into one line naming the cause.
+	fmt.Fprintf(&g.buf, "        pthread_t t;\n")
+	fmt.Fprintf(&g.buf, "        if (pthread_create(&t, NULL, mfl_go_run_%d, s) != 0) {\n", id)
+	g.buf.WriteString("            perror(\"go: pthread_create\"); exit(1);\n")
+	g.buf.WriteString("        }\n")
+	g.buf.WriteString("        pthread_detach(t);\n")
 	g.buf.WriteString("    }\n")
 	return nil
 }

--- a/runcaptured_stderr_test.go
+++ b/runcaptured_stderr_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// RunCaptured used to return only the child's stdout, so a program that died
+// arrived as a bare "signal: aborted (core dumped)" or "exit status 1" with
+// every word of explanation thrown away — no glibc abort message, no deadlock
+// report, no sanitizer trace, no "bind: Address already in use".
+//
+// That is what made a websocket test that failed once and never again
+// impossible to diagnose: by the time anyone looked, the only evidence had
+// already been discarded by the harness.
+
+// TestRunCapturedIncludesStderrOnFailure: a program that writes to stderr and
+// exits non-zero reports both facts.
+func TestRunCapturedIncludesStderrOnFailure(t *testing.T) {
+	// A deadlock is a realistic instance of the problem: the runtime explains
+	// itself in detail on stderr and exits 2, and every word of that
+	// explanation used to be discarded by the harness.
+	prog := progFromSrc(t, `
+func main() {
+    println("on stdout")
+    flush()
+    c := make(chan int)
+    x := <-c
+    println(str(x))
+}`)
+	out, err := RunCaptured(prog)
+	if err == nil {
+		t.Fatal("expected a non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "deadlock") {
+		t.Fatalf("stderr was dropped from the error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "exit status 2") {
+		t.Fatalf("the exit status went missing: %v", err)
+	}
+	if !strings.Contains(out, "on stdout") {
+		t.Fatalf("stdout should still be returned separately, got %q", out)
+	}
+}
+
+// ...and a program that succeeds is unaffected: no stderr, no decoration.
+func TestRunCapturedCleanRunUnchanged(t *testing.T) {
+	prog := progFromSrc(t, `func main() { println("fine") }`)
+	out, err := RunCaptured(prog)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(out) != "fine" {
+		t.Fatalf("unexpected stdout %q", out)
+	}
+}

--- a/selfhost/cgen.src
+++ b/selfhost/cgen.src
@@ -739,7 +739,14 @@ func cg_go(iid, idx) {
     if len(stroffs) > 0 {
         cemit("        mfl_freeze_strs(" + str(len(stroffs)) + ", (int[]){" + join_offs(stroffs) + "}, s);\n")
     }
-    cemit("        pthread_t t; pthread_create(&t, NULL, mfl_go_run_" + ids + ", s); pthread_detach(t);\n")
+    // mirrors the Go emitter: a failed spawn is reported, not ignored — an
+    // unchecked pthread_create makes a goroutine silently not run and leaves
+    // `t` uninitialized for the detach
+    cemit("        pthread_t t;\n")
+    cemit("        if (pthread_create(&t, NULL, mfl_go_run_" + ids + ", s) != 0) {\n")
+    cemit("            perror(\"go: pthread_create\"); exit(1);\n")
+    cemit("        }\n")
+    cemit("        pthread_detach(t);\n")
     cemit("    }\n")
 }
 

--- a/ws_test.go
+++ b/ws_test.go
@@ -1,10 +1,34 @@
 package main
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"strings"
 	"testing"
 )
+
+// freeLoopbackPort asks the kernel for an unused port and hands it back.
+//
+// A hard-coded port is a test that fails for a reason that has nothing to do
+// with the code under test: anything else on the machine holding it makes
+// `listen` abort the process with "bind: Address already in use", which
+// reaches the Go test as a bare exit status. There is an unavoidable window
+// between closing this listener and the MFL program binding it, but a window
+// of microseconds against a specific port is a different proposition from a
+// constant that is either free for the whole suite or never.
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("no loopback available: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("closing the probe listener: %v", err)
+	}
+	return port
+}
 
 // wsProg composes machweb.src + ws.src + the test app (ws.src needs machweb's hijack).
 func wsProg(t *testing.T, app string) *Program {
@@ -32,7 +56,7 @@ func wsProg(t *testing.T, app string) *Program {
 //	masked "hi": 81 82 | 01020304 (mask) | 69 6b  ('h'^01, 'i'^02)
 //	key "dGhlIHNhbXBsZSBub25jZQ==" -> accept "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" (the RFC example)
 func TestWebSocketEchoRoundTrip(t *testing.T) {
-	app := `
+	app := fmt.Sprintf(`
 func serve_one(srv, handler) { conn := accept(srv)  machweb_handle(conn, handler) }
 func echo(req) (res) {
     res = ws(req, func(c) {
@@ -55,7 +79,7 @@ func read_some(c) (s) {
     }
 }
 func main() {
-    port := 18241
+    port := %d
     srv := listen(port)
     if srv < 0 { println("listen-failed")  return }
     go serve_one(srv, func(req) { return echo(req) })
@@ -71,7 +95,7 @@ func main() {
     close(c)
     println("HS<" + hs + ">")
     println("FRAME<" + frame + ">")
-}`
+}`, freeLoopbackPort(t))
 	out, err := RunCaptured(wsProg(t, app))
 	if err != nil {
 		t.Fatalf("run: %v", err)


### PR DESCRIPTION
`TestWebSocketEchoRoundTrip` failed once under the full suite with
`signal: aborted (core dumped)` and never again.

**This does not claim to fix that abort.** I could not reproduce it: ~350 runs
sequential, under CPU load, concurrent, pinned to a single core, and under
ASan+UBSan — all clean, and no core was retained (apport ignores `/tmp`
binaries). What it fixes is everything that made that failure both likelier and
impossible to diagnose, two of which are real bugs in their own right.

## 1. The evidence was being thrown away

`Output()` **already** captures the child's stderr, into `ExitError.Stderr`.
Nothing ever looked at it, and `t.Fatalf("run: %v", err)` prints only the signal
name — so every glibc abort message, deadlock report, sanitizer trace and
`bind: Address already in use` in this suite has been discarded at exactly the
moment it was needed. That is why a one-off failure was a dead end.

Deliberately *without* setting `cmd.Stderr`: that replaces `Output`'s own
capture with a second pipe `RunCaptured` would have to drain, for no gain.

## 2. A `go` statement ignored `pthread_create`'s result

With `RLIMIT_NPROC` set just above the current thread count, the old emitter:

```
rc=0   ran=0 of 200 goroutines   "main finished"   stderr: (empty)
```

**A program that did none of its work and reported success.** Under the load
where flakes appear, `EAGAIN` is not exotic. `t` was also left uninitialized and
then detached, which is undefined behaviour. Now:

```
rc=1   go: pthread_create: Resource temporarily unavailable
```

Mirrored in `selfhost/cgen.src`; the codegen oracle confirms both emitters still
agree.

## 3. The test hard-coded port 18241

Anything else holding it makes `listen` abort the process with `bind: Address
already in use` (demonstrated), which reaches the test as an opaque exit status.
It now asks the kernel for a free port.

## 4. A nil-map panic I had just introduced

`cgentest` builds its `cgen` by hand and does not initialize every memo, so a
program using `copy()` panicked there instead of emitting C. `sortMemo` had the
same latent bug already. This is the path the **codegen oracle** runs, so the
crash was waiting for someone to add such a program to the corpus.

## Not changed

`mfl_listen` calls `exit(1)` on bind failure, so every `if srv < 0` guard in MFL
is dead code. Making it return `-1` would silently degrade the unguarded servers
in `framework/machweb.src` into `accept(-1)` loops — that deserves its own issue
and decision, not a drive-by.

## Gates

| gate | result |
|---|---|
| `go vet ./...` | clean |
| `go test .` | ok, 166s (baseline ~170s) |
| `make examples` | clean |
| codegen oracle | PASS 415, FAIL 0 |
| self-hosting fixpoint | PASS |
| prelude | unchanged |

Two suite runs during this work timed out at 600s and I initially blamed my own
change; both were in fact my leftover stress-test processes holding the machine
at load average 16. The 166s figure above is from a quiet machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed background task creation now reports a clear error and exits instead of failing silently.
  - Build and execution errors now include relevant captured diagnostic output, making failures easier to investigate.
  - Code generation no longer crashes when programs use copying or sorting features.
  - WebSocket testing now avoids conflicts from fixed local ports.

- **Tests**
  - Added coverage for error reporting, background task creation, copying, sorting, and WebSocket communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->