### PR TITLE
release: v0.138.0 — UDP, positional file I/O, and a bind address for listen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.138.0
 
 **UDP and positional file writes.** Two gaps that between them made a whole class
 of program impossible to write in pure MFL: anything speaking a connectionless

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # The MFL Language Specification
 
-Version 0.137.0
+Version 0.138.0
 
 MFL (Machine-First Language) is a statically-typed, Go-flavored backend language
 **shaped for machine authoring**: minimal syntax, no type annotations, one


### PR DESCRIPTION
Cuts v0.138.0. No code change: `SPEC.md` was still on 0.137.0 (`guide.go` and the README badge were already bumped), and the `Unreleased` changelog section becomes this version's entry.

## Why now

`listen_on(host, port)` landed in #654. `listen()` hardcoded `INADDR_ANY`, so a server told to serve localhost was reachable from the whole network with no way to say otherwise — every server ever written against `listen()` had this.

No released compiler carries it yet. The agent-first CLI boilerplates bind loopback by default per cli-daemon-spec §1, so their CI currently has to build machin from source instead of using `install.sh`. Tagging this releases them from that.

## Also since v0.137.0

- `udp_socket` / `udp_sendto` / `udp_recvfrom` — connectionless protocols (a tracker is BEP 15, the DHT is BEP 5).
- `write_file_at` / `read_file_at` — filling and reading a file out of order. The only random-access primitive before was `mmap_file`, which is read-only, so a program had to buffer the whole file in RAM.

## Checks

`main` is currently red on exactly one step — `Released-version check` — because it advertises 0.138.0 with no such tag. This is the fix that step asks for; `tools/version-check.sh` passes on this commit via its release-commit path.

After merge: `git tag -a v0.138.0 -m "MFL v0.138.0" <merge-sha> && git push origin v0.138.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjQVGD6aZJFhqAaCsTtAp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to identify the current release as version 0.138.0.
  - Updated the specification’s documented version from 0.137.0 to 0.138.0.
  - Existing changelog content remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->