### PR TITLE
codegen: emit cstruct typedefs before the user structs that hold them

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -4570,12 +4570,33 @@ func (g *cgen) program(p *Program) (string, error) {
 			fmt.Fprintf(&out, "%sextern %s %s(%s);\n", attr, externCType(ef.Ret), ef.Name, ps)
 		}
 	}
-	// struct typedefs, in declaration order (a struct may reference earlier ones)
-	for _, td := range p.Types {
+	// Which of p.Types came from an `extern` cstruct rather than a `type`
+	// declaration. Needed before the typedefs are written, not after: see the
+	// ordering note below.
+	cstructNames := map[string]bool{}
+	for _, ed := range p.Externs {
+		for _, cs := range ed.Structs {
+			cstructNames[cs.Name] = true
+		}
+	}
+	// struct typedefs, CSTRUCT WRAPPERS FIRST and user structs after.
+	//
+	// Declaration order is not enough. A user struct may hold a cstruct as a
+	// field -- `type Theme struct { bg Color }` over an `extern` Color -- and
+	// the mfl_ wrappers for cstructs are appended to p.Types after the user
+	// types whatever the source order, so `typedef struct { mfl_Color f_bg; }
+	// mfl_Theme;` was emitted before mfl_Color existed. The C compiler then
+	// reported `unknown type name 'mfl_Color'` and a cascade of int mismatches
+	// from its own error recovery, while `machin check` had already said the
+	// program was fine -- the worst diagnostic this compiler can produce.
+	//
+	// Two passes are sufficient and cannot loop: a cstruct's fields are C
+	// types, so a cstruct can never reference a user struct back.
+	emitTypedef := func(td *TypeDecl) {
 		if td.COpaque != "" {
 			// an opaque FFI handle: wrap the real C type by value in one hidden field
 			fmt.Fprintf(&out, "typedef struct { %s _c; } mfl_%s;\n", td.COpaque, td.Name)
-			continue
+			return
 		}
 		fmt.Fprintf(&out, "typedef struct {")
 		for _, f := range td.Fields {
@@ -4583,15 +4604,19 @@ func (g *cgen) program(p *Program) (string, error) {
 		}
 		fmt.Fprintf(&out, " } mfl_%s;\n", td.Name)
 	}
+	for _, td := range p.Types {
+		if cstructNames[td.Name] {
+			emitTypedef(td)
+		}
+	}
+	for _, td := range p.Types {
+		if !cstructNames[td.Name] {
+			emitTypedef(td)
+		}
+	}
 	// FFI struct marshaling: convert each cstruct between its MFL value (mfl_Name,
 	// with int64/double/nested mfl_ fields) and the C layout (Name) at the
 	// boundary. A nested cstruct field recurses through its own mfl_from_/mfl_to_.
-	cstructNames := map[string]bool{}
-	for _, ed := range p.Externs {
-		for _, cs := range ed.Structs {
-			cstructNames[cs.Name] = true
-		}
-	}
 	for _, ed := range p.Externs {
 		for _, cs := range ed.Structs {
 			if cs.Opaque {

--- a/cstruct_field_test.go
+++ b/cstruct_field_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Compile a whole .src (externs and type declarations included, which
+// runNative's per-function parser cannot take) and run it.
+func buildAndRunSrc(t *testing.T, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "p.src")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mflPath := filepath.Join(dir, "p.mfl")
+	out, err := exec.Command("go", "run", ".", "encode", srcPath).Output()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := os.WriteFile(mflPath, out, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "p")
+	if b, err := exec.Command("go", "run", ".", "build", mflPath, "-o", bin).CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, b)
+	}
+	got, err := exec.Command(bin).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v\n%s", err, got)
+	}
+	return string(got)
+}
+
+// A user struct may hold a cstruct as a field. The mfl_ wrappers for cstructs
+// land in the type list AFTER the user types whatever the source order says,
+// so the typedef for the holder was emitted before the typedef for the field's
+// type: gcc reported `unknown type name 'mfl_Pt'` and a cascade of int
+// mismatches from its own error recovery, while `machin check` had already
+// reported the program as fine. Header-less on purpose, so this needs no
+// third-party library installed.
+func TestCStructAsStructField(t *testing.T) {
+	got := buildAndRunSrc(t, `extern "geom" {
+	cstruct Pt { x f64 y f64 }
+	fn geom_unused(Pt) f64
+}
+
+type Holder struct {
+	p    Pt
+	name string
+}
+
+func main() {
+	h := Holder{}
+	h.p = Pt{3.0, 4.0}
+	h.name = "ok"
+	println(h.name)
+	println(str(h.p.x + h.p.y))
+}
+`)
+	if want := "ok\n7\n"; got != want {
+		t.Fatalf("cstruct as a struct field: got %q, want %q", got, want)
+	}
+}
+
+// The same one level deeper: the ordering has to hold for a whole chain.
+func TestCStructNestedTwoDeep(t *testing.T) {
+	got := buildAndRunSrc(t, `extern "geom" {
+	cstruct Pt { x f64 y f64 }
+	fn geom_unused(Pt) f64
+}
+
+type Inner struct { p Pt }
+type Outer struct { in Inner }
+
+func main() {
+	o := Outer{}
+	o.in = Inner{}
+	o.in.p = Pt{1.5, 2.5}
+	println(str(o.in.p.x * o.in.p.y))
+}
+`)
+	if want := "3.75\n"; !strings.HasPrefix(got, want) {
+		t.Fatalf("cstruct two levels deep: got %q, want prefix %q", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #650.

A user `struct` holding an `extern` `cstruct` as a field passed `machin check`
and then failed in cc. The field type was never wrong — the holder was simply
emitted first:

```c
typedef struct { mfl_Color f_bg; } mfl_Theme;   // uses it
typedef struct { int64_t f_r; ... } mfl_Color;  // declares it, too late
```

The typedef loop walked `p.Types` "in declaration order", but the `mfl_`
wrappers for cstructs are appended **after** the user types whatever the source
order says — in the repro the `extern` block is the first thing in the file.

## The change

Two passes: cstruct wrappers, then everything else. It cannot loop, because a
cstruct's fields are C types and so a cstruct can never reference a user struct
back. The body of the emission is unchanged and lifted into a closure so both
passes share it.

## Tests

`TestCStructAsStructField` and `TestCStructNestedTwoDeep`, header-less so they
need no third-party library present. Both **fail on the parent commit** with
the cc error, pass here. Full `go test ./...` green (217s).

## Why fix rather than document

The failure mode is the worst this compiler produces: `check` says the program
is fine, and the user gets C errors naming generated identifiers they never
wrote, with nothing pointing at the field that caused it.

It is also not an exotic shape. Every use of `b2BodyId` in machin-physics is a
`[]b2BodyId` rather than a named field — which reads as a style choice and is
actually this bug being routed around.

Found building a Box2D biped in MFL (machin-aplomb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation failures when user-defined structs contain cstruct fields.
  * Corrected typedef ordering for nested cstruct fields, including multi-level nesting.

* **Tests**
  * Added coverage confirming affected programs compile and run successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->